### PR TITLE
Fix diff EOF rendering, commit draft loss, LFS preview; polish DAG

### DIFF
--- a/crates/jayjay-core/src/repo/diff/entry.rs
+++ b/crates/jayjay-core/src/repo/diff/entry.rs
@@ -12,9 +12,9 @@ use pollster::FutureExt as _;
 use super::{
     TreePair,
     materialize::{
-        extract_image_preview, git_lfs_object_placeholder, git_lfs_pointer_placeholder,
-        is_image_path, materialized_to_string, parse_binary_placeholder_size,
-        parse_git_lfs_pointer, preview_placeholder,
+        ImagePreviewResult, extract_image_preview, git_lfs_object_placeholder,
+        git_lfs_pointer_placeholder, is_image_path, materialized_to_string,
+        parse_binary_placeholder_size, parse_git_lfs_pointer, preview_placeholder,
     },
 };
 use crate::repo::support::block_on_result;
@@ -72,18 +72,12 @@ pub(super) fn materialize_diff_content(
     )?;
 
     if is_image_path(path.as_internal_file_string()) {
-        let old_preview = extract_image_preview(path, old_value)?;
-        let new_preview = extract_image_preview(path, new_value)?;
-        let old_content = match (&old_preview, hunk_type) {
-            (Some(preview), _) => Some(preview_placeholder(preview)),
-            (None, HunkType::Added) => None,
-            (None, _) => Some("<binary file>".to_owned()),
-        };
-        let new_content = match (&new_preview, hunk_type) {
-            (Some(preview), _) => Some(preview_placeholder(preview)),
-            (None, HunkType::Removed) => None,
-            (None, _) => Some("<binary file>".to_owned()),
-        };
+        let old_result = extract_image_preview(path, old_value)?;
+        let new_result = extract_image_preview(path, new_value)?;
+        let old_content = image_side_content(&old_result, hunk_type, Side::Old);
+        let new_content = image_side_content(&new_result, hunk_type, Side::New);
+        let old_preview = image_side_preview(old_result);
+        let new_preview = image_side_preview(new_result);
         return Ok(DiffContent {
             old_content,
             new_content,
@@ -105,6 +99,35 @@ pub(super) fn materialize_diff_content(
         new_preview: None,
         hunk_type,
     })
+}
+
+#[derive(Clone, Copy)]
+enum Side {
+    Old,
+    New,
+}
+
+fn image_side_content(
+    result: &ImagePreviewResult,
+    hunk_type: HunkType,
+    side: Side,
+) -> Option<String> {
+    match result {
+        ImagePreviewResult::Image(preview) => Some(preview_placeholder(preview)),
+        ImagePreviewResult::GitLfsPointer(pointer) => Some(git_lfs_pointer_placeholder(pointer)),
+        ImagePreviewResult::None => match (side, hunk_type) {
+            (Side::Old, HunkType::Added) => None,
+            (Side::New, HunkType::Removed) => None,
+            _ => Some("<binary file>".to_owned()),
+        },
+    }
+}
+
+fn image_side_preview(result: ImagePreviewResult) -> Option<DiffPreview> {
+    match result {
+        ImagePreviewResult::Image(preview) => Some(preview),
+        ImagePreviewResult::GitLfsPointer(_) | ImagePreviewResult::None => None,
+    }
 }
 
 pub(super) fn first_diff_content(

--- a/crates/jayjay-core/src/repo/diff/materialize.rs
+++ b/crates/jayjay-core/src/repo/diff/materialize.rs
@@ -20,20 +20,30 @@ pub(super) fn is_image_path(path: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Caches image bytes to a content-addressed temp file; returns None for non-files, empty, or oversized.
+pub(super) enum ImagePreviewResult {
+    Image(DiffPreview),
+    GitLfsPointer(GitLfsPointerInfo),
+    None,
+}
+
+/// Sniffs for LFS pointer bytes before caching; otherwise writes a content-addressed temp file.
 pub(super) fn extract_image_preview(
     path: &jj_lib::repo_path::RepoPath,
     value: MaterializedTreeValue,
-) -> CoreResult<Option<DiffPreview>> {
+) -> CoreResult<ImagePreviewResult> {
     let MaterializedTreeValue::File(mut file) = value else {
-        return Ok(None);
+        return Ok(ImagePreviewResult::None);
     };
     let bytes = block_on_result(
         &format!("read image {}", path.as_internal_file_string()),
         file.read_all(path),
     )?;
     if bytes.is_empty() || bytes.len() > MAX_IMAGE_BYTES {
-        return Ok(None);
+        return Ok(ImagePreviewResult::None);
+    }
+
+    if let Some(pointer) = detect_git_lfs_pointer_bytes(&bytes) {
+        return Ok(ImagePreviewResult::GitLfsPointer(pointer));
     }
 
     let path_str = path.as_internal_file_string();
@@ -63,9 +73,14 @@ pub(super) fn extract_image_preview(
         }
     }
 
-    Ok(Some(DiffPreview::Image {
+    Ok(ImagePreviewResult::Image(DiffPreview::Image {
         path: cache_path.to_string_lossy().into_owned(),
     }))
+}
+
+fn detect_git_lfs_pointer_bytes(bytes: &[u8]) -> Option<GitLfsPointerInfo> {
+    let text = std::str::from_utf8(bytes).ok()?;
+    parse_git_lfs_pointer(text)
 }
 
 /// Text placeholder — needed so rename detection and hunk iteration see the entry.
@@ -214,6 +229,26 @@ mod tests {
         assert!(is_image_path("Screenshot.PNG"));
         assert!(is_image_path("photo.JPEG"));
         assert!(is_image_path("sprite.Gif"));
+    }
+
+    #[test]
+    fn detects_git_lfs_pointer_bytes() {
+        let pointer_text = b"version https://git-lfs.github.com/spec/v1\n\
+             oid sha256:496634778d7b9bdbdb4b98b43a08a00ce8d794ed135a0cb1f345bf6febc5b9b4\n\
+             size 742800\n";
+        let pointer = detect_git_lfs_pointer_bytes(pointer_text).expect("should detect pointer");
+        assert_eq!(pointer.size, 742800);
+
+        // PNG magic bytes → not a pointer.
+        let png_magic = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        assert!(detect_git_lfs_pointer_bytes(&png_magic).is_none());
+
+        // Random binary noise → not a pointer.
+        let garbage = [0xFFu8; 32];
+        assert!(detect_git_lfs_pointer_bytes(&garbage).is_none());
+
+        // Empty → not a pointer.
+        assert!(detect_git_lfs_pointer_bytes(&[]).is_none());
     }
 
     #[test]

--- a/crates/jayjay-uniffi/src/types.rs
+++ b/crates/jayjay-uniffi/src/types.rs
@@ -166,6 +166,7 @@ pub struct DiffLine {
     pub new_line_no: Option<u32>,
     pub style: core::diff::DiffSpanStyle,
     pub spans: Vec<core::diff::DiffSpan>,
+    pub no_eof_newline: bool,
 }
 
 #[uniffi::remote(Record)]
@@ -173,6 +174,7 @@ pub struct FileDiff {
     pub path: String,
     pub language: String,
     pub lines: Vec<core::diff::DiffLine>,
+    pub whitespace_only_hidden: bool,
 }
 
 #[uniffi::remote(Record)]

--- a/crates/jj-diff/src/compute.rs
+++ b/crates/jj-diff/src/compute.rs
@@ -37,6 +37,7 @@ fn compute_file_diff_impl(
             path: path.to_owned(),
             language: language.to_owned(),
             lines: vec![],
+            whitespace_only_hidden: false,
         };
     }
 
@@ -78,6 +79,7 @@ fn compute_file_diff_impl(
                         new_line_no: Some(new_idx),
                         style: DiffSpanStyle::Context,
                         spans,
+                        no_eof_newline: false,
                     });
                 }
                 old_idx += 1;
@@ -119,12 +121,14 @@ fn compute_file_diff_impl(
                             new_line_no: None,
                             style: DiffSpanStyle::Removed,
                             spans: rem_spans,
+                            no_eof_newline: false,
                         });
                         result_lines.push(DiffLine {
                             old_line_no: None,
                             new_line_no: Some(new_ln),
                             style: DiffSpanStyle::Added,
                             spans: add_spans,
+                            no_eof_newline: false,
                         });
                     }
                 }
@@ -142,6 +146,7 @@ fn compute_file_diff_impl(
                             new_line_no: None,
                             style: DiffSpanStyle::Removed,
                             spans,
+                            no_eof_newline: false,
                         });
                     }
                 }
@@ -159,6 +164,7 @@ fn compute_file_diff_impl(
                             new_line_no: Some(new_ln),
                             style: DiffSpanStyle::Added,
                             spans,
+                            no_eof_newline: false,
                         });
                     }
                 }
@@ -176,12 +182,29 @@ fn compute_file_diff_impl(
                         new_line_no: Some(new_idx),
                         style: DiffSpanStyle::Added,
                         spans,
+                        no_eof_newline: false,
                     });
                 }
                 new_idx += 1;
                 op_pos += 1;
             }
         }
+    }
+
+    // Rust's .lines() strips the trailing newline; reconcile bytes vs lines so EOF markers surface.
+    let no_eof_old = !old.is_empty() && !old.ends_with('\n');
+    let no_eof_new = !new.is_empty() && !new.ends_with('\n');
+    let eof_differs = no_eof_old != no_eof_new;
+    let any_change = result_lines
+        .iter()
+        .any(|l| matches!(l.style, DiffSpanStyle::Added | DiffSpanStyle::Removed));
+
+    let mut whitespace_only_hidden = false;
+
+    if eof_differs {
+        apply_eof_markers(&mut result_lines, no_eof_old, no_eof_new);
+    } else if !any_change && old != new && ignore_whitespace {
+        whitespace_only_hidden = true;
     }
 
     let lines = if collapse {
@@ -194,5 +217,52 @@ fn compute_file_diff_impl(
         path: path.to_owned(),
         language: language.to_owned(),
         lines,
+        whitespace_only_hidden,
     }
+}
+
+/// Mark each side's last line with `no_eof_newline`; split a shared-Context last line into a pair so the marker can attribute per side.
+fn apply_eof_markers(lines: &mut Vec<DiffLine>, no_eof_old: bool, no_eof_new: bool) {
+    let last_old_idx = lines.iter().rposition(|l| l.old_line_no.is_some());
+    let last_new_idx = lines.iter().rposition(|l| l.new_line_no.is_some());
+
+    if let (Some(oi), Some(ni)) = (last_old_idx, last_new_idx) {
+        if oi == ni && lines[oi].style == DiffSpanStyle::Context {
+            split_context_for_eof(lines, oi, no_eof_old, no_eof_new);
+            return;
+        }
+    }
+
+    if no_eof_old {
+        if let Some(idx) = last_old_idx {
+            lines[idx].no_eof_newline = true;
+        }
+    }
+    if no_eof_new {
+        if let Some(idx) = last_new_idx {
+            lines[idx].no_eof_newline = true;
+        }
+    }
+}
+
+/// Spans stay as Context — the text is identical, so no word-level highlight.
+fn split_context_for_eof(
+    lines: &mut Vec<DiffLine>,
+    idx: usize,
+    no_eof_old: bool,
+    no_eof_new: bool,
+) {
+    let original = lines.remove(idx);
+    let mut removed = original.clone();
+    removed.new_line_no = None;
+    removed.style = DiffSpanStyle::Removed;
+    removed.no_eof_newline = no_eof_old;
+
+    let mut added = original;
+    added.old_line_no = None;
+    added.style = DiffSpanStyle::Added;
+    added.no_eof_newline = no_eof_new;
+
+    lines.insert(idx, removed);
+    lines.insert(idx + 1, added);
 }

--- a/crates/jj-diff/src/context.rs
+++ b/crates/jj-diff/src/context.rs
@@ -10,6 +10,7 @@ pub(super) fn collapse_context(lines: Vec<DiffLine>) -> Vec<DiffLine> {
         path: String::new(),
         language: String::new(),
         lines,
+        whitespace_only_hidden: false,
     };
     collapse_context_with_mapping(&full).diff.lines
 }
@@ -68,6 +69,7 @@ pub fn collapse_context_with_mapping(full_diff: &FileDiff) -> CollapsedDiff {
                 path: full_diff.path.clone(),
                 language: full_diff.language.clone(),
                 lines: result,
+                whitespace_only_hidden: full_diff.whitespace_only_hidden,
             },
             display_to_full: mapping,
         };
@@ -110,6 +112,7 @@ pub fn collapse_context_with_mapping(full_diff: &FileDiff) -> CollapsedDiff {
             path: full_diff.path.clone(),
             language: full_diff.language.clone(),
             lines: result,
+            whitespace_only_hidden: full_diff.whitespace_only_hidden,
         },
         display_to_full: mapping,
     }
@@ -125,5 +128,6 @@ pub(super) fn separator_line(hidden_count: usize) -> DiffLine {
             style: DiffSpanStyle::Separator,
             token: SyntaxToken::Plain,
         }],
+        no_eof_newline: false,
     }
 }

--- a/crates/jj-diff/src/tests.rs
+++ b/crates/jj-diff/src/tests.rs
@@ -477,6 +477,134 @@ fn test_ignore_whitespace() {
         "whitespace-only change should be hidden when ignoring whitespace, got {} changes",
         changed.len()
     );
+    assert!(
+        diff.whitespace_only_hidden,
+        "whitespace_only_hidden should flag ignore_whitespace-suppressed diffs"
+    );
+}
+
+#[test]
+fn test_eof_newline_added_synthesizes_visible_hunk() {
+    // File gains a trailing newline — Rust's .lines() would miss this, we synthesize a visible pair.
+    let old = "a\nb";
+    let new = "a\nb\n";
+    let diff = compute_file_diff("test.txt", old, new, false);
+
+    let removed = diff
+        .lines
+        .iter()
+        .find(|l| l.style == DiffSpanStyle::Removed)
+        .expect("should have a removed line for EOF newline change");
+    let added = diff
+        .lines
+        .iter()
+        .find(|l| l.style == DiffSpanStyle::Added)
+        .expect("should have an added line for EOF newline change");
+
+    assert!(removed.no_eof_newline, "old side lacks trailing newline");
+    assert!(!added.no_eof_newline, "new side has trailing newline");
+}
+
+#[test]
+fn test_eof_newline_removed_synthesizes_visible_hunk() {
+    let old = "a\nb\n";
+    let new = "a\nb";
+    let diff = compute_file_diff("test.txt", old, new, false);
+
+    let removed = diff
+        .lines
+        .iter()
+        .find(|l| l.style == DiffSpanStyle::Removed)
+        .expect("should have a removed line");
+    let added = diff
+        .lines
+        .iter()
+        .find(|l| l.style == DiffSpanStyle::Added)
+        .expect("should have an added line");
+
+    assert!(!removed.no_eof_newline, "old side has trailing newline");
+    assert!(added.no_eof_newline, "new side lacks trailing newline");
+}
+
+#[test]
+fn test_eof_newline_only_no_whitespace_flag() {
+    // EOF-newline-only changes are visible via synthesized hunk, not hidden by the whitespace flag.
+    let diff = compute_file_diff("test.txt", "a\nb", "a\nb\n", false);
+    assert!(
+        !diff.whitespace_only_hidden,
+        "EOF-newline change should synthesize a visible hunk, not set whitespace flag"
+    );
+}
+
+#[test]
+fn test_eof_splits_shared_context_when_real_changes_exist() {
+    let diff = compute_file_diff("test.txt", "a\nchanged\nc", "a\nfixed\nc\n", false);
+
+    let tail_removed = diff
+        .lines
+        .iter()
+        .rev()
+        .find(|l| l.style == DiffSpanStyle::Removed && l.old_line_no == Some(3))
+        .expect("trailing shared-context 'c' should split into a removed line");
+    let tail_added = diff
+        .lines
+        .iter()
+        .rev()
+        .find(|l| l.style == DiffSpanStyle::Added && l.new_line_no == Some(3))
+        .expect("trailing shared-context 'c' should split into an added line");
+    assert!(tail_removed.no_eof_newline);
+    assert!(!tail_added.no_eof_newline);
+
+    let mid_removed = diff
+        .lines
+        .iter()
+        .find(|l| l.style == DiffSpanStyle::Removed && l.old_line_no == Some(2))
+        .expect("middle 'changed' removed line must still exist");
+    assert!(
+        !mid_removed.no_eof_newline,
+        "earlier removed line must not carry the EOF marker"
+    );
+}
+
+#[test]
+fn test_eof_marker_lands_on_side_without_its_own_op() {
+    // Pure addition: old has no Removed op; marker must land on the last line belonging to old.
+    let diff = compute_file_diff("test.txt", "a", "a\nb\n", false);
+
+    let last_old = diff
+        .lines
+        .iter()
+        .rev()
+        .find(|l| l.old_line_no.is_some())
+        .expect("diff should contain a line representing old");
+    assert!(last_old.no_eof_newline);
+    for line in diff.lines.iter().filter(|l| l.new_line_no.is_some()) {
+        assert!(!line.no_eof_newline);
+    }
+}
+
+#[test]
+fn test_eof_newline_marker_on_real_change() {
+    // Real line change AND EOF newline differs — the last Removed/Added should be marked.
+    let old = "a\nold";
+    let new = "a\nnew\n";
+    let diff = compute_file_diff("test.txt", old, new, false);
+
+    let last_removed = diff
+        .lines
+        .iter()
+        .rev()
+        .find(|l| l.style == DiffSpanStyle::Removed)
+        .expect("should have a removed line");
+    let last_added = diff
+        .lines
+        .iter()
+        .rev()
+        .find(|l| l.style == DiffSpanStyle::Added)
+        .expect("should have an added line");
+
+    assert!(last_removed.no_eof_newline, "last old line lacks newline");
+    assert!(!last_added.no_eof_newline, "last new line has newline");
 }
 
 // ── Regression tests from v0.2.6–v0.2.7 session ───────────────

--- a/crates/jj-diff/src/types.rs
+++ b/crates/jj-diff/src/types.rs
@@ -25,6 +25,8 @@ pub struct DiffLine {
     pub new_line_no: Option<u32>,
     pub style: DiffSpanStyle,
     pub spans: Vec<DiffSpan>,
+    /// True if this line is the last line on its side and the file has no trailing newline.
+    pub no_eof_newline: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -32,6 +34,8 @@ pub struct FileDiff {
     pub path: String,
     pub language: String,
     pub lines: Vec<DiffLine>,
+    /// True when bytes differ but every line matches after whitespace normalization.
+    pub whitespace_only_hidden: bool,
 }
 
 /// A collapsed diff with a mapping from display line indices to full diff line indices.

--- a/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/NativeDiffView.swift
+++ b/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/NativeDiffView.swift
@@ -235,6 +235,15 @@ public struct NativeDiffView: NSViewRepresentable {
             if line.spans.isEmpty {
                 result.append(NSAttributedString(string: " ", attributes: [.font: font]))
             }
+            if line.noEofNewline {
+                let dim: [NSAttributedString.Key: Any] = [.font: font, .foregroundColor: theme.gutterText]
+                result.append(NSAttributedString(string: "  ⊘", attributes: dim))
+                var arrowAttrs = dim
+                // ↵ sits lower than ⊘ in most monospace fonts; nudge it up to match visual center.
+                arrowAttrs[.baselineOffset] = 1.5
+                result.append(NSAttributedString(string: "↵", attributes: arrowAttrs))
+                result.append(NSAttributedString(string: "  no newline at EOF", attributes: dim))
+            }
             result.append(NSAttributedString(string: "\n", attributes: [.font: font]))
             lineBgColors.append(theme.lineBg(line.style))
         }

--- a/shell/mac/Sources/JayJay/Detail/DetailHeader.swift
+++ b/shell/mac/Sources/JayJay/Detail/DetailHeader.swift
@@ -21,9 +21,12 @@ extension ChangeDetailView {
                 HStack(spacing: 4) {
                     Text("Bookmarks").jayjayFont(11).foregroundStyle(.secondary).frame(width: 70, alignment: .trailing)
                     ForEach(detail.info.bookmarks, id: \.self) { name in
-                        Text(name).jayjayFont(11, design: .monospaced)
-                            .padding(.horizontal, 6).padding(.vertical, 2)
-                            .background(.tint.opacity(0.15), in: .capsule)
+                        HStack(spacing: 4) {
+                            Text(name).jayjayFont(11, design: .monospaced)
+                                .padding(.horizontal, 6).padding(.vertical, 2)
+                                .background(.tint.opacity(0.15), in: .capsule)
+                            CopyIconButton(value: name, help: "Copy bookmark name")
+                        }
                     }
                 }
             }

--- a/shell/mac/Sources/JayJay/Diff/DiffSection.swift
+++ b/shell/mac/Sources/JayJay/Diff/DiffSection.swift
@@ -175,34 +175,53 @@ struct DiffSection: View {
             ProgressView()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else if let diff = fileDiff, !diff.lines.isEmpty {
-            Group {
-                if settings.sideBySideDiff, isTwoColumnDiff(diff) {
-                    SideBySideDiffView(diff: diff)
-                        .id("sbs-\(hunk.path)")
-                } else {
-                    NativeDiffView(
-                        diff: diff,
-                        gutterActions: DiffGutterContextActions(
-                            openDiffEdit: onOpenDiffEdit,
-                            onLineSelectionChanged: { selectedLineRange = $0 },
-                            selectedLineRange: selectedLineRange,
-                            abandonSelectedLines: isWorkingCopy ? abandonSelectedLines : nil
-                        )
-                    )
-                    .id("unified-\(hunk.path)")
+            VStack(alignment: .leading, spacing: 6) {
+                if diff.whitespaceOnlyHidden {
+                    whitespaceHiddenBanner
                 }
+                Group {
+                    if settings.sideBySideDiff, isTwoColumnDiff(diff) {
+                        SideBySideDiffView(diff: diff)
+                            .id("sbs-\(hunk.path)")
+                    } else {
+                        NativeDiffView(
+                            diff: diff,
+                            gutterActions: DiffGutterContextActions(
+                                openDiffEdit: onOpenDiffEdit,
+                                onLineSelectionChanged: { selectedLineRange = $0 },
+                                selectedLineRange: selectedLineRange,
+                                abandonSelectedLines: isWorkingCopy ? abandonSelectedLines : nil
+                            )
+                        )
+                        .id("unified-\(hunk.path)")
+                    }
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color.primary.opacity(0.03), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+                )
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.primary.opacity(0.03), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-            .overlay(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-            )
         } else if hunk.oldContent == nil, hunk.newContent == nil, !isComputing, loadedPath == hunk.path {
             Text("No textual preview available for this file.")
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
         }
+    }
+
+    private var whitespaceHiddenBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "eye.slash")
+                .foregroundStyle(.orange)
+            Text("Whitespace-only changes hidden by the 'Ignore whitespace' setting.")
+                .jayjayFont(11)
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color.orange.opacity(0.08), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 
     private func isTwoColumnDiff(_ diff: FileDiff) -> Bool {

--- a/shell/mac/Sources/JayJay/Repo/CommitBox.swift
+++ b/shell/mac/Sources/JayJay/Repo/CommitBox.swift
@@ -2,11 +2,11 @@ import SwiftUI
 
 struct CommitBox: View {
     let description: String
+    @Binding var draft: String
     let onCommit: (String) async -> Bool
     let onGenerateMessage: () async -> String?
     let aiProvider: String
 
-    @State private var draft = ""
     @State private var isGenerating = false
     @State private var isCommitting = false
 
@@ -81,7 +81,7 @@ struct CommitBox: View {
             }
         }
         .padding(12)
-        .onAppear { draft = description }
-        .onChange(of: description) { _, newValue in draft = newValue }
+        .onAppear { if draft.isEmpty { draft = description } }
+        .onChange(of: description) { _, newValue in if draft.isEmpty { draft = newValue } }
     }
 }

--- a/shell/mac/Sources/JayJay/Repo/DAGNodeStyle.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAGNodeStyle.swift
@@ -1,0 +1,66 @@
+import JayJayCore
+import SwiftUI
+
+/// Shape marks trunk bookmarks as diamonds; fill encodes working-copy/conflict/empty/bookmark state.
+struct DAGNodeStyle {
+    enum Shape {
+        case circle
+        case diamond
+    }
+
+    enum Fill {
+        case filled(Color)
+        case outlined(Color, lineWidth: CGFloat)
+    }
+
+    let shape: Shape
+    let radius: CGFloat
+    let fill: Fill
+
+    func path(in rect: CGRect) -> Path {
+        switch shape {
+            case .circle:
+                return Path(ellipseIn: rect)
+            case .diamond:
+                return Path { p in
+                    let cx = rect.midX
+                    let cy = rect.midY
+                    p.move(to: CGPoint(x: cx, y: rect.minY))
+                    p.addLine(to: CGPoint(x: rect.maxX, y: cy))
+                    p.addLine(to: CGPoint(x: cx, y: rect.maxY))
+                    p.addLine(to: CGPoint(x: rect.minX, y: cy))
+                    p.closeSubpath()
+                }
+        }
+    }
+
+    static func resolve(change: ChangeInfo) -> DAGNodeStyle {
+        let isTrunk = change.bookmarks.contains(where: isTrunkBookmark)
+        let hasBookmark = !change.bookmarks.isEmpty
+        let shape: Shape = isTrunk ? .diamond : .circle
+        let radius: CGFloat = (isTrunk || hasBookmark) ? nodeRadius + 1 : nodeRadius
+
+        let fill: Fill
+        if change.isWorkingCopy {
+            fill = .filled(.accentColor)
+        } else if change.hasConflict {
+            fill = .filled(.red)
+        } else if change.isEmpty {
+            fill = .outlined(.secondary.opacity(0.5), lineWidth: 1.5)
+        } else if isTrunk || hasBookmark {
+            fill = .outlined(.accentColor.opacity(0.85), lineWidth: 1.8)
+        } else {
+            fill = .filled(.secondary.opacity(0.5))
+        }
+
+        return DAGNodeStyle(shape: shape, radius: radius, fill: fill)
+    }
+}
+
+private let trunkBookmarkNames: Set<String> = ["main", "master", "trunk"]
+
+/// Matches bare "main" as well as remote-qualified forms like "main@origin".
+private func isTrunkBookmark(_ name: String) -> Bool {
+    let bare = name.split(separator: "@").first.map(String.init) ?? name
+    return trunkBookmarkNames.contains(bare)
+}

--- a/shell/mac/Sources/JayJay/Repo/DAGRow.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAGRow.swift
@@ -145,22 +145,19 @@ struct DAGRow: View {
                     ctx.stroke(path, with: .color(.secondary.opacity(0.3)), style: style)
                 }
 
-                // Draw node
+                let style = DAGNodeStyle.resolve(change: change)
                 let nodeRect = CGRect(
-                    x: myX - nodeRadius,
-                    y: nodeY - nodeRadius,
-                    width: nodeRadius * 2,
-                    height: nodeRadius * 2
+                    x: myX - style.radius,
+                    y: nodeY - style.radius,
+                    width: style.radius * 2,
+                    height: style.radius * 2
                 )
-                let nodePath = Path(ellipseIn: nodeRect)
-                if change.isWorkingCopy {
-                    ctx.fill(nodePath, with: .color(.accentColor))
-                } else if change.isEmpty {
-                    ctx.stroke(nodePath, with: .color(.secondary.opacity(0.5)), style: StrokeStyle(lineWidth: 1.5))
-                } else if change.hasConflict {
-                    ctx.fill(nodePath, with: .color(.red))
-                } else {
-                    ctx.fill(nodePath, with: .color(.secondary.opacity(0.5)))
+                let nodePath = style.path(in: nodeRect)
+                switch style.fill {
+                    case .filled(let color):
+                        ctx.fill(nodePath, with: .color(color))
+                    case .outlined(let color, let lineWidth):
+                        ctx.stroke(nodePath, with: .color(color), style: StrokeStyle(lineWidth: lineWidth))
                 }
 
                 if viewModel.isRebaseCandidate {
@@ -172,7 +169,7 @@ struct DAGRow: View {
                     if viewModel.isRebaseHoverTarget {
                         let ringRect = nodeRect.insetBy(dx: -4, dy: -4)
                         ctx.stroke(
-                            Path(ellipseIn: ringRect),
+                            style.path(in: ringRect),
                             with: .color(.accentColor.opacity(0.45)),
                             style: StrokeStyle(lineWidth: 2)
                         )
@@ -186,7 +183,7 @@ struct DAGRow: View {
                     if viewModel.isRebaseArmed {
                         let ringRect = nodeRect.insetBy(dx: -3, dy: -3)
                         ctx.stroke(
-                            Path(ellipseIn: ringRect),
+                            style.path(in: ringRect),
                             with: .color(.accentColor.opacity(0.35)),
                             style: StrokeStyle(lineWidth: 1.5, dash: [3, 3])
                         )

--- a/shell/mac/Sources/JayJay/Repo/RepoSidebar.swift
+++ b/shell/mac/Sources/JayJay/Repo/RepoSidebar.swift
@@ -55,6 +55,7 @@ extension RepoContentView {
                 Divider()
                 CommitBox(
                     description: viewModel.workingCopyDescription,
+                    draft: $viewModel.commitDraft,
                     onCommit: { await viewModel.commit(message: $0, manageSubmodules: settings.enableGitSubmoduleSupport) },
                     onGenerateMessage: { await viewModel.generateCommitMessage() },
                     aiProvider: viewModel.aiProvider

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
@@ -17,6 +17,7 @@ final class RepoViewModel: ChangeActions, DAGActions, BookmarkActions {
     var compareFromId: String?
     var bookmarks: [BookmarkInfo] = []
     var workingCopyDescription: String = ""
+    var commitDraft: String = ""
     var opLogEntries: [OpLogEntry] = []
     var submoduleAttentionItems: [GitSubmoduleStatus] = []
     var pendingCommitMessage: String?

--- a/shell/mac/Sources/JayJay/Settings/SettingsComponents.swift
+++ b/shell/mac/Sources/JayJay/Settings/SettingsComponents.swift
@@ -4,7 +4,6 @@ struct CopyableRow: View {
     let label: String
     let value: String
     let copyValue: String
-    @State private var copied = false
 
     init(_ label: String, value: String, copyValue: String? = nil) {
         self.label = label
@@ -16,19 +15,29 @@ struct CopyableRow: View {
         HStack(alignment: .top, spacing: 8) {
             Text(label).jayjayFont(11).foregroundStyle(.secondary).frame(width: 70, alignment: .trailing)
             Text(value).jayjayFont(11, design: .monospaced).textSelection(.enabled)
-            Button {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(copyValue, forType: .string)
-                copied = true
-                Task { try? await Task.sleep(for: .seconds(1.5)); copied = false }
-            } label: {
-                Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                    .jayjayFont(9)
-                    .foregroundStyle(copied ? Color.green : Color.secondary.opacity(0.5))
-            }
-            .buttonStyle(.plain)
-            .help("Copy \(label.lowercased())")
+            CopyIconButton(value: copyValue, help: "Copy \(label.lowercased())")
         }
+    }
+}
+
+struct CopyIconButton: View {
+    let value: String
+    let help: String
+    @State private var copied = false
+
+    var body: some View {
+        Button {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(value, forType: .string)
+            copied = true
+            Task { try? await Task.sleep(for: .seconds(1.5)); copied = false }
+        } label: {
+            Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                .jayjayFont(9)
+                .foregroundStyle(copied ? Color.green : Color.secondary.opacity(0.5))
+        }
+        .buttonStyle(.plain)
+        .help(help)
     }
 }
 


### PR DESCRIPTION
## Summary

Five fixes + polish bundled together from one debugging session:

- **Diff engine (jj-diff)** — Rust's `.lines()` silently drops the trailing newline, so an EOF-newline-only change produced an all-Equal diff and rendered as plain file content. Added `no_eof_newline` on `DiffLine` + `whitespace_only_hidden` on `FileDiff`. Post-process synthesizes a visible Remove+Add pair (with spans kept as Context so there's no spurious word-level highlight) and marks the last affected line per side when EOF differs alongside real changes.
- **Diff renderer (NativeDiffView)** — render `⊘↵  no newline at EOF` in dim gutter color on lines carrying the flag. `DiffSection` shows a small orange banner when `whitespaceOnlyHidden` suppressed real changes.
- **Commit box draft loss** — `CommitBox` lives inside `if shouldShowCommitBox`, so switching to any other change unmounted it and destroyed `@State draft`. Hoisted to `RepoViewModel.commitDraft` via `Binding`. Also guarded seeding with `draft.isEmpty` so background `workingCopyDescription` refreshes no longer clobber in-progress typing.
- **LFS pointer image preview** — when LFS is uninstalled and a pointer file is committed under an image extension, `extract_image_preview` used to cache the ~130-byte pointer text as a bogus `.png`, leading to an infinite `AsyncImage` spinner. Now sniffs LFS pointer bytes first; caller emits the same `<git lfs pointer ...>` placeholder the text path already knows how to render.
- **DAG node styling** — new `DAGNodeStyle` helper. Trunk-bookmarked commits (`main` / `master` / `trunk`, with optional `@origin` / `@upstream`) render as diamonds; other bookmarked commits render as hollow accent-stroked circles. Rebase overlays now match the node shape.
- **Bookmark copy button** — extracted `CopyIconButton` (the icon + flash pattern that already lived inside `CopyableRow`) and dropped one next to each bookmark capsule in the Detail header.

## Test plan

- [x] \`cargo test -p jj-diff\` — 31 pass incl. 4 new tests: EOF-newline added/removed synthesizes a visible pair, marker on real changes, and \`whitespace_only_hidden\` flag for \`ignore_whitespace\`-suppressed diffs
- [x] \`just test\` — all Rust crates green (79 tests)
- [x] \`just test-app\` — all Swift unit tests green (22)
- [x] \`cargo clippy --workspace\` + \`swiftlint\` clean
- [ ] Open a file with trailing-newline-only change: see \`⊘↵  no newline at EOF\` on the side that lacks it, line text is *not* word-highlighted red/green
- [ ] Type in commit box, select another change, select @ again: draft is preserved
- [ ] Open a repo with an uninstalled LFS pointer image: placeholder renders instead of infinite spinner
- [ ] DAG view with a \`main\` bookmark: trunk commit renders as a diamond; side bookmarks as outlined circles
- [ ] Detail view with bookmarks: copy icon flashes ✓ on click