### PR TITLE
deps: add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
       jj:
         patterns:
           - "jj-*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     commit-message:
       prefix: "deps(rust)"
     open-pull-requests-limit: 10
@@ -24,6 +28,10 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     commit-message:
       prefix: "deps(swift)"
     open-pull-requests-limit: 5
@@ -33,6 +41,10 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     commit-message:
       prefix: "deps(swift)"
     open-pull-requests-limit: 5
@@ -43,6 +55,10 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
     commit-message:
       prefix: "deps(actions)"
     open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+
+updates:
+  # Rust (Cargo) dependencies
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      tree-sitter:
+        patterns:
+          - "tree-sitter*"
+      jj:
+        patterns:
+          - "jj-*"
+    commit-message:
+      prefix: "deps(rust)"
+    open-pull-requests-limit: 10
+
+  # Swift Package Manager dependencies
+  - package-ecosystem: swift
+    directory: /shell/mac
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "deps(swift)"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: swift
+    directory: /shell/mac/Packages/JayJayDiffUI
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "deps(swift)"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    commit-message:
+      prefix: "deps(actions)"
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,19 +36,6 @@ updates:
       prefix: "deps(swift)"
     open-pull-requests-limit: 5
 
-  - package-ecosystem: swift
-    directory: /shell/mac/Packages/JayJayDiffUI
-    schedule:
-      interval: weekly
-      day: monday
-    ignore:
-      - dependency-name: "*"
-        update-types:
-          - "version-update:semver-patch"
-    commit-message:
-      prefix: "deps(swift)"
-    open-pull-requests-limit: 5
-
   # GitHub Actions
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Configure weekly checks for Cargo (Rust), Swift Package Manager, and
GitHub Actions ecosystems. Groups tree-sitter and jj crates to reduce
PR noise.

https://claude.ai/code/session_015r8jSbUcFS4ZHE8LqqrRUm