### PR TITLE
Add Solidity, SQL, XML, Zig, Nix, Make highlighting; bump 0.2.14 (build 18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jayjay-cli"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "clap",
  "urlencoding",
@@ -1820,14 +1820,20 @@ dependencies = [
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-json",
+ "tree-sitter-make",
  "tree-sitter-md",
+ "tree-sitter-nix",
  "tree-sitter-python",
  "tree-sitter-ruby",
  "tree-sitter-rust",
+ "tree-sitter-sequel",
+ "tree-sitter-solidity",
  "tree-sitter-swift",
  "tree-sitter-toml-ng",
  "tree-sitter-typescript",
+ "tree-sitter-xml",
  "tree-sitter-yaml",
+ "tree-sitter-zig",
 ]
 
 [[package]]
@@ -2899,10 +2905,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
+name = "tree-sitter-make"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5998dc7cbcbdab19fae8aefef982bf2d6544513d8d2e69cc44aec4c63810104"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-md"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-nix"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4952a9733f3a98f6683a0ccd1035d84ab7a52f7e84eeed58548d86765ad92de3"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -2939,6 +2965,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-sequel"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d198ad3c319c02e43c21efa1ec796b837afcb96ffaef1a40c1978fbdcec7d17"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-solidity"
+version = "1.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eacf8875b70879f0cb670c60b233ad0b68752d9e1474e6c3ef168eea8a90b25"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-swift"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,10 +3015,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-xml"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e670041f591d994f54d597ddcd8f4ebc930e282c4c76a42268743b71f0c8b6b3"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-yaml"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-zig"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab11fc124851b0db4dd5e55983bbd9631192e93238389dcd44521715e5d53e28"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,12 @@ tree-sitter-java = "0.23"
 tree-sitter-yaml = "0.7"
 tree-sitter-md = "0.5"
 tree-sitter-swift = "0.7"
+tree-sitter-solidity = "1.2"
+tree-sitter-sequel = "0.3"
+tree-sitter-xml = "0.7"
+tree-sitter-zig = "1.1"
+tree-sitter-nix = "0.3"
+tree-sitter-make = "1.1"
 
 [profile.dev]
 debug = "line-tables-only"

--- a/crates/jayjay-cli/Cargo.toml
+++ b/crates/jayjay-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jayjay-cli"
-version = "0.2.13"
+version = "0.2.14"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/jj-diff/Cargo.toml
+++ b/crates/jj-diff/Cargo.toml
@@ -29,3 +29,9 @@ tree-sitter-toml-ng = { workspace = true }
 tree-sitter-md = { workspace = true }
 tree-sitter-yaml = { workspace = true }
 tree-sitter-swift = { workspace = true }
+tree-sitter-solidity = { workspace = true }
+tree-sitter-sequel = { workspace = true }
+tree-sitter-xml = { workspace = true }
+tree-sitter-zig = { workspace = true }
+tree-sitter-nix = { workspace = true }
+tree-sitter-make = { workspace = true }

--- a/crates/jj-diff/src/syntax.rs
+++ b/crates/jj-diff/src/syntax.rs
@@ -164,6 +164,24 @@ fn make_config(language: &str) -> Option<HighlightConfiguration> {
             tree_sitter_swift::LANGUAGE,
             tree_sitter_swift::HIGHLIGHTS_QUERY,
         ),
+        "solidity" => (
+            tree_sitter_solidity::LANGUAGE,
+            tree_sitter_solidity::HIGHLIGHT_QUERY,
+        ),
+        "sql" => (
+            tree_sitter_sequel::LANGUAGE,
+            tree_sitter_sequel::HIGHLIGHTS_QUERY,
+        ),
+        "xml" => (
+            tree_sitter_xml::LANGUAGE_XML,
+            tree_sitter_xml::XML_HIGHLIGHT_QUERY,
+        ),
+        "zig" => (tree_sitter_zig::LANGUAGE, tree_sitter_zig::HIGHLIGHTS_QUERY),
+        "nix" => (tree_sitter_nix::LANGUAGE, tree_sitter_nix::HIGHLIGHTS_QUERY),
+        "make" => (
+            tree_sitter_make::LANGUAGE,
+            tree_sitter_make::HIGHLIGHTS_QUERY,
+        ),
         _ => return None,
     };
 
@@ -174,6 +192,10 @@ fn make_config(language: &str) -> Option<HighlightConfiguration> {
 }
 
 pub fn language_for_path(path: &str) -> &'static str {
+    let basename = path.rsplit('/').next().unwrap_or(path);
+    if matches!(basename, "Makefile" | "makefile" | "GNUmakefile") {
+        return "make";
+    }
     let ext = path.rsplit('.').next().unwrap_or("");
     match ext {
         "rs" => "rust",
@@ -184,7 +206,6 @@ pub fn language_for_path(path: &str) -> &'static str {
         "py" => "python",
         "go" => "go",
         "java" => "java",
-        "kt" | "kts" => "kotlin",
         "c" | "h" => "c",
         "cpp" | "cc" | "cxx" | "hpp" => "cpp",
         "rb" => "ruby",
@@ -197,6 +218,10 @@ pub fn language_for_path(path: &str) -> &'static str {
         "md" | "markdown" => "markdown",
         "sql" => "sql",
         "xml" => "xml",
+        "sol" => "solidity",
+        "zig" => "zig",
+        "nix" => "nix",
+        "mk" => "make",
         _ => "plaintext",
     }
 }

--- a/releases/0.2.14.html
+++ b/releases/0.2.14.html
@@ -1,0 +1,5 @@
+<h3>Syntax highlighting</h3>
+<ul>
+    <li>Added syntax highlighting for Solidity (<code>.sol</code>), SQL (<code>.sql</code>), XML (<code>.xml</code>), Zig (<code>.zig</code>), Nix (<code>.nix</code>), and Make (<code>Makefile</code>, <code>.mk</code>) — previously these rendered as plain text in diffs.</li>
+    <li>Removed the unwired <code>.kt</code>/<code>.kts</code> mapping that silently fell back to plain text; Kotlin highlighting will return when the maintained grammar ships highlight queries upstream.</li>
+</ul>

--- a/shell/justfile
+++ b/shell/justfile
@@ -24,8 +24,8 @@ signing_identity := "Developer ID Application: Tao Xu (V28VJH6B6S)"
 team_id := "V28VJH6B6S"
 bundle_id := "dev.hewig.jayjay"
 app_name := "JayJay"
-version := "0.2.13"
-build_number := "17"
+version := "0.2.14"
+build_number := "18"
 release_dir := root / "build" / "release"
 
 default: list

--- a/shell/mac/project.yml
+++ b/shell/mac/project.yml
@@ -59,8 +59,8 @@ targets:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: app
         PRODUCT_BUNDLE_IDENTIFIER: dev.hewig.jayjay
-        MARKETING_VERSION: "0.2.13"
-        CURRENT_PROJECT_VERSION: 17
+        MARKETING_VERSION: "0.2.14"
+        CURRENT_PROJECT_VERSION: 18
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_CFBundleDisplayName: JayJay
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.developer-tools


### PR DESCRIPTION
## Summary

- Add tree-sitter grammars for Solidity, SQL, XML, Zig, Nix, and Make so those files render with syntax highlighting in the diff viewer.
- Bump version to 0.2.14 (build 18).

## Test plan

- [ ] Open a `.sol`, `.sql`, `.xml`, `.zig`, `.nix`, and `Makefile` change and confirm highlighting renders.
- [ ] Verify version surfaces correctly in About / appcast.