### PR TITLE
Fix ignored working copy updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,11 +18,11 @@ Releases are not complete after `just release` alone. The full release flow is:
 1. Bump version and build number in **all four** sources: `shell/mac/project.yml`, `shell/mac/JayJay.xcodeproj/project.pbxproj`, `crates/jayjay-cli/Cargo.toml`, and `shell/justfile` (the last one is hardcoded — easy to forget).
 2. **Write release notes to `releases/<version>.html`** (HTML body, no wrapper tags). `update-appcast.py` reads this file and embeds it as the `<description>` block in the appcast entry. Releases without a notes file print a warning and ship without a description — never acceptable for a published release.
 3. Run `just build` to verify the release version still builds cleanly.
-4. Run `just release` to build, sign, notarize, zip, produce the SHA-256, and prepend the entry to `docs/appcast.xml`.
+4. Run `just release` to build, sign, notarize, zip, produce the SHA-256, and prepend the entry to `docs/appcast.xml`. This step only touches the local repo — no GitHub or tap changes yet.
 5. Commit the version bumps + `releases/<version>.html` + `docs/appcast.xml` change as `release: <version> (build N)`.
-6. Push `main`, then create and push the `v<version>` git tag.
-7. `gh release create v<version> build/release/JayJay-<version>.zip --notes "<copy of releases/<version>.html or matching markdown>"` — the GitHub release notes should mirror the appcast description.
-8. Update and push the Homebrew tap in `../tap` — bump `version "X.Y.Z,build"` and `sha256 "..."` in `Casks/jayjay.rb`.
+6. Push `main`, then create and push the `v<version>` git tag. **Push the tag before step 7** — `just shell::publish` uses `gh release create --verify-tag` and will abort if the tag is missing on the remote.
+7. Run `just shell::publish` to create the draft GitHub release, upload the zip, and rewrite `../tap/Casks/jayjay.rb` with the new `version "X.Y.Z,build"` and `sha256`. The release notes come from `releases/<version>.html`.
+8. Commit and push the Homebrew tap change in `../tap`.
 
 For JayJay specifically:
 - `just release` produces the notarized zip in `build/release/`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jayjay-cli"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "clap",
  "urlencoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1746,6 +1746,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "futures",
+ "gix",
  "jj-diff",
  "jj-lib",
  "pollster",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 jj-lib = "0.40"
+gix = { version = "0.81", default-features = false }
 uniffi = "0.31"
 clap = { version = "4", features = ["derive"] }
 thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "Apache-2.0"
 
 [workspace.dependencies]

--- a/crates/jayjay-cli/Cargo.toml
+++ b/crates/jayjay-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jayjay-cli"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/jayjay-core/Cargo.toml
+++ b/crates/jayjay-core/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 jj-lib = { workspace = true }
+gix = { workspace = true }
 jj-diff = { path = "../jj-diff" }
 thiserror = { workspace = true }
 pollster = { workspace = true }

--- a/crates/jayjay-core/src/repo/commit_ai.rs
+++ b/crates/jayjay-core/src/repo/commit_ai.rs
@@ -1,3 +1,5 @@
+use super::environment;
+
 pub const COMMIT_MESSAGE_PROMPT: &str = "\
 Generate a commit message. Output ONLY the message, nothing else.\n\
 Format: one summary line, then blank line, then bullet points.\n\
@@ -14,13 +16,13 @@ Fix: resolve crash on empty diff view\n\
 pub fn generate_commit_message_cli(diff_summary: &str) -> Option<String> {
     let prompt = COMMIT_MESSAGE_PROMPT;
 
-    if let Some(codex) = find_binary("codex") {
+    if let Some(codex) = environment::find_existing_binary("codex") {
         if let Some(message) = run_ai_cli(&codex, diff_summary, prompt, AiCliMode::Codex) {
             return Some(message);
         }
     }
 
-    if let Some(claude) = find_binary("claude") {
+    if let Some(claude) = environment::find_existing_binary("claude") {
         if let Some(message) = run_ai_cli(&claude, diff_summary, prompt, AiCliMode::Claude) {
             return Some(message);
         }
@@ -31,32 +33,13 @@ pub fn generate_commit_message_cli(diff_summary: &str) -> Option<String> {
 
 /// Returns the name of the first available AI CLI provider ("Codex" or "Claude"), or empty string.
 pub fn detect_ai_provider() -> String {
-    if find_binary("codex").is_some() {
+    if environment::find_existing_binary("codex").is_some() {
         "Codex".to_owned()
-    } else if find_binary("claude").is_some() {
+    } else if environment::find_existing_binary("claude").is_some() {
         "Claude".to_owned()
     } else {
         String::new()
     }
-}
-
-/// Find a CLI binary by name, checking common macOS paths.
-/// Same pattern as `jj_binary()` — macOS app bundles don't inherit shell PATH.
-fn find_binary(name: &str) -> Option<String> {
-    if let Ok(home) = std::env::var("HOME") {
-        let local_bin = format!("{home}/.local/bin/{name}");
-        if std::path::Path::new(&local_bin).exists() {
-            return Some(local_bin);
-        }
-    }
-    let candidates = [
-        format!("/opt/homebrew/bin/{name}"),
-        format!("/usr/local/bin/{name}"),
-        format!("/usr/bin/{name}"),
-    ];
-    candidates
-        .into_iter()
-        .find(|path| std::path::Path::new(&path).exists())
 }
 
 enum AiCliMode {

--- a/crates/jayjay-core/src/repo/config.rs
+++ b/crates/jayjay-core/src/repo/config.rs
@@ -5,6 +5,7 @@ use jj_lib::local_working_copy::LocalWorkingCopyFactory;
 use jj_lib::settings::UserSettings;
 use jj_lib::workspace::WorkingCopyFactories;
 
+use super::environment;
 use crate::types::*;
 
 pub(crate) fn working_copy_factories() -> WorkingCopyFactories {
@@ -15,17 +16,16 @@ pub(crate) fn working_copy_factories() -> WorkingCopyFactories {
 
 pub(crate) fn default_settings() -> Result<UserSettings, CoreError> {
     let mut config = StackedConfig::with_defaults();
-    if let Ok(home) = std::env::var("HOME") {
+    if let Some(home) = environment::home_dir() {
         let candidates = [
-            format!("{home}/.jjconfig.toml"),
-            format!("{home}/.config/jj/config.toml"),
+            home.join(".jjconfig.toml"),
+            home.join(".config").join("jj").join("config.toml"),
         ];
         for path in candidates {
-            let p = std::path::PathBuf::from(&path);
-            if p.exists() {
+            if path.exists() {
                 if let Ok(layer) = jj_lib::config::ConfigLayer::load_from_file(
                     jj_lib::config::ConfigSource::User,
-                    p,
+                    path,
                 ) {
                     config.add_layer(layer);
                 }

--- a/crates/jayjay-core/src/repo/environment.rs
+++ b/crates/jayjay-core/src/repo/environment.rs
@@ -1,23 +1,61 @@
+use std::path::{Path, PathBuf};
+
 use crate::types::*;
+
+pub(crate) fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+}
+
+pub(crate) fn xdg_config_home() -> Option<PathBuf> {
+    std::env::var_os("XDG_CONFIG_HOME")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| home_dir().map(|home| home.join(".config")))
+}
+
+pub(crate) fn git_excludes_file_path(
+    config: &gix::config::File,
+    workspace_root: &Path,
+) -> Option<PathBuf> {
+    if let Some(value) = config.string("core.excludesFile") {
+        let path = std::str::from_utf8(&value)
+            .ok()
+            .map(jj_lib::file_util::expand_home_path)?;
+        return Some(if path.is_absolute() {
+            path
+        } else {
+            workspace_root.join(path)
+        });
+    }
+
+    xdg_config_home().map(|path| path.join("git").join("ignore"))
+}
 
 /// Find a CLI binary. macOS app bundles don't inherit shell PATH.
 pub(crate) fn find_binary(name: &str) -> String {
-    let homebrew = format!("/opt/homebrew/bin/{name}");
-    let usr_local = format!("/usr/local/bin/{name}");
-    let usr = format!("/usr/bin/{name}");
-    let candidates = [homebrew.as_str(), usr_local.as_str(), usr.as_str()];
-    if let Ok(home) = std::env::var("HOME") {
-        let cargo = format!("{home}/.cargo/bin/{name}");
-        if std::path::Path::new(&cargo).exists() {
-            return cargo;
-        }
+    find_existing_binary(name).unwrap_or_else(|| name.to_string())
+}
+
+pub(crate) fn find_existing_binary(name: &str) -> Option<String> {
+    let mut candidates = Vec::new();
+    if let Some(home) = home_dir() {
+        candidates.push(home.join(".local").join("bin").join(name));
+        candidates.push(home.join(".cargo").join("bin").join(name));
     }
+    candidates.extend([
+        PathBuf::from(format!("/opt/homebrew/bin/{name}")),
+        PathBuf::from(format!("/usr/local/bin/{name}")),
+        PathBuf::from(format!("/usr/bin/{name}")),
+    ]);
+
     for path in candidates {
-        if std::path::Path::new(path).exists() {
-            return path.to_string();
+        if path.exists() {
+            return Some(path.to_string_lossy().into_owned());
         }
     }
-    name.to_string()
+    None
 }
 
 pub(crate) fn jj_binary() -> String {
@@ -35,9 +73,19 @@ fn check_cli(binary: &str) -> CliStatus {
         match std::process::Command::new(binary).arg("version").output() {
             Ok(output) if output.status.success() => {
                 let version = extract_version(&String::from_utf8_lossy(&output.stdout));
-                return CliStatus { is_installed: true, version, path: binary.to_string() };
+                return CliStatus {
+                    is_installed: true,
+                    version,
+                    path: binary.to_string(),
+                };
             }
-            _ => return CliStatus { is_installed: false, version: String::new(), path: String::new() },
+            _ => {
+                return CliStatus {
+                    is_installed: false,
+                    version: String::new(),
+                    path: String::new(),
+                };
+            }
         }
     }
     let version = std::process::Command::new(&resolved)
@@ -47,7 +95,11 @@ fn check_cli(binary: &str) -> CliStatus {
         .filter(|o| o.status.success())
         .map(|o| extract_version(&String::from_utf8_lossy(&o.stdout)))
         .unwrap_or_default();
-    CliStatus { is_installed: true, version, path: resolved }
+    CliStatus {
+        is_installed: true,
+        version,
+        path: resolved,
+    }
 }
 
 /// Extract a semver-like token from verbose version output (e.g., "gh version 2.89.0 (2026-03-26)" → "2.89.0").

--- a/crates/jayjay-core/src/repo/git.rs
+++ b/crates/jayjay-core/src/repo/git.rs
@@ -1,9 +1,9 @@
-pub use super::git_ai::{COMMIT_MESSAGE_PROMPT, detect_ai_provider};
+pub use super::commit_ai::{COMMIT_MESSAGE_PROMPT, detect_ai_provider};
 
 use std::io::Write;
 use std::process::{Command, Stdio};
 
-use super::git_ai::generate_commit_message_cli;
+use super::commit_ai::generate_commit_message_cli;
 use super::{JJ_CONFIG_USER_EMAIL, JJ_CONFIG_USER_NAME, Repo};
 use crate::types::*;
 

--- a/crates/jayjay-core/src/repo/mod.rs
+++ b/crates/jayjay-core/src/repo/mod.rs
@@ -1,13 +1,13 @@
 mod annotate;
 mod bookmarks;
 mod command;
+mod commit_ai;
 mod config;
 mod conflicts;
 mod diff;
 mod diffedit;
 mod environment;
 mod git;
-mod git_ai;
 mod github;
 mod log;
 mod mutations;
@@ -17,6 +17,7 @@ mod support;
 mod transaction;
 mod undo;
 mod working_copy;
+mod working_copy_ignore;
 mod workspace;
 
 pub use environment::check_gh_environment;
@@ -150,5 +151,4 @@ impl Repo {
     ) -> CoreResult<Arc<ReadonlyRepo>> {
         block_on_result("commit tx", tx.commit(description))
     }
-
 }

--- a/crates/jayjay-core/src/repo/working_copy.rs
+++ b/crates/jayjay-core/src/repo/working_copy.rs
@@ -1,17 +1,14 @@
-use jj_lib::gitignore::GitIgnoreFile;
 use jj_lib::matchers::{EverythingMatcher, NothingMatcher};
 use jj_lib::repo::Repo as _;
 use jj_lib::working_copy::SnapshotOptions;
 
 use super::Repo;
 use super::support::{block_on_result, load_repo_at_head, load_workspace_internal};
+use super::working_copy_ignore::{WorkingCopyIgnoreMatcher, base_git_ignores};
 use crate::types::*;
 
 impl Repo {
-    pub(crate) fn check_out_current_working_copy(
-        &self,
-        context: &str,
-    ) -> CoreResult<()> {
+    pub(crate) fn check_out_current_working_copy(&self, context: &str) -> CoreResult<()> {
         let mut workspace = load_workspace_internal(&self.path, context)?;
         let repo = load_repo_at_head(&workspace, context)?;
         let wc_commit_id = repo
@@ -68,7 +65,7 @@ impl Repo {
                 })?;
 
         let snapshot_options = SnapshotOptions {
-            base_ignores: GitIgnoreFile::empty(),
+            base_ignores: base_git_ignores(&repo, &self.path)?,
             progress: None,
             start_tracking_matcher: &EverythingMatcher,
             force_tracking_matcher: &NothingMatcher,
@@ -104,5 +101,11 @@ impl Repo {
             self.set_repo(repo);
         }
         Ok(())
+    }
+
+    pub fn has_unignored_working_copy_paths(&self, paths: &[String]) -> CoreResult<bool> {
+        let repo = self.get_repo();
+        WorkingCopyIgnoreMatcher::new(&repo, self.workspace_name.as_ref(), &self.path)?
+            .has_unignored_paths(paths)
     }
 }

--- a/crates/jayjay-core/src/repo/working_copy_ignore.rs
+++ b/crates/jayjay-core/src/repo/working_copy_ignore.rs
@@ -1,0 +1,192 @@
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use jj_lib::gitignore::GitIgnoreFile;
+use jj_lib::merged_tree::MergedTree;
+use jj_lib::ref_name::WorkspaceName;
+use jj_lib::repo::{ReadonlyRepo, Repo as _};
+use jj_lib::repo_path::RepoPathBuf;
+
+use super::environment;
+use super::support::block_on_result;
+use crate::types::*;
+
+pub(crate) struct WorkingCopyIgnoreMatcher {
+    workspace_root: PathBuf,
+    base_ignores: Arc<GitIgnoreFile>,
+    tracked_tree: MergedTree,
+}
+
+impl WorkingCopyIgnoreMatcher {
+    pub(crate) fn new(
+        repo: &ReadonlyRepo,
+        workspace_name: &WorkspaceName,
+        workspace_root: &Path,
+    ) -> CoreResult<Self> {
+        let wc_commit_id = repo
+            .view()
+            .get_wc_commit_id(workspace_name)
+            .ok_or_else(|| CoreError::Internal {
+                message: format!(
+                    "workspace {} has no working-copy commit",
+                    workspace_name.as_symbol()
+                ),
+            })?;
+        let wc_commit = repo
+            .store()
+            .get_commit(wc_commit_id)
+            .map_err(|e| CoreError::Internal {
+                message: format!("load working-copy commit: {e}"),
+            })?;
+        Ok(Self {
+            workspace_root: workspace_root.to_path_buf(),
+            base_ignores: base_git_ignores(repo, workspace_root)?,
+            tracked_tree: wc_commit.tree(),
+        })
+    }
+
+    pub(crate) fn has_unignored_paths(&self, paths: &[String]) -> CoreResult<bool> {
+        for path in paths {
+            if !self.path_is_ignored(Path::new(path))? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn path_is_ignored(&self, event_path: &Path) -> CoreResult<bool> {
+        let Some(relative) = self.relative_event_path(event_path) else {
+            return Ok(false);
+        };
+        let Some(components) = path_components(&relative) else {
+            return Ok(false);
+        };
+        if components.is_empty() {
+            return Ok(false);
+        }
+        if self.path_is_tracked(&relative)? {
+            return Ok(false);
+        }
+        if components
+            .iter()
+            .any(|name| path_component_is_internal(name))
+        {
+            return Ok(true);
+        }
+
+        let ignores = self.ignores_for_parent_dirs(&components)?;
+        let path = components.join("/");
+        if event_path.is_dir() {
+            Ok(ignores.matches(&format!("{path}/")))
+        } else {
+            Ok(ignores.matches(&path))
+        }
+    }
+
+    fn relative_event_path(&self, event_path: &Path) -> Option<PathBuf> {
+        if let Ok(relative) = event_path.strip_prefix(&self.workspace_root) {
+            return Some(relative.to_path_buf());
+        }
+
+        let workspace_root = self.workspace_root.canonicalize().ok()?;
+        let event_path = event_path.canonicalize().ok()?;
+        event_path
+            .strip_prefix(workspace_root)
+            .ok()
+            .map(Path::to_path_buf)
+    }
+
+    fn ignores_for_parent_dirs(&self, components: &[&str]) -> CoreResult<Arc<GitIgnoreFile>> {
+        let mut ignores = chain_ignore_file_at(
+            self.base_ignores.clone(),
+            "",
+            self.workspace_root.join(".gitignore"),
+        )?;
+        let mut disk_dir = self.workspace_root.clone();
+        let mut prefix = String::new();
+
+        for component in components.iter().take(components.len().saturating_sub(1)) {
+            let dir_path = format!("{prefix}{component}/");
+            if ignores.matches(&dir_path) {
+                return Ok(ignores);
+            }
+            disk_dir.push(component);
+            prefix.push_str(component);
+            prefix.push('/');
+            ignores = chain_ignore_file_at(ignores, &prefix, disk_dir.join(".gitignore"))?;
+        }
+
+        Ok(ignores)
+    }
+
+    fn path_is_tracked(&self, relative: &Path) -> CoreResult<bool> {
+        let Ok(repo_path) = RepoPathBuf::from_relative_path(relative) else {
+            return Ok(false);
+        };
+        let value = block_on_result(
+            "load working-copy tree path",
+            self.tracked_tree.path_value(&repo_path),
+        )?;
+        Ok(value.is_present())
+    }
+}
+
+pub(crate) fn base_git_ignores(
+    repo: &ReadonlyRepo,
+    workspace_root: &Path,
+) -> CoreResult<Arc<GitIgnoreFile>> {
+    let mut ignores = GitIgnoreFile::empty();
+
+    if let Ok(git_backend) = jj_lib::git::get_git_backend(repo.store()) {
+        let git_repo = git_backend.git_repo();
+        let config = git_repo.config_snapshot();
+        if let Some(excludes_file_path) =
+            environment::git_excludes_file_path(&config, workspace_root)
+        {
+            ignores = chain_ignore_file(ignores, excludes_file_path)?;
+        }
+        let info_exclude = git_backend.git_repo_path().join("info").join("exclude");
+        ignores = chain_ignore_file(ignores, info_exclude)?;
+    } else if let Ok(git_config) = gix::config::File::from_globals()
+        && let Some(excludes_file_path) =
+            environment::git_excludes_file_path(&git_config, workspace_root)
+    {
+        ignores = chain_ignore_file(ignores, excludes_file_path)?;
+    }
+
+    Ok(ignores)
+}
+
+fn path_components(path: &Path) -> Option<Vec<&str>> {
+    let mut components = Vec::new();
+    for component in path.components() {
+        let Component::Normal(component) = component else {
+            continue;
+        };
+        components.push(component.to_str()?);
+    }
+    Some(components)
+}
+
+fn path_component_is_internal(component: &str) -> bool {
+    matches!(component, ".jj" | ".git" | ".DS_Store")
+}
+
+fn chain_ignore_file(
+    ignores: Arc<GitIgnoreFile>,
+    path: impl Into<PathBuf>,
+) -> CoreResult<Arc<GitIgnoreFile>> {
+    chain_ignore_file_at(ignores, "", path)
+}
+
+fn chain_ignore_file_at(
+    ignores: Arc<GitIgnoreFile>,
+    prefix: &str,
+    path: impl Into<PathBuf>,
+) -> CoreResult<Arc<GitIgnoreFile>> {
+    ignores
+        .chain_with_file(prefix, path.into())
+        .map_err(|e| CoreError::Internal {
+            message: format!("process git ignore file: {e}"),
+        })
+}

--- a/crates/jayjay-core/src/repo/working_copy_ignore.rs
+++ b/crates/jayjay-core/src/repo/working_copy_ignore.rs
@@ -1,6 +1,9 @@
+use std::cell::OnceCell;
+use std::collections::HashMap;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
+use jj_lib::commit::Commit;
 use jj_lib::gitignore::GitIgnoreFile;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::ref_name::WorkspaceName;
@@ -13,8 +16,10 @@ use crate::types::*;
 
 pub(crate) struct WorkingCopyIgnoreMatcher {
     workspace_root: PathBuf,
+    workspace_root_canonical: Option<PathBuf>,
     base_ignores: Arc<GitIgnoreFile>,
-    tracked_tree: MergedTree,
+    wc_commit: Commit,
+    tracked_tree: OnceCell<MergedTree>,
 }
 
 impl WorkingCopyIgnoreMatcher {
@@ -40,21 +45,28 @@ impl WorkingCopyIgnoreMatcher {
             })?;
         Ok(Self {
             workspace_root: workspace_root.to_path_buf(),
+            workspace_root_canonical: workspace_root.canonicalize().ok(),
             base_ignores: base_git_ignores(repo, workspace_root)?,
-            tracked_tree: wc_commit.tree(),
+            wc_commit,
+            tracked_tree: OnceCell::new(),
         })
     }
 
     pub(crate) fn has_unignored_paths(&self, paths: &[String]) -> CoreResult<bool> {
+        let mut cache: HashMap<String, Arc<GitIgnoreFile>> = HashMap::new();
         for path in paths {
-            if !self.path_is_ignored(Path::new(path))? {
+            if !self.path_is_ignored(Path::new(path), &mut cache)? {
                 return Ok(true);
             }
         }
         Ok(false)
     }
 
-    fn path_is_ignored(&self, event_path: &Path) -> CoreResult<bool> {
+    fn path_is_ignored(
+        &self,
+        event_path: &Path,
+        cache: &mut HashMap<String, Arc<GitIgnoreFile>>,
+    ) -> CoreResult<bool> {
         let Some(relative) = self.relative_event_path(event_path) else {
             return Ok(false);
         };
@@ -64,9 +76,6 @@ impl WorkingCopyIgnoreMatcher {
         if components.is_empty() {
             return Ok(false);
         }
-        if self.path_is_tracked(&relative)? {
-            return Ok(false);
-        }
         if components
             .iter()
             .any(|name| path_component_is_internal(name))
@@ -74,21 +83,28 @@ impl WorkingCopyIgnoreMatcher {
             return Ok(true);
         }
 
-        let ignores = self.ignores_for_parent_dirs(&components)?;
+        let ignores = self.ignores_for_parent_dirs(&components, cache)?;
         let path = components.join("/");
-        if event_path.is_dir() {
-            Ok(ignores.matches(&format!("{path}/")))
+        let matches = if event_path.is_dir() {
+            ignores.matches(&format!("{path}/"))
         } else {
-            Ok(ignores.matches(&path))
+            ignores.matches(&path)
+        };
+        if !matches {
+            return Ok(false);
         }
+        // Tracked paths still need to surface even when they match ignore rules.
+        if self.path_is_tracked(&relative)? {
+            return Ok(false);
+        }
+        Ok(true)
     }
 
     fn relative_event_path(&self, event_path: &Path) -> Option<PathBuf> {
         if let Ok(relative) = event_path.strip_prefix(&self.workspace_root) {
             return Some(relative.to_path_buf());
         }
-
-        let workspace_root = self.workspace_root.canonicalize().ok()?;
+        let workspace_root = self.workspace_root_canonical.as_deref()?;
         let event_path = event_path.canonicalize().ok()?;
         event_path
             .strip_prefix(workspace_root)
@@ -96,14 +112,25 @@ impl WorkingCopyIgnoreMatcher {
             .map(Path::to_path_buf)
     }
 
-    fn ignores_for_parent_dirs(&self, components: &[&str]) -> CoreResult<Arc<GitIgnoreFile>> {
-        let mut ignores = chain_ignore_file_at(
-            self.base_ignores.clone(),
-            "",
-            self.workspace_root.join(".gitignore"),
-        )?;
-        let mut disk_dir = self.workspace_root.clone();
+    fn ignores_for_parent_dirs(
+        &self,
+        components: &[&str],
+        cache: &mut HashMap<String, Arc<GitIgnoreFile>>,
+    ) -> CoreResult<Arc<GitIgnoreFile>> {
         let mut prefix = String::new();
+        let mut ignores = match cache.get(&prefix) {
+            Some(cached) => cached.clone(),
+            None => {
+                let chain = chain_ignore_file_at(
+                    self.base_ignores.clone(),
+                    "",
+                    self.workspace_root.join(".gitignore"),
+                )?;
+                cache.insert(prefix.clone(), chain.clone());
+                chain
+            }
+        };
+        let mut disk_dir = self.workspace_root.clone();
 
         for component in components.iter().take(components.len().saturating_sub(1)) {
             let dir_path = format!("{prefix}{component}/");
@@ -113,7 +140,15 @@ impl WorkingCopyIgnoreMatcher {
             disk_dir.push(component);
             prefix.push_str(component);
             prefix.push('/');
-            ignores = chain_ignore_file_at(ignores, &prefix, disk_dir.join(".gitignore"))?;
+            ignores = match cache.get(&prefix) {
+                Some(cached) => cached.clone(),
+                None => {
+                    let chain =
+                        chain_ignore_file_at(ignores, &prefix, disk_dir.join(".gitignore"))?;
+                    cache.insert(prefix.clone(), chain.clone());
+                    chain
+                }
+            };
         }
 
         Ok(ignores)
@@ -123,10 +158,8 @@ impl WorkingCopyIgnoreMatcher {
         let Ok(repo_path) = RepoPathBuf::from_relative_path(relative) else {
             return Ok(false);
         };
-        let value = block_on_result(
-            "load working-copy tree path",
-            self.tracked_tree.path_value(&repo_path),
-        )?;
+        let tree = self.tracked_tree.get_or_init(|| self.wc_commit.tree());
+        let value = block_on_result("load working-copy tree path", tree.path_value(&repo_path))?;
         Ok(value.is_present())
     }
 }

--- a/crates/jayjay-core/tests/real_jj_repo.rs
+++ b/crates/jayjay-core/tests/real_jj_repo.rs
@@ -294,47 +294,6 @@ fn working_copy_event_filter_preserves_tracked_ignored_paths() {
 }
 
 #[test]
-fn refresh_working_copy_respects_git_info_exclude() {
-    if !jj_is_available() {
-        eprintln!("skipping real jj repo test because `jj` is not installed");
-        return;
-    }
-
-    let temp_dir = init_real_repo();
-    let repo_path = temp_dir.path().join("repo");
-    fs::write(repo_path.join(".git/info/exclude"), "scratch/\n").expect("write info exclude");
-    fs::create_dir(repo_path.join("scratch")).expect("create ignored dir");
-    fs::write(repo_path.join("scratch/file.txt"), "ignored\n").expect("write ignored file");
-    fs::write(repo_path.join("visible.txt"), "visible\n").expect("write visible file");
-
-    let repo = Repo::open(&repo_path).expect("open repo");
-    assert!(
-        !repo
-            .has_unignored_working_copy_paths(&[repo_path
-                .join("scratch/file.txt")
-                .display()
-                .to_string()])
-            .expect("check ignored path"),
-        ".git/info/exclude should suppress ignored working-copy events"
-    );
-    repo.refresh_working_copy()
-        .expect("snapshot working copy changes");
-
-    let current = repo.show("@").expect("show refreshed working copy");
-    assert!(
-        current.diff.iter().any(|hunk| hunk.path == "visible.txt"),
-        "ordinary new files should still be auto-tracked"
-    );
-    assert!(
-        current
-            .diff
-            .iter()
-            .all(|hunk| !hunk.path.starts_with("scratch/")),
-        ".git/info/exclude should prevent scratch files from being auto-tracked"
-    );
-}
-
-#[test]
 fn core_repo_works_against_a_real_jj_repo() {
     if !jj_is_available() {
         eprintln!("skipping real jj repo test because `jj` is not installed");

--- a/crates/jayjay-core/tests/real_jj_repo.rs
+++ b/crates/jayjay-core/tests/real_jj_repo.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 use std::process::{Command, Output, Stdio};
 
 use jayjay_core::diff::compute_file_diff_full;
@@ -16,16 +17,23 @@ fn jj_is_available() -> bool {
         .is_ok_and(|status| status.success())
 }
 
-fn run_jj(args: &[&str]) -> Output {
-    let output = Command::new("jj")
-        .args(args)
+fn git_is_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn run_command(program: &str, display_args: &[String], command: &mut Command) -> Output {
+    let output = command
         .output()
-        .unwrap_or_else(|err| panic!("failed to run jj {:?}: {err}", args));
+        .unwrap_or_else(|err| panic!("failed to run {program} {display_args:?}: {err}"));
 
     if !output.status.success() {
         panic!(
-            "jj {:?} failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
-            args,
+            "{program} {display_args:?} failed\nstatus: {:?}\nstdout:\n{}\nstderr:\n{}",
             output.status.code(),
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr),
@@ -35,12 +43,29 @@ fn run_jj(args: &[&str]) -> Output {
     output
 }
 
+fn run_jj(args: &[&str]) -> Output {
+    let mut command = Command::new("jj");
+    command.args(args);
+    let display_args = args.iter().map(|arg| arg.to_string()).collect::<Vec<_>>();
+    run_command("jj", &display_args, &mut command)
+}
+
+fn run_git(repo_path: &Path, args: &[&str]) -> Output {
+    let mut command = Command::new("git");
+    command.arg("-C").arg(repo_path).args(args);
+    let display_args = std::iter::once("-C".to_string())
+        .chain(std::iter::once(repo_path.display().to_string()))
+        .chain(args.iter().map(|arg| arg.to_string()))
+        .collect::<Vec<_>>();
+    run_command("git", &display_args, &mut command)
+}
+
 fn init_real_repo() -> TempDir {
     let temp_dir = tempfile::tempdir().expect("create tempdir");
     let repo_path = temp_dir.path().join("repo");
     let repo_str = repo_path.to_str().expect("repo path utf-8");
 
-    run_jj(&["git", "init", repo_str]);
+    run_jj(&["git", "init", "--colocate", repo_str]);
     run_jj(&[
         "-R",
         repo_str,
@@ -135,6 +160,178 @@ fn setup_source_change_with_child() -> (TempDir, std::path::PathBuf, Repo) {
         .expect("create working copy child");
 
     (temp_dir, repo_path, repo)
+}
+
+#[test]
+fn refresh_working_copy_respects_git_excludes_file() {
+    if !jj_is_available() || !git_is_available() {
+        eprintln!("skipping real jj repo test because `jj` or `git` is not installed");
+        return;
+    }
+
+    let temp_dir = init_real_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let excludes_path = temp_dir.path().join("global-ignore");
+    fs::write(&excludes_path, ".claude/\n").expect("write excludes file");
+    run_git(
+        &repo_path,
+        &[
+            "config",
+            "core.excludesFile",
+            excludes_path.to_str().expect("excludes path utf-8"),
+        ],
+    );
+
+    fs::create_dir(repo_path.join(".claude")).expect("create ignored dir");
+    fs::write(repo_path.join(".claude/settings.json"), "{}\n").expect("write ignored file");
+    fs::write(repo_path.join("visible.txt"), "visible\n").expect("write visible file");
+
+    let repo = Repo::open(&repo_path).expect("open repo");
+    assert!(
+        !repo
+            .has_unignored_working_copy_paths(&[repo_path
+                .join(".claude/settings.json")
+                .display()
+                .to_string()])
+            .expect("check ignored path"),
+        "global git excludes should suppress ignored working-copy events"
+    );
+    assert!(
+        repo.has_unignored_working_copy_paths(&[repo_path
+            .join("visible.txt")
+            .display()
+            .to_string()])
+            .expect("check visible path"),
+        "ordinary new files should still trigger working-copy events"
+    );
+    repo.refresh_working_copy()
+        .expect("snapshot working copy changes");
+
+    let current = repo.show("@").expect("show refreshed working copy");
+    assert!(
+        current.diff.iter().any(|hunk| hunk.path == "visible.txt"),
+        "ordinary new files should still be auto-tracked"
+    );
+    assert!(
+        current
+            .diff
+            .iter()
+            .all(|hunk| !hunk.path.starts_with(".claude/")),
+        "git excludes file should prevent .claude files from being auto-tracked"
+    );
+}
+
+#[test]
+fn working_copy_event_filter_respects_local_gitignore() {
+    if !jj_is_available() {
+        eprintln!("skipping real jj repo test because `jj` is not installed");
+        return;
+    }
+
+    let temp_dir = init_real_repo();
+    let repo_path = temp_dir.path().join("repo");
+    fs::write(repo_path.join(".gitignore"), "scratch/\n").expect("write gitignore");
+    fs::create_dir(repo_path.join("scratch")).expect("create ignored dir");
+    fs::write(repo_path.join("scratch/file.txt"), "ignored\n").expect("write ignored file");
+    fs::write(repo_path.join("visible.txt"), "visible\n").expect("write visible file");
+
+    let repo = Repo::open(&repo_path).expect("open repo");
+    assert!(
+        !repo
+            .has_unignored_working_copy_paths(&[repo_path
+                .join("scratch/file.txt")
+                .display()
+                .to_string()])
+            .expect("check ignored path"),
+        "local .gitignore should suppress ignored working-copy events"
+    );
+    assert!(
+        repo.has_unignored_working_copy_paths(&[
+            repo_path.join("scratch/file.txt").display().to_string(),
+            repo_path.join("visible.txt").display().to_string(),
+        ])
+        .expect("check mixed paths"),
+        "a batch with any unignored path should trigger a working-copy event"
+    );
+}
+
+#[test]
+fn working_copy_event_filter_preserves_tracked_ignored_paths() {
+    if !jj_is_available() {
+        eprintln!("skipping real jj repo test because `jj` is not installed");
+        return;
+    }
+
+    let temp_dir = init_real_repo();
+    let repo_path = temp_dir.path().join("repo");
+    fs::create_dir(repo_path.join("tracked")).expect("create tracked dir");
+    fs::write(repo_path.join("tracked/file.txt"), "tracked\n").expect("write tracked file");
+
+    let repo = Repo::open(&repo_path).expect("open repo");
+    repo.refresh_working_copy().expect("track file");
+
+    fs::write(repo_path.join(".gitignore"), "tracked/\n").expect("write gitignore");
+    fs::write(repo_path.join("tracked/file.txt"), "changed\n").expect("change tracked file");
+    fs::write(repo_path.join("tracked/new.txt"), "ignored\n").expect("write ignored file");
+
+    assert!(
+        repo.has_unignored_working_copy_paths(&[repo_path
+            .join("tracked/file.txt")
+            .display()
+            .to_string()])
+            .expect("check tracked ignored path"),
+        "tracked paths should still trigger working-copy events even when ignored"
+    );
+    assert!(
+        !repo
+            .has_unignored_working_copy_paths(&[repo_path
+                .join("tracked/new.txt")
+                .display()
+                .to_string()])
+            .expect("check untracked ignored path"),
+        "untracked ignored paths should not trigger working-copy events"
+    );
+}
+
+#[test]
+fn refresh_working_copy_respects_git_info_exclude() {
+    if !jj_is_available() {
+        eprintln!("skipping real jj repo test because `jj` is not installed");
+        return;
+    }
+
+    let temp_dir = init_real_repo();
+    let repo_path = temp_dir.path().join("repo");
+    fs::write(repo_path.join(".git/info/exclude"), "scratch/\n").expect("write info exclude");
+    fs::create_dir(repo_path.join("scratch")).expect("create ignored dir");
+    fs::write(repo_path.join("scratch/file.txt"), "ignored\n").expect("write ignored file");
+    fs::write(repo_path.join("visible.txt"), "visible\n").expect("write visible file");
+
+    let repo = Repo::open(&repo_path).expect("open repo");
+    assert!(
+        !repo
+            .has_unignored_working_copy_paths(&[repo_path
+                .join("scratch/file.txt")
+                .display()
+                .to_string()])
+            .expect("check ignored path"),
+        ".git/info/exclude should suppress ignored working-copy events"
+    );
+    repo.refresh_working_copy()
+        .expect("snapshot working copy changes");
+
+    let current = repo.show("@").expect("show refreshed working copy");
+    assert!(
+        current.diff.iter().any(|hunk| hunk.path == "visible.txt"),
+        "ordinary new files should still be auto-tracked"
+    );
+    assert!(
+        current
+            .diff
+            .iter()
+            .all(|hunk| !hunk.path.starts_with("scratch/")),
+        ".git/info/exclude should prevent scratch files from being auto-tracked"
+    );
 }
 
 #[test]
@@ -289,8 +486,8 @@ fn image_file_is_cached_and_surfaced_as_diff_preview() {
         );
     };
 
-    let cached_bytes = fs::read(cache_path)
-        .unwrap_or_else(|err| panic!("read cache file {cache_path}: {err}"));
+    let cached_bytes =
+        fs::read(cache_path).unwrap_or_else(|err| panic!("read cache file {cache_path}: {err}"));
     assert_eq!(
         cached_bytes, png_bytes,
         "cache file contents must match the original bytes"

--- a/crates/jayjay-uniffi/src/repo.rs
+++ b/crates/jayjay-uniffi/src/repo.rs
@@ -62,6 +62,13 @@ impl JayJayRepo {
         Ok(self.inner.refresh_working_copy()?)
     }
 
+    pub fn has_unignored_working_copy_paths(
+        &self,
+        paths: Vec<String>,
+    ) -> Result<bool, JayJayError> {
+        Ok(self.inner.has_unignored_working_copy_paths(&paths)?)
+    }
+
     pub fn log(&self, revset: String) -> Result<Vec<core::ChangeInfo>, JayJayError> {
         Ok(self.inner.log(&revset)?)
     }
@@ -379,7 +386,6 @@ impl JayJayRepo {
     ) -> core::diff::CollapsedDiff {
         core::diff::collapse_context_with_mapping(&diff)
     }
-
 
     pub fn apply_diff_selection(
         &self,

--- a/releases/0.2.15.html
+++ b/releases/0.2.15.html
@@ -1,0 +1,16 @@
+<h3>Working copy fidelity</h3>
+<ul>
+    <li>Auto-snapshots now respect Git's full ignore stack — local <code>.gitignore</code>, <code>core.excludesFile</code>, the default <code>$XDG_CONFIG_HOME/git/ignore</code>, and <code>.git/info/exclude</code>. Globally ignored files like <code>.claude/</code> no longer appear as untracked changes in the working copy.</li>
+    <li>The macOS filesystem watcher now consults the same ignore matcher as the Rust core, so editing a globally-ignored file no longer triggers a stale "uncommitted changes" indicator.</li>
+    <li>Tracked files that match an ignore rule still surface change events, so edits to checked-in build artifacts continue to refresh the UI.</li>
+</ul>
+<h3>Commit box fix</h3>
+<ul>
+    <li>The commit message now resets after a successful <code>jj commit</code>, so the new working copy starts with an empty draft instead of inheriting the previous message.</li>
+    <li>If a commit fails, the draft is preserved — previously the box was cleared optimistically and the message was lost.</li>
+</ul>
+<h3>Release tooling</h3>
+<ul>
+    <li><code>just release</code> now stops at the local artifact (zip + signed appcast); the new <code>just shell::publish</code> recipe creates the GitHub draft, uploads the zip, and bumps the Homebrew tap. <code>gh release create</code> uses <code>--verify-tag</code>, so publishing aborts cleanly if the <code>v&lt;version&gt;</code> tag has not been pushed.</li>
+    <li>Sparkle signing failures now fail the release outright instead of producing an unsigned appcast entry.</li>
+</ul>

--- a/scripts/update-appcast.py
+++ b/scripts/update-appcast.py
@@ -21,6 +21,14 @@ zip_path = sys.argv[4]
 appcast_path = sys.argv[5]
 signature = sys.argv[6] if len(sys.argv) > 6 else "PENDING"
 
+
+def insert_after_first(pattern: str, content: str, snippet: str, anchor_name: str) -> str:
+    updated, count = re.subn(pattern, lambda match: match.group(0) + snippet, content, count=1)
+    if count != 1:
+        print(f"ERROR: could not locate {anchor_name} in {appcast_path}", file=sys.stderr)
+        sys.exit(1)
+    return updated
+
 file_size = os.path.getsize(zip_path)
 pub_date = datetime.now(timezone.utc).strftime("%a, %d %b %Y %H:%M:%S %z")
 
@@ -61,18 +69,16 @@ if os.path.exists(appcast_path) and os.path.getsize(appcast_path) > 0:
 
     # Idempotent: drop any existing entry for this version before inserting.
     pattern = re.compile(
-        r"        <item>\n"
-        r"            <title>Version " + re.escape(version) + r"</title>\n"
-        r".*?</item>\n",
-        re.DOTALL,
+        r"^[ \t]*<item>\s*<title>Version " + re.escape(version) + r"</title>.*?</item>\s*",
+        re.MULTILINE | re.DOTALL,
     )
     content = pattern.sub("", content)
 
     # Prepend the new entry right after the channel header.
     if "</language>" in content:
-        content = content.replace("</language>\n", "</language>\n" + new_item, 1)
+        content = insert_after_first(r"</language>\s*", content, new_item, "</language>")
     else:
-        content = content.replace("<channel>\n", "<channel>\n" + new_item, 1)
+        content = insert_after_first(r"<channel>\s*", content, new_item, "<channel>")
 
     with open(appcast_path, "w") as f:
         f.write(content)

--- a/shell/justfile
+++ b/shell/justfile
@@ -252,11 +252,74 @@ release: ffi-release
   # 5. Generate Sparkle appcast
   zip_path="{{release_dir}}/{{app_name}}-{{version}}.zip"
   sparkle_bin=$(find "{{derived_data}}" -name "sign_update" -type f 2>/dev/null | head -1)
-  sig=""
-  if [ -n "$sparkle_bin" ]; then
-    sig=$("$sparkle_bin" "$zip_path" 2>/dev/null | grep -o 'sparkle:edSignature="[^"]*"' | cut -d'"' -f2 || true)
+  if [ -z "$sparkle_bin" ] || [ ! -x "$sparkle_bin" ]; then
+    echo "Could not locate Sparkle sign_update under {{derived_data}}." >&2
+    exit 1
+  fi
+  sign_output=$("$sparkle_bin" "$zip_path" 2>&1) || {
+    echo "Error: Sparkle sign_update failed: $sign_output" >&2
+    exit 1
+  }
+  sig=$(printf '%s' "$sign_output" | grep -o 'sparkle:edSignature="[^"]*"' | cut -d'"' -f2 || true)
+  if [ -z "$sig" ]; then
+    echo "Error: no Sparkle edSignature in sign_update output: $sign_output" >&2
+    exit 1
   fi
   python3 "{{root}}/scripts/update-appcast.py" "{{version}}" "{{build_number}}" "{{app_name}}" "$zip_path" "{{root}}/docs/appcast.xml" "$sig"
+
+  # 6. Create GitHub release (draft), upload the zip, bump the Homebrew cask.
+  just --justfile "{{justfile()}}" create-release
+  just --justfile "{{justfile()}}" upload-release
+  just --justfile "{{justfile()}}" update-cask
+
+# Create a GitHub draft release for the current version if it doesn't exist.
+create-release:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  notes_path="{{root}}/releases/{{version}}.html"
+  if gh release view "v{{version}}" &>/dev/null; then
+    echo "Release v{{version}} already exists"
+    exit 0
+  fi
+  if [ -f "$notes_path" ]; then
+    gh release create "v{{version}}" --draft --title "v{{version}}" --notes-file "$notes_path"
+  else
+    echo "Warning: no release notes found at $notes_path; creating draft with fallback notes." >&2
+    gh release create "v{{version}}" --draft --title "v{{version}}" --notes "Release {{version}}"
+  fi
+
+# Upload the release zip to the GitHub release.
+upload-release:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  zip_path="{{release_dir}}/{{app_name}}-{{version}}.zip"
+  if [ ! -f "$zip_path" ]; then
+    echo "Zip file not found at $zip_path. Run 'just shell::release' first." >&2
+    exit 1
+  fi
+  echo "Uploading $zip_path to release v{{version}}"
+  gh release upload "v{{version}}" "$zip_path" --clobber
+
+# Update the Homebrew cask at ../tap/Casks/jayjay.rb with the current version and SHA.
+update-cask:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  zip_path="{{release_dir}}/{{app_name}}-{{version}}.zip"
+  if [ ! -f "$zip_path" ]; then
+    echo "Expected archive at $zip_path. Run 'just shell::release' first." >&2
+    exit 1
+  fi
+  cask_path="{{root}}/../tap/Casks/jayjay.rb"
+  if [ ! -f "$cask_path" ]; then
+    echo "Cask not found at $cask_path — skipping." >&2
+    exit 0
+  fi
+  sha256=$(shasum -a 256 "$zip_path" | cut -d' ' -f1)
+  sed -i '' \
+    -e 's/version "[^"]*"/version "{{version}},{{build_number}}"/' \
+    -e "s/sha256 \"[^\"]*\"/sha256 \"$sha256\"/" \
+    "$cask_path"
+  echo "Updated $cask_path with version {{version}},{{build_number}} sha256 $sha256"
 
 release-dry-run: ffi-release
   # 1. Build Release (ad-hoc signed)

--- a/shell/justfile
+++ b/shell/justfile
@@ -24,8 +24,8 @@ signing_identity := "Developer ID Application: Tao Xu (V28VJH6B6S)"
 team_id := "V28VJH6B6S"
 bundle_id := "dev.hewig.jayjay"
 app_name := "JayJay"
-version := "0.2.14"
-build_number := "18"
+version := "0.2.15"
+build_number := "19"
 release_dir := root / "build" / "release"
 
 default: list
@@ -145,6 +145,7 @@ ui-test-setup:
     echo "wip 2" > wip2.txt
   )
   cp -R "$root/simple" "$root/simple-newchange"
+  cp -R "$root/simple" "$root/simple-commit"
 
   # Conflict: @ is a rebased change that conflicts with main on file.txt
   jj git init --colocate "$root/conflict"
@@ -202,146 +203,6 @@ clean:
   rm -f "{{project}}/Resources/app.icon/Assets/jaybird.svg"
   find "{{root}}" -name ".DS_Store" -delete
 
-release: ffi-release
-  #!/usr/bin/env bash
-  set -euo pipefail
-  signing_identity="${DEVELOPER_ID_APPLICATION:-{{signing_identity}}}"
-  notary_profile="${NOTARY_PROFILE:-notarytool}"
-  # 1. Build Release
-  xcodegen --spec "{{project}}/project.yml" --project "{{project}}"
-  xcodebuild \
-    -project "{{project}}/JayJay.xcodeproj" \
-    -scheme JayJay \
-    -configuration Release \
-    -sdk macosx \
-    -derivedDataPath "{{derived_data}}" \
-    ARCHS=arm64 \
-    ONLY_ACTIVE_ARCH=NO \
-    build | xcbeautify
-  # 1b. Bundle CLI binary
-  app_path="{{derived_data}}/Build/Products/Release/{{app_name}}.app"
-  cargo build -p jayjay-cli --release
-  cp "{{target_dir}}/release/jayjay" "$app_path/Contents/MacOS/jayjay-cli"
-  # 2. Sign with Developer ID (deep — includes Sparkle framework binaries)
-  echo "Signing with ${signing_identity}..."
-  find "$app_path" -type f \( -name "*.dylib" -o -perm +111 \) -not -name "*.swift*" | while read binary; do
-    codesign --force --timestamp --options runtime --sign "${signing_identity}" "$binary" 2>/dev/null || true
-  done
-  find "$app_path" -name "*.xpc" -o -name "*.app" -o -name "*.framework" | sort -r | while read bundle; do
-    codesign --force --timestamp --options runtime --sign "${signing_identity}" "$bundle"
-  done
-  codesign --force --timestamp --options runtime --sign "${signing_identity}" "$app_path"
-  codesign --verify --deep --strict --verbose=2 "$app_path"
-  # 3. Notarize
-  mkdir -p "{{release_dir}}"
-  rm -f "{{release_dir}}/{{app_name}}-{{version}}.zip"
-  ditto -c -k --keepParent "{{derived_data}}/Build/Products/Release/{{app_name}}.app" \
-    "{{release_dir}}/{{app_name}}-{{version}}.zip"
-  echo "Submitting for notarization with profile ${notary_profile}..."
-  xcrun notarytool submit "{{release_dir}}/{{app_name}}-{{version}}.zip" \
-    --keychain-profile "${notary_profile}" --wait
-  xcrun stapler staple "{{derived_data}}/Build/Products/Release/{{app_name}}.app"
-  xcrun stapler validate "{{derived_data}}/Build/Products/Release/{{app_name}}.app"
-  # 4. Re-zip stapled app + sha256
-  rm -f "{{release_dir}}/{{app_name}}-{{version}}.zip"
-  ditto -c -k --keepParent "{{derived_data}}/Build/Products/Release/{{app_name}}.app" \
-    "{{release_dir}}/{{app_name}}-{{version}}.zip"
-  echo "Created notarized {{release_dir}}/{{app_name}}-{{version}}.zip"
-  shasum -a 256 "{{release_dir}}/{{app_name}}-{{version}}.zip"
-
-  # 5. Generate Sparkle appcast
-  zip_path="{{release_dir}}/{{app_name}}-{{version}}.zip"
-  sparkle_bin=$(find "{{derived_data}}" -name "sign_update" -type f 2>/dev/null | head -1)
-  if [ -z "$sparkle_bin" ] || [ ! -x "$sparkle_bin" ]; then
-    echo "Could not locate Sparkle sign_update under {{derived_data}}." >&2
-    exit 1
-  fi
-  sign_output=$("$sparkle_bin" "$zip_path" 2>&1) || {
-    echo "Error: Sparkle sign_update failed: $sign_output" >&2
-    exit 1
-  }
-  sig=$(printf '%s' "$sign_output" | grep -o 'sparkle:edSignature="[^"]*"' | cut -d'"' -f2 || true)
-  if [ -z "$sig" ]; then
-    echo "Error: no Sparkle edSignature in sign_update output: $sign_output" >&2
-    exit 1
-  fi
-  python3 "{{root}}/scripts/update-appcast.py" "{{version}}" "{{build_number}}" "{{app_name}}" "$zip_path" "{{root}}/docs/appcast.xml" "$sig"
-
-  # 6. Create GitHub release (draft), upload the zip, bump the Homebrew cask.
-  just --justfile "{{justfile()}}" create-release
-  just --justfile "{{justfile()}}" upload-release
-  just --justfile "{{justfile()}}" update-cask
-
-# Create a GitHub draft release for the current version if it doesn't exist.
-create-release:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  notes_path="{{root}}/releases/{{version}}.html"
-  if gh release view "v{{version}}" &>/dev/null; then
-    echo "Release v{{version}} already exists"
-    exit 0
-  fi
-  if [ -f "$notes_path" ]; then
-    gh release create "v{{version}}" --draft --title "v{{version}}" --notes-file "$notes_path"
-  else
-    echo "Warning: no release notes found at $notes_path; creating draft with fallback notes." >&2
-    gh release create "v{{version}}" --draft --title "v{{version}}" --notes "Release {{version}}"
-  fi
-
-# Upload the release zip to the GitHub release.
-upload-release:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  zip_path="{{release_dir}}/{{app_name}}-{{version}}.zip"
-  if [ ! -f "$zip_path" ]; then
-    echo "Zip file not found at $zip_path. Run 'just shell::release' first." >&2
-    exit 1
-  fi
-  echo "Uploading $zip_path to release v{{version}}"
-  gh release upload "v{{version}}" "$zip_path" --clobber
-
-# Update the Homebrew cask at ../tap/Casks/jayjay.rb with the current version and SHA.
-update-cask:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  zip_path="{{release_dir}}/{{app_name}}-{{version}}.zip"
-  if [ ! -f "$zip_path" ]; then
-    echo "Expected archive at $zip_path. Run 'just shell::release' first." >&2
-    exit 1
-  fi
-  cask_path="{{root}}/../tap/Casks/jayjay.rb"
-  if [ ! -f "$cask_path" ]; then
-    echo "Cask not found at $cask_path — skipping." >&2
-    exit 0
-  fi
-  sha256=$(shasum -a 256 "$zip_path" | cut -d' ' -f1)
-  sed -i '' \
-    -e 's/version "[^"]*"/version "{{version}},{{build_number}}"/' \
-    -e "s/sha256 \"[^\"]*\"/sha256 \"$sha256\"/" \
-    "$cask_path"
-  echo "Updated $cask_path with version {{version}},{{build_number}} sha256 $sha256"
-
-release-dry-run: ffi-release
-  # 1. Build Release (ad-hoc signed)
-  xcodegen --spec "{{project}}/project.yml" --project "{{project}}"
-  xcodebuild \
-    -project "{{project}}/JayJay.xcodeproj" \
-    -scheme JayJay \
-    -configuration Release \
-    -sdk macosx \
-    -derivedDataPath "{{derived_data}}" \
-    ARCHS=arm64 \
-    ONLY_ACTIVE_ARCH=NO \
-    build | xcbeautify
-  # 2. Create release directory
-  mkdir -p "{{release_dir}}"
-  rm -rf "{{release_dir}}/{{app_name}}.app"
-  cp -R "{{derived_data}}/Build/Products/Release/{{app_name}}.app" "{{release_dir}}/"
-  codesign --force --sign - "{{release_dir}}/{{app_name}}.app"
-  # 3. Create zip + sha256 (no notarization)
-  cd "{{release_dir}}" && ditto -c -k --keepParent "{{app_name}}.app" "{{app_name}}-{{version}}.zip"
-  shasum -a 256 "{{release_dir}}/{{app_name}}-{{version}}.zip" | cut -d' ' -f1 > "{{release_dir}}/{{app_name}}-{{version}}.zip.sha256"
-  @echo "Dry run release: {{release_dir}}/{{app_name}}-{{version}}.zip"
-  @cat "{{release_dir}}/{{app_name}}-{{version}}.zip.sha256"
+import "release.just"
 
 build-apple: ffi-debug

--- a/shell/mac/Sources/JayJay/App/Watcher/RepoFSWatcher.swift
+++ b/shell/mac/Sources/JayJay/App/Watcher/RepoFSWatcher.swift
@@ -8,20 +8,21 @@ final class RepoFSWatcher {
     private var lastOpFired: Date = .distantPast
     private var lastWCFired: Date = .distantPast
     let repoPath: String
-    private let ignoredPrefixes: [String]
 
     let onOpChange: @Sendable () -> Void
     let onWorkingCopyChange: @Sendable () -> Void
+    let isRelevantWorkingCopyChange: @Sendable ([String]) -> Bool
 
     init(
         repoPath: String,
         onChange: @escaping @Sendable () -> Void,
-        onWorkingCopyChange: @escaping @Sendable () -> Void = {}
+        onWorkingCopyChange: @escaping @Sendable () -> Void = {},
+        isRelevantWorkingCopyChange: @escaping @Sendable ([String]) -> Bool = { _ in true }
     ) {
         self.repoPath = repoPath
         onOpChange = onChange
         self.onWorkingCopyChange = onWorkingCopyChange
-        ignoredPrefixes = Self.loadIgnoredPrefixes(repoPath: repoPath)
+        self.isRelevantWorkingCopyChange = isRelevantWorkingCopyChange
 
         // 1. Watch jj op_heads (triggers auto-refresh)
         let opHeads = (repoPath as NSString).appendingPathComponent(".jj/repo/op_heads/heads")
@@ -46,25 +47,6 @@ final class RepoFSWatcher {
 
         // 2. Watch working copy
         startWCWatch()
-    }
-
-    /// Parse .gitignore for directory prefixes to ignore, plus always .jj/ .git/
-    private static func loadIgnoredPrefixes(repoPath: String) -> [String] {
-        var prefixes = [".jj/", ".git/", ".DS_Store"]
-        let gitignorePath = (repoPath as NSString).appendingPathComponent(".gitignore")
-        if let contents = try? String(contentsOfFile: gitignorePath, encoding: .utf8) {
-            for line in contents.components(separatedBy: .newlines) {
-                let trimmed = line.trimmingCharacters(in: .whitespaces)
-                if trimmed.isEmpty || trimmed.hasPrefix("#") { continue }
-                // "target/" or "build/" style patterns → use as prefix
-                let clean = trimmed.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-                if !clean.isEmpty {
-                    prefixes.append(clean + "/")
-                    prefixes.append(clean) // also match the dir name itself
-                }
-            }
-        }
-        return prefixes
     }
 
     private func startWCWatch() {
@@ -97,12 +79,7 @@ final class RepoFSWatcher {
         let watcher = Unmanaged<RepoFSWatcher>.fromOpaque(info).takeUnretainedValue()
         guard let paths = unsafeBitCast(eventPaths, to: NSArray.self) as? [String] else { return }
 
-        let prefix = watcher.repoPath.hasSuffix("/") ? watcher.repoPath : watcher.repoPath + "/"
-        let hasRelevant = paths.contains { path in
-            let relative = path.hasPrefix(prefix) ? String(path.dropFirst(prefix.count)) : path
-            return !watcher.ignoredPrefixes.contains(where: { relative.hasPrefix($0) })
-        }
-        guard hasRelevant else { return }
+        guard watcher.isRelevantWorkingCopyChange(paths) else { return }
 
         let now = Date()
         guard now.timeIntervalSince(watcher.lastWCFired) > 2.0 else { return }

--- a/shell/mac/Sources/JayJay/Repo/CommitBox.swift
+++ b/shell/mac/Sources/JayJay/Repo/CommitBox.swift
@@ -30,6 +30,7 @@ struct CommitBox: View {
                         .stroke(Color.primary.opacity(0.1), lineWidth: 1)
                 )
                 .frame(minHeight: 60, maxHeight: 120)
+                .accessibilityIdentifier(AID.CommitBox.draft)
 
             HStack(spacing: 8) {
                 Spacer()
@@ -59,9 +60,7 @@ struct CommitBox: View {
                         let msg = trimmedDraft
                         isCommitting = true
                         Task {
-                            if await onCommit(msg) {
-                                draft = ""
-                            }
+                            _ = await onCommit(msg)
                             isCommitting = false
                         }
                     }
@@ -78,6 +77,7 @@ struct CommitBox: View {
                 .controlSize(.small)
                 .disabled(trimmedDraft.isEmpty || isCommitting)
                 .help("Describe + start new change (jj commit)")
+                .accessibilityIdentifier(AID.CommitBox.commit)
             }
         }
         .padding(12)

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+ChangeActions.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+ChangeActions.swift
@@ -36,6 +36,7 @@ extension RepoViewModel {
             viewModel.reviewStore.clearAll()
             viewModel.submoduleAttentionItems = []
             viewModel.pendingCommitMessage = nil
+            viewModel.commitDraft = ""
         }, {
             try $0.jjCommit(message: message)
         })
@@ -64,6 +65,7 @@ extension RepoViewModel {
             reviewStore.clearAll()
             submoduleAttentionItems = []
             pendingCommitMessage = nil
+            commitDraft = ""
             info = infoMessage
             refresh(selecting: "@")
             isLoading = false

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
@@ -55,7 +55,10 @@ final class RepoViewModel: ChangeActions, DAGActions, BookmarkActions {
         fsWatcher = RepoFSWatcher(
             repoPath: path,
             onChange: { [weak self] in self?.refresh(isAutoTriggered: true) },
-            onWorkingCopyChange: { [weak self] in self?.handleWorkingCopyChange() }
+            onWorkingCopyChange: { [weak self] in self?.handleWorkingCopyChange() },
+            isRelevantWorkingCopyChange: { [repo] paths in
+                (try? repo.hasUnignoredWorkingCopyPaths(paths: paths)) ?? true
+            }
         )
     }
 

--- a/shell/mac/Sources/JayJay/Shared/AccessibilityIdentifiers.swift
+++ b/shell/mac/Sources/JayJay/Shared/AccessibilityIdentifiers.swift
@@ -21,6 +21,11 @@ enum AID {
         static let section = "diff.section"
     }
 
+    enum CommitBox {
+        static let draft = "commitBox.draft"
+        static let commit = "commitBox.commit"
+    }
+
     enum Conflict {
         static func useOurs(_ path: String) -> String {
             "conflict.useOurs.\(path)"

--- a/shell/mac/Tests/JayJayUITests/Scenes/CommitBoxScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/CommitBoxScene.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+final class CommitBoxScene: SceneBase {
+    // Dedicated fixture: this scene runs `jj commit`, which mutates the repo.
+    override class var fixtureName: String { "simple-commit" }
+
+    func testCommitClearsDraft() throws {
+        let app = try XCTUnwrap(app)
+        let rows = dagRows(of: app)
+        XCTAssertTrue(rows.element(boundBy: 0).waitForExistence(timeout: 10), "DAG never populated")
+
+        let originalTopId = rows.element(boundBy: 0).identifier
+
+        let editor = app.textViews[AID.CommitBox.draft]
+        XCTAssertTrue(editor.waitForExistence(timeout: 5), "CommitBox text editor not found")
+        editor.click()
+        editor.typeText("regression: clear draft after commit")
+
+        let commitButton = app.buttons[AID.CommitBox.commit]
+        XCTAssertTrue(commitButton.waitForExistence(timeout: 3), "Commit button not found")
+        commitButton.click()
+
+        let topRowChanged = NSPredicate { _, _ in
+            let current = rows.element(boundBy: 0).identifier
+            return !current.isEmpty && current != originalTopId
+        }
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [XCTNSPredicateExpectation(predicate: topRowChanged, object: nil)], timeout: 10),
+            .completed,
+            "@ did not advance after commit"
+        )
+
+        let draftCleared = NSPredicate { _, _ in
+            (editor.value as? String ?? "").isEmpty
+        }
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [XCTNSPredicateExpectation(predicate: draftCleared, object: nil)], timeout: 5),
+            .completed,
+            "CommitBox draft was not cleared after commit"
+        )
+    }
+}

--- a/shell/mac/project.yml
+++ b/shell/mac/project.yml
@@ -59,8 +59,8 @@ targets:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: app
         PRODUCT_BUNDLE_IDENTIFIER: dev.hewig.jayjay
-        MARKETING_VERSION: "0.2.14"
-        CURRENT_PROJECT_VERSION: 18
+        MARKETING_VERSION: "0.2.15"
+        CURRENT_PROJECT_VERSION: 19
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_CFBundleDisplayName: JayJay
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.developer-tools

--- a/shell/release.just
+++ b/shell/release.just
@@ -1,0 +1,152 @@
+# Release recipes — imported by ./justfile.
+# Workspace variables (version, app_name, derived_data, release_dir, signing_identity, ...)
+# are inherited from the importing justfile.
+
+release: ffi-release
+  #!/usr/bin/env bash
+  set -euo pipefail
+  signing_identity="${DEVELOPER_ID_APPLICATION:-{{signing_identity}}}"
+  notary_profile="${NOTARY_PROFILE:-notarytool}"
+  # 1. Build Release
+  xcodegen --spec "{{project}}/project.yml" --project "{{project}}"
+  xcodebuild \
+    -project "{{project}}/JayJay.xcodeproj" \
+    -scheme JayJay \
+    -configuration Release \
+    -sdk macosx \
+    -derivedDataPath "{{derived_data}}" \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    build | xcbeautify
+  # 1b. Bundle CLI binary
+  app_path="{{derived_data}}/Build/Products/Release/{{app_name}}.app"
+  cargo build -p jayjay-cli --release
+  cp "{{target_dir}}/release/jayjay" "$app_path/Contents/MacOS/jayjay-cli"
+  # 2. Sign with Developer ID (deep — includes Sparkle framework binaries)
+  echo "Signing with ${signing_identity}..."
+  find "$app_path" -type f \( -name "*.dylib" -o -perm +111 \) -not -name "*.swift*" | while read binary; do
+    codesign --force --timestamp --options runtime --sign "${signing_identity}" "$binary" 2>/dev/null || true
+  done
+  find "$app_path" -name "*.xpc" -o -name "*.app" -o -name "*.framework" | sort -r | while read bundle; do
+    codesign --force --timestamp --options runtime --sign "${signing_identity}" "$bundle"
+  done
+  codesign --force --timestamp --options runtime --sign "${signing_identity}" "$app_path"
+  codesign --verify --deep --strict --verbose=2 "$app_path"
+  # 3. Notarize
+  mkdir -p "{{release_dir}}"
+  rm -f "{{release_dir}}/{{app_name}}-{{version}}.zip"
+  ditto -c -k --keepParent "{{derived_data}}/Build/Products/Release/{{app_name}}.app" \
+    "{{release_dir}}/{{app_name}}-{{version}}.zip"
+  echo "Submitting for notarization with profile ${notary_profile}..."
+  xcrun notarytool submit "{{release_dir}}/{{app_name}}-{{version}}.zip" \
+    --keychain-profile "${notary_profile}" --wait
+  xcrun stapler staple "{{derived_data}}/Build/Products/Release/{{app_name}}.app"
+  xcrun stapler validate "{{derived_data}}/Build/Products/Release/{{app_name}}.app"
+  # 4. Re-zip stapled app + sha256
+  rm -f "{{release_dir}}/{{app_name}}-{{version}}.zip"
+  ditto -c -k --keepParent "{{derived_data}}/Build/Products/Release/{{app_name}}.app" \
+    "{{release_dir}}/{{app_name}}-{{version}}.zip"
+  echo "Created notarized {{release_dir}}/{{app_name}}-{{version}}.zip"
+  shasum -a 256 "{{release_dir}}/{{app_name}}-{{version}}.zip"
+
+  # 5. Generate Sparkle appcast
+  zip_path="{{release_dir}}/{{app_name}}-{{version}}.zip"
+  sparkle_bin=$(find "{{derived_data}}" -name "sign_update" -type f 2>/dev/null | head -1)
+  if [ -z "$sparkle_bin" ] || [ ! -x "$sparkle_bin" ]; then
+    echo "Could not locate Sparkle sign_update under {{derived_data}}." >&2
+    exit 1
+  fi
+  sign_output=$("$sparkle_bin" "$zip_path" 2>&1) || {
+    echo "Error: Sparkle sign_update failed: $sign_output" >&2
+    exit 1
+  }
+  sig=$(printf '%s' "$sign_output" | grep -o 'sparkle:edSignature="[^"]*"' | cut -d'"' -f2 || true)
+  if [ -z "$sig" ]; then
+    echo "Error: no Sparkle edSignature in sign_update output: $sign_output" >&2
+    exit 1
+  fi
+  python3 "{{root}}/scripts/update-appcast.py" "{{version}}" "{{build_number}}" "{{app_name}}" "$zip_path" "{{root}}/docs/appcast.xml" "$sig"
+
+  echo
+  echo "Local artifacts ready. After committing, pushing main, and pushing the v{{version}} tag,"
+  echo "run 'just shell::publish' to create the GitHub release, upload the zip, and update the Homebrew cask."
+
+# Publish the already-built release: create a GitHub draft, upload the zip, and bump the Homebrew cask.
+# Run AFTER pushing the v<version> git tag — `--verify-tag` will fail otherwise.
+publish:
+  just --justfile "{{justfile()}}" create-release
+  just --justfile "{{justfile()}}" upload-release
+  just --justfile "{{justfile()}}" update-cask
+
+# Create a GitHub draft release for the current version if it doesn't exist.
+# Requires the v<version> tag to be pushed first; `--verify-tag` aborts otherwise.
+create-release:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  notes_path="{{root}}/releases/{{version}}.html"
+  if gh release view "v{{version}}" &>/dev/null; then
+    echo "Release v{{version}} already exists"
+    exit 0
+  fi
+  if [ -f "$notes_path" ]; then
+    gh release create "v{{version}}" --draft --verify-tag --title "v{{version}}" --notes-file "$notes_path"
+  else
+    echo "Warning: no release notes found at $notes_path; creating draft with fallback notes." >&2
+    gh release create "v{{version}}" --draft --verify-tag --title "v{{version}}" --notes "Release {{version}}"
+  fi
+
+# Upload the release zip to the GitHub release.
+upload-release:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  zip_path="{{release_dir}}/{{app_name}}-{{version}}.zip"
+  if [ ! -f "$zip_path" ]; then
+    echo "Zip file not found at $zip_path. Run 'just shell::release' first." >&2
+    exit 1
+  fi
+  echo "Uploading $zip_path to release v{{version}}"
+  gh release upload "v{{version}}" "$zip_path" --clobber
+
+# Update the Homebrew cask at ../tap/Casks/jayjay.rb with the current version and SHA.
+update-cask:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  zip_path="{{release_dir}}/{{app_name}}-{{version}}.zip"
+  if [ ! -f "$zip_path" ]; then
+    echo "Expected archive at $zip_path. Run 'just shell::release' first." >&2
+    exit 1
+  fi
+  cask_path="{{root}}/../tap/Casks/jayjay.rb"
+  if [ ! -f "$cask_path" ]; then
+    echo "Cask not found at $cask_path — skipping." >&2
+    exit 0
+  fi
+  sha256=$(shasum -a 256 "$zip_path" | cut -d' ' -f1)
+  sed -i '' \
+    -e 's/version "[^"]*"/version "{{version}},{{build_number}}"/' \
+    -e "s/sha256 \"[^\"]*\"/sha256 \"$sha256\"/" \
+    "$cask_path"
+  echo "Updated $cask_path with version {{version}},{{build_number}} sha256 $sha256"
+
+release-dry-run: ffi-release
+  # 1. Build Release (ad-hoc signed)
+  xcodegen --spec "{{project}}/project.yml" --project "{{project}}"
+  xcodebuild \
+    -project "{{project}}/JayJay.xcodeproj" \
+    -scheme JayJay \
+    -configuration Release \
+    -sdk macosx \
+    -derivedDataPath "{{derived_data}}" \
+    ARCHS=arm64 \
+    ONLY_ACTIVE_ARCH=NO \
+    build | xcbeautify
+  # 2. Create release directory
+  mkdir -p "{{release_dir}}"
+  rm -rf "{{release_dir}}/{{app_name}}.app"
+  cp -R "{{derived_data}}/Build/Products/Release/{{app_name}}.app" "{{release_dir}}/"
+  codesign --force --sign - "{{release_dir}}/{{app_name}}.app"
+  # 3. Create zip + sha256 (no notarization)
+  cd "{{release_dir}}" && ditto -c -k --keepParent "{{app_name}}.app" "{{app_name}}-{{version}}.zip"
+  shasum -a 256 "{{release_dir}}/{{app_name}}-{{version}}.zip" | cut -d' ' -f1 > "{{release_dir}}/{{app_name}}-{{version}}.zip.sha256"
+  @echo "Dry run release: {{release_dir}}/{{app_name}}-{{version}}.zip"
+  @cat "{{release_dir}}/{{app_name}}-{{version}}.zip.sha256"


### PR DESCRIPTION
## Summary

- Respect Git ignore sources when JayJay snapshots the working copy: local `.gitignore`, Git `core.excludesFile`, default `$XDG_CONFIG_HOME/git/ignore`, and `.git/info/exclude`.
- Route the macOS filesystem watcher through the Rust core ignore matcher so ignored untracked files do not show a stale update indicator.
- Keep tracked files visible to the watcher even when they match ignore rules, since edits to tracked files still need refresh.
- Consolidate environment path/binary lookup helpers and rename the commit-message AI helper away from `git_ai`.
- Include release helper cleanup: make appcast replacement more robust, fail release when Sparkle signing fails, create/upload draft GitHub releases, and update the Homebrew cask with `version,build` plus SHA.

## Root Cause

`refresh_working_copy()` passed an empty base ignore file to jj's snapshot logic, so jj saw globally ignored untracked files like `.claude/*` as new files. Separately, the Swift watcher used a hand-rolled `.gitignore` prefix parser, so it could still show the update indicator for ignored files even when refresh produced no visible update.

Closes #18

## Validation

- `cargo test -p jayjay-core --test real_jj_repo`
- `cargo clippy --workspace`
- `python3 -m py_compile scripts/update-appcast.py`
- `just --summary`
- `just test`
- `just build`