### PR TITLE
release: 0.2.18 (build 22)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jayjay-cli"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "clap",
  "urlencoding",

--- a/crates/jayjay-cli/Cargo.toml
+++ b/crates/jayjay-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jayjay-cli"
-version = "0.2.17"
+version = "0.2.18"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/jayjay-core/src/dag.rs
+++ b/crates/jayjay-core/src/dag.rs
@@ -1,0 +1,195 @@
+//! DAG lane-assignment for the jj log graph.
+//!
+//! Mirrors `shell/mac/Sources/JayJay/Repo/DAGLayout.swift`. Pure logic — both
+//! the SwiftUI shell (via uniffi) and the GPUI shell can render against the
+//! same lane assignments.
+
+use std::collections::HashMap;
+
+use crate::types::{EdgeType, GraphEntry};
+
+pub const LANE_WIDTH: f32 = 16.0;
+pub const NODE_RADIUS: f32 = 4.0;
+pub const ROW_LEADING_PADDING: f32 = 4.0;
+pub const ROW_VERTICAL_PADDING: f32 = 8.0;
+pub const NODE_CENTER_Y: f32 = 12.0;
+
+/// Pre-computed lane assignment for a sequence of `GraphEntry` rows.
+#[derive(Debug, Clone, Default)]
+pub struct DagLayout {
+    /// Lane index for each commit_id (hex).
+    pub lanes: HashMap<String, usize>,
+    /// Total active lanes at each row index.
+    pub active_lanes_per_row: Vec<usize>,
+    /// Lane indices that continue through each row.
+    pub active_lane_indices_per_row: Vec<Vec<usize>>,
+}
+
+impl DagLayout {
+    pub fn compute(entries: &[GraphEntry]) -> Self {
+        let mut lanes: HashMap<String, usize> = HashMap::new();
+        let mut active: Vec<Option<String>> = Vec::new();
+        let mut active_counts: Vec<usize> = Vec::with_capacity(entries.len());
+        let mut active_indices: Vec<Vec<usize>> = Vec::with_capacity(entries.len());
+
+        for entry in entries {
+            let cid = &entry.change.commit_id;
+
+            if !lanes.contains_key(cid) {
+                let lane = match active
+                    .iter()
+                    .position(|c| c.as_deref() == Some(cid.as_str()))
+                {
+                    Some(existing) => existing,
+                    None => assign_lane(cid, &mut active, None),
+                };
+                lanes.insert(cid.clone(), lane);
+            }
+
+            let my_lane = lanes[cid];
+            if my_lane < active.len() {
+                active[my_lane] = None;
+            }
+
+            for edge in &entry.edges {
+                if edge.edge_type == EdgeType::Missing {
+                    continue;
+                }
+                if !lanes.contains_key(&edge.target) {
+                    let lane = assign_lane(&edge.target, &mut active, Some(my_lane));
+                    lanes.insert(edge.target.clone(), lane);
+                }
+            }
+
+            active_counts.push(active.len());
+            let row_active: Vec<usize> = active
+                .iter()
+                .enumerate()
+                .filter_map(|(i, c)| c.as_ref().map(|_| i))
+                .collect();
+            active_indices.push(row_active);
+        }
+
+        DagLayout {
+            lanes,
+            active_lanes_per_row: active_counts,
+            active_lane_indices_per_row: active_indices,
+        }
+    }
+
+    pub fn lane(&self, commit_id: &str) -> usize {
+        self.lanes.get(commit_id).copied().unwrap_or(0)
+    }
+
+    pub fn max_lanes(&self) -> usize {
+        self.active_lanes_per_row.iter().copied().max().unwrap_or(1)
+    }
+
+    pub fn active_lane_indices(&self, row: usize) -> &[usize] {
+        self.active_lane_indices_per_row
+            .get(row)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+}
+
+fn assign_lane(
+    commit_id: &str,
+    active: &mut Vec<Option<String>>,
+    preferring: Option<usize>,
+) -> usize {
+    if let Some(preferred) = preferring
+        && preferred < active.len()
+        && active[preferred].is_none()
+    {
+        active[preferred] = Some(commit_id.to_owned());
+        return preferred;
+    }
+    if let Some(free) = active.iter().position(|c| c.is_none()) {
+        active[free] = Some(commit_id.to_owned());
+        return free;
+    }
+    active.push(Some(commit_id.to_owned()));
+    active.len() - 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{ChangeInfo, GraphEdge};
+
+    fn entry(commit_id: &str, parents: &[&str]) -> GraphEntry {
+        GraphEntry {
+            change: ChangeInfo {
+                change_id: format!("change-{commit_id}"),
+                commit_id: commit_id.to_owned(),
+                description: String::new(),
+                author: String::new(),
+                email: String::new(),
+                timestamp_millis: 0,
+                parents: parents.iter().map(|s| (*s).to_owned()).collect(),
+                bookmarks: Vec::new(),
+                is_working_copy: false,
+                has_conflict: false,
+                is_empty: false,
+                is_immutable: false,
+                is_divergent: false,
+            },
+            edges: parents
+                .iter()
+                .map(|p| GraphEdge {
+                    target: (*p).to_owned(),
+                    edge_type: EdgeType::Direct,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn empty_entries() {
+        let layout = DagLayout::compute(&[]);
+        assert!(layout.lanes.is_empty());
+        assert_eq!(layout.max_lanes(), 1);
+    }
+
+    #[test]
+    fn linear_chain_on_lane_zero() {
+        // C -> B -> A, all on lane 0
+        let entries = vec![entry("C", &["B"]), entry("B", &["A"]), entry("A", &[])];
+        let layout = DagLayout::compute(&entries);
+        assert_eq!(layout.lane("C"), 0);
+        assert_eq!(layout.lane("B"), 0);
+        assert_eq!(layout.lane("A"), 0);
+        assert_eq!(layout.max_lanes(), 1);
+    }
+
+    #[test]
+    fn fork_uses_two_lanes() {
+        // D has two parents B and C, both have parent A.
+        // Reverse-topological order: D, B, C, A
+        let entries = vec![
+            entry("D", &["B", "C"]),
+            entry("B", &["A"]),
+            entry("C", &["A"]),
+            entry("A", &[]),
+        ];
+        let layout = DagLayout::compute(&entries);
+        assert_eq!(layout.lane("D"), 0);
+        assert_eq!(layout.lane("B"), 0); // fork's first edge stays on parent's lane
+        assert_eq!(layout.lane("C"), 1); // second edge spawns new lane
+        assert_eq!(layout.lane("A"), 0); // merged back into B's lane
+        assert!(layout.max_lanes() >= 2);
+    }
+
+    #[test]
+    fn missing_edges_dont_assign_lanes() {
+        let mut e = entry("A", &[]);
+        e.edges.push(GraphEdge {
+            target: "missing-parent".to_owned(),
+            edge_type: EdgeType::Missing,
+        });
+        let layout = DagLayout::compute(&[e]);
+        assert!(!layout.lanes.contains_key("missing-parent"));
+        assert_eq!(layout.lane("A"), 0);
+    }
+}

--- a/crates/jayjay-core/src/file_tree.rs
+++ b/crates/jayjay-core/src/file_tree.rs
@@ -50,32 +50,38 @@ impl TreeNode {
         }
     }
 
-    fn flatten(&self, depth: u32, results: &mut Vec<FileTreeEntry>) {
+    fn flatten(&self, depth: u32, parent_path: &str, results: &mut Vec<FileTreeEntry>) {
         // Sort: directories first, then files
         let mut sorted: Vec<&(String, TreeNode)> = self.children.iter().collect();
         sorted.sort_by_key(|(_, n)| n.hunk_index.is_some());
 
         for (key, child) in sorted {
             if let Some(idx) = child.hunk_index {
+                let path = if parent_path.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{parent_path}/{key}")
+                };
                 results.push(FileTreeEntry {
                     name: key.clone(),
-                    path: String::new(), // filled by caller
+                    path,
                     depth,
                     hunk_index: Some(idx),
                 });
             } else {
-                let dir_name = if child.name.is_empty() {
-                    key.clone()
+                let dir_segment = child.name.clone();
+                let dir_path = if parent_path.is_empty() {
+                    dir_segment.clone()
                 } else {
-                    child.name.clone()
+                    format!("{parent_path}/{dir_segment}")
                 };
                 results.push(FileTreeEntry {
-                    name: dir_name,
-                    path: String::new(),
+                    name: dir_segment,
+                    path: dir_path.clone(),
                     depth,
                     hunk_index: None,
                 });
-                child.flatten(depth + 1, results);
+                child.flatten(depth + 1, &dir_path, results);
             }
         }
     }
@@ -92,9 +98,10 @@ pub fn build_file_tree(paths: &[String]) -> Vec<FileTreeEntry> {
     }
     root.collapse();
     let mut results = Vec::new();
-    root.flatten(0, &mut results);
+    let root_prefix = root.name.clone();
+    root.flatten(0, &root_prefix, &mut results);
 
-    // Fill in paths for file entries
+    // File entries point at the original on-disk path.
     for entry in &mut results {
         if let Some(idx) = entry.hunk_index
             && let Some(p) = paths.get(idx as usize)
@@ -199,5 +206,96 @@ mod tests {
         let file_entries: Vec<_> = tree.iter().filter(|e| e.hunk_index.is_some()).collect();
         assert_eq!(dir_entries.len(), 1, "should have 1 directory");
         assert_eq!(file_entries.len(), 3, "should have 3 files");
+    }
+
+    /// Every entry — including directories — has a non-empty, unique `path`.
+    #[test]
+    fn test_directory_paths_are_unique_and_populated() {
+        let tree = build_file_tree(&[
+            "src/diff/line.rs".to_string(),
+            "src/diff/mod.rs".to_string(),
+            "src/repo/log.rs".to_string(),
+            "src/repo/mod.rs".to_string(),
+        ]);
+
+        for entry in &tree {
+            assert!(
+                !entry.path.is_empty(),
+                "entry {:?} has empty path",
+                entry.name
+            );
+        }
+
+        let paths: std::collections::HashSet<&str> = tree.iter().map(|e| e.path.as_str()).collect();
+        assert_eq!(
+            paths.len(),
+            tree.len(),
+            "duplicate paths found in tree: {:?}",
+            tree.iter().map(|e| &e.path).collect::<Vec<_>>()
+        );
+
+        let dirs: Vec<&FileTreeEntry> = tree.iter().filter(|e| e.hunk_index.is_none()).collect();
+        let dir_paths: Vec<&str> = dirs.iter().map(|e| e.path.as_str()).collect();
+        // Directory paths must be the full accumulated path (including any
+        // prefix collapsed into root) so they prefix-match their file children.
+        assert!(
+            dir_paths.contains(&"src/diff"),
+            "missing 'src/diff' dir, got {dir_paths:?}"
+        );
+        assert!(
+            dir_paths.contains(&"src/repo"),
+            "missing 'src/repo' dir, got {dir_paths:?}"
+        );
+        let dir_path: &str = "src/diff";
+        assert!(
+            tree.iter()
+                .any(|e| e.hunk_index.is_some() && e.path.starts_with(&format!("{dir_path}/"))),
+            "files under {dir_path} should have it as a prefix"
+        );
+    }
+
+    /// A realistic tree (~20 files, mixed depths) produces no duplicate paths.
+    #[test]
+    fn test_realistic_tree_no_duplicate_dirs() {
+        let paths: Vec<String> = [
+            "Cargo.lock",
+            "Cargo.toml",
+            "shell/gpui/Cargo.toml",
+            "shell/gpui/src/diff/colors.rs",
+            "shell/gpui/src/diff/diff_view.rs",
+            "shell/gpui/src/diff/file_column.rs",
+            "shell/gpui/src/diff/line.rs",
+            "shell/gpui/src/diff/mod.rs",
+            "shell/gpui/src/fonts.rs",
+            "shell/gpui/src/log_view.rs",
+            "shell/gpui/src/main.rs",
+            "shell/gpui/src/theme.rs",
+            "shell/gpui/src/ui.rs",
+            "shell/gpui/assets/fonts/Phosphor.ttf",
+            "crates/jayjay-core/src/dag.rs",
+            "crates/jayjay-core/src/lib.rs",
+            "crates/jayjay-core/Cargo.toml",
+            "crates/jayjay-uniffi/src/lib.rs",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+
+        let tree = build_file_tree(&paths);
+
+        let paths_set: std::collections::HashSet<&str> =
+            tree.iter().map(|e| e.path.as_str()).collect();
+        assert_eq!(
+            paths_set.len(),
+            tree.len(),
+            "duplicate paths in realistic tree:\n{:#?}",
+            tree.iter()
+                .map(|e| (e.depth, &e.name, &e.path))
+                .collect::<Vec<_>>()
+        );
+
+        for e in &tree {
+            assert!(!e.path.is_empty(), "empty path for {:?}", e.name);
+        }
     }
 }

--- a/crates/jayjay-core/src/lib.rs
+++ b/crates/jayjay-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub use jj_diff as diff;
 pub use jj_diff::syntax;
+pub mod dag;
 pub mod file_tree;
 mod repo;
 mod types;

--- a/crates/jayjay-uniffi/src/dag.rs
+++ b/crates/jayjay-uniffi/src/dag.rs
@@ -1,0 +1,28 @@
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct DagLayoutData {
+    pub lanes: std::collections::HashMap<String, u32>,
+    pub active_lanes_per_row: Vec<u32>,
+    pub active_lane_indices_per_row: Vec<Vec<u32>>,
+}
+
+#[uniffi::export]
+pub fn compute_dag_layout(entries: Vec<jayjay_core::GraphEntry>) -> DagLayoutData {
+    let layout = jayjay_core::dag::DagLayout::compute(&entries);
+    DagLayoutData {
+        lanes: layout
+            .lanes
+            .into_iter()
+            .map(|(k, v)| (k, v as u32))
+            .collect(),
+        active_lanes_per_row: layout
+            .active_lanes_per_row
+            .iter()
+            .map(|&v| v as u32)
+            .collect(),
+        active_lane_indices_per_row: layout
+            .active_lane_indices_per_row
+            .iter()
+            .map(|row| row.iter().map(|&v| v as u32).collect())
+            .collect(),
+    }
+}

--- a/crates/jayjay-uniffi/src/diff.rs
+++ b/crates/jayjay-uniffi/src/diff.rs
@@ -1,0 +1,6 @@
+#[uniffi::export]
+pub fn build_side_by_side_rows(
+    lines: Vec<jayjay_core::diff::DiffLine>,
+) -> Vec<jayjay_core::diff::SideBySideRow> {
+    jayjay_core::diff::build_side_by_side_rows(&lines)
+}

--- a/crates/jayjay-uniffi/src/lib.rs
+++ b/crates/jayjay-uniffi/src/lib.rs
@@ -1,16 +1,13 @@
 uniffi::setup_scaffolding!();
 
+mod dag;
+mod diff;
 mod error;
 mod repo;
 mod types;
 
+pub use dag::*;
+pub use diff::*;
 pub use error::*;
 pub use repo::*;
 pub use types::*;
-
-#[uniffi::export]
-pub fn build_side_by_side_rows(
-    lines: Vec<jayjay_core::diff::DiffLine>,
-) -> Vec<jayjay_core::diff::SideBySideRow> {
-    jayjay_core::diff::build_side_by_side_rows(&lines)
-}

--- a/releases/0.2.18.html
+++ b/releases/0.2.18.html
@@ -1,0 +1,19 @@
+<h3>Diff polish</h3>
+<ul>
+    <li>New <b>Unified / Side-by-side</b> toggle in the diff header — replaces the icon-only toggle so the active mode is unambiguous.</li>
+</ul>
+<h3>File list polish</h3>
+<ul>
+    <li>Tree mode now supports <b>folding directories</b>: click a folder row's chevron to collapse, click again to expand. Fold state is per-window and survives change selection.</li>
+    <li>Hidden the always-on system scrollbar on the DAG and file lists (no behavior change beyond visual quiet).</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+    <li>Fixed duplicate folder rows in the tree file list — directory entries now carry their full path so SwiftUI's <code>ForEach</code> can key them uniquely.</li>
+    <li>About window: Sponsor / Star on GitHub buttons no longer pick up the macOS default-button accent highlight on open.</li>
+</ul>
+<h3>Internal</h3>
+<ul>
+    <li>DAG lane assignment moved to <code>jayjay_core::dag</code> (Rust). The Swift <code>DAGLayout</code> is now a thin uniffi wrapper, so the lane logic is shared with future shells.</li>
+    <li><code>jayjay-uniffi</code> split into per-feature modules (<code>dag</code>, <code>diff</code>, <code>error</code>, <code>repo</code>, <code>types</code>); <code>lib.rs</code> is a thin umbrella.</li>
+</ul>

--- a/shell/justfile
+++ b/shell/justfile
@@ -24,8 +24,8 @@ signing_identity := "Developer ID Application: Tao Xu (V28VJH6B6S)"
 team_id := "V28VJH6B6S"
 bundle_id := "dev.hewig.jayjay"
 app_name := "JayJay"
-version := "0.2.17"
-build_number := "21"
+version := "0.2.18"
+build_number := "22"
 release_dir := root / "build" / "release"
 
 default: list

--- a/shell/mac/Sources/JayJay/Detail/FileColumn.swift
+++ b/shell/mac/Sources/JayJay/Detail/FileColumn.swift
@@ -142,6 +142,7 @@ extension ChangeDetailView {
                 .listRowInsets(EdgeInsets(top: 0, leading: 4, bottom: 0, trailing: 4))
         }
         .listStyle(.plain)
+        .scrollIndicators(.never)
         .id(detail.info.commitId)
     }
 

--- a/shell/mac/Sources/JayJay/Detail/FileListView.swift
+++ b/shell/mac/Sources/JayJay/Detail/FileListView.swift
@@ -101,39 +101,75 @@ struct FileRow: View {
     }
 }
 
-// MARK: - Tree file list (caches buildFileTree across re-renders)
+// MARK: - Tree file list
+
+// Folder-grouped file list with click-to-collapse directories.
 
 struct TreeFileList<RowContent: View>: View {
     let filteredDiff: [DiffHunk]
     let commitId: String
     let fileRowView: (DiffHunk) -> RowContent
     @State private var treeEntries: [FileTreeEntry] = []
+    @State private var collapsedDirs: Set<String> = []
 
     var body: some View {
         List {
-            ForEach(treeEntries, id: \.path) { entry in
+            ForEach(visibleEntries, id: \.path) { entry in
                 if let hunkIdx = entry.hunkIndex, Int(hunkIdx) < filteredDiff.count {
                     let hunk = filteredDiff[Int(hunkIdx)]
                     fileRowView(hunk)
                         .padding(.leading, CGFloat(entry.depth) * 12)
                         .tag(hunk.path)
                 } else {
-                    HStack(spacing: 4) {
-                        Image(systemName: "folder").foregroundStyle(.secondary).jayjayFont(11)
-                        Text(entry.name).jayjayFont(12, weight: .medium)
-                    }
-                    .padding(.leading, CGFloat(entry.depth) * 12)
+                    folderRow(entry)
                 }
             }
         }
         .listStyle(.plain)
+        .scrollIndicators(.never)
         .id(commitId)
         .onAppear { rebuildTree() }
         .onChange(of: filteredDiff.map(\.path)) { rebuildTree() }
     }
 
+    private var visibleEntries: [FileTreeEntry] {
+        guard !collapsedDirs.isEmpty else { return treeEntries }
+        return treeEntries.filter { entry in
+            !collapsedDirs.contains(where: { entry.path.hasPrefix("\($0)/") })
+        }
+    }
+
+    @ViewBuilder
+    private func folderRow(_ entry: FileTreeEntry) -> some View {
+        let isCollapsed = collapsedDirs.contains(entry.path)
+        Button {
+            if isCollapsed {
+                collapsedDirs.remove(entry.path)
+            } else {
+                collapsedDirs.insert(entry.path)
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: isCollapsed ? "chevron.right" : "chevron.down")
+                    .foregroundStyle(.tertiary)
+                    .jayjayFont(9)
+                    .frame(width: 10)
+                Image(systemName: "folder").foregroundStyle(.secondary).jayjayFont(11)
+                Text(entry.name).jayjayFont(12, weight: .medium)
+                Spacer(minLength: 0)
+            }
+            .contentShape(Rectangle())
+            .padding(.leading, CGFloat(entry.depth) * 12)
+        }
+        .buttonStyle(.plain)
+    }
+
     private func rebuildTree() {
         treeEntries = buildFileTree(paths: filteredDiff.map(\.path))
+        // Drop collapsed dirs that no longer exist in the new tree, otherwise
+        // a leftover prefix from a previous change can hide files in this one.
+        let validDirs = Set(treeEntries.compactMap { $0.hunkIndex == nil ? $0.path : nil })
+        collapsedDirs.formIntersection(validDirs)
     }
 }
 

--- a/shell/mac/Sources/JayJay/Diff/DiffSection.swift
+++ b/shell/mac/Sources/JayJay/Diff/DiffSection.swift
@@ -79,6 +79,29 @@ struct DiffSection: View, DiffGutterEditActions {
                     .jayjayFont(10)
                     .foregroundStyle(.secondary)
             }
+            Button {
+                settings.sideBySideDiff.toggle()
+            } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: settings.sideBySideDiff
+                        ? "rectangle.split.2x1"
+                        : "text.justify")
+                        .jayjayFont(11)
+                    Text(settings.sideBySideDiff ? "Side-by-side" : "Unified")
+                        .jayjayFont(11)
+                }
+                .foregroundStyle(settings.sideBySideDiff ? Color.accentColor : .secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(
+                    settings.sideBySideDiff
+                        ? AnyShapeStyle(Color.accentColor.opacity(0.14))
+                        : AnyShapeStyle(Color.primary.opacity(0.06)),
+                    in: RoundedRectangle(cornerRadius: 4, style: .continuous)
+                )
+            }
+            .buttonStyle(.plain)
+            .help(settings.sideBySideDiff ? "Switch to unified" : "Switch to side-by-side")
             Text(label(for: hunk.hunkType))
                 .jayjayFont(11, weight: .semibold)
                 .padding(.horizontal, 8)

--- a/shell/mac/Sources/JayJay/Repo/DAGLayout.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAGLayout.swift
@@ -7,83 +7,29 @@ let dagRowLeadingPadding: CGFloat = 4
 let dagRowVerticalPadding: CGFloat = 8
 let dagNodeCenterY: CGFloat = 12
 
-/// Pre-computes which lane (column) each commit occupies.
+/// Thin Swift wrapper over `jayjay_core::dag::DagLayout` (via uniffi).
 struct DAGLayout {
-    /// Lane index for each commit ID.
-    let lanes: [String: Int]
-    /// Total number of active lanes at each row.
-    let activeLanesPerRow: [Int]
-    /// The exact lane indices that continue through each row.
-    let activeLaneIndicesPerRow: [[Int]]
+    private let lanes: [String: UInt32]
+    private let activeLanesPerRow: [UInt32]
+    private let activeLaneIndicesPerRow: [[UInt32]]
 
     init(entries: [GraphEntry]) {
-        var lanes: [String: Int] = [:]
-        var activeLanes: [String?] = []
-        var activeCounts: [Int] = []
-        var activeLaneIndices: [[Int]] = []
-
-        for entry in entries {
-            let cid = entry.change.commitId
-
-            if lanes[cid] == nil {
-                if let existing = activeLanes.firstIndex(of: cid) {
-                    lanes[cid] = existing
-                } else {
-                    lanes[cid] = Self.assignLane(for: cid, in: &activeLanes)
-                }
-            }
-
-            guard let myLane = lanes[cid] else { continue }
-            if myLane < activeLanes.count { activeLanes[myLane] = nil }
-
-            for edge in entry.edges where edge.edgeType != .missing {
-                if lanes[edge.target] == nil {
-                    lanes[edge.target] = Self.assignLane(
-                        for: edge.target, in: &activeLanes, preferring: myLane
-                    )
-                }
-            }
-
-            activeCounts.append(activeLanes.count)
-            activeLaneIndices.append(
-                activeLanes.enumerated().compactMap { lane, commitId in
-                    commitId == nil ? nil : lane
-                }
-            )
-        }
-
-        self.lanes = lanes
-        activeLanesPerRow = activeCounts
-        activeLaneIndicesPerRow = activeLaneIndices
+        let data = computeDagLayout(entries: entries)
+        lanes = data.lanes
+        activeLanesPerRow = data.activeLanesPerRow
+        activeLaneIndicesPerRow = data.activeLaneIndicesPerRow
     }
 
     func lane(for commitId: String) -> Int {
-        lanes[commitId] ?? 0
+        Int(lanes[commitId] ?? 0)
     }
 
     func maxLanes() -> Int {
-        activeLanesPerRow.max() ?? 1
+        Int(activeLanesPerRow.max() ?? 1)
     }
 
     func activeLaneIndices(at row: Int) -> [Int] {
         guard activeLaneIndicesPerRow.indices.contains(row) else { return [] }
-        return activeLaneIndicesPerRow[row]
-    }
-
-    /// Assign a lane for `commitId`, reusing `preferring` if free, else first free slot, else new.
-    private static func assignLane(
-        for commitId: String, in activeLanes: inout [String?], preferring: Int? = nil
-    ) -> Int {
-        if let preferred = preferring, preferred < activeLanes.count, activeLanes[preferred] == nil {
-            activeLanes[preferred] = commitId
-            return preferred
-        }
-        if let free = activeLanes.firstIndex(of: nil) {
-            activeLanes[free] = commitId
-            return free
-        }
-        let lane = activeLanes.count
-        activeLanes.append(commitId)
-        return lane
+        return activeLaneIndicesPerRow[row].map(Int.init)
     }
 }

--- a/shell/mac/Sources/JayJay/Repo/DAGView.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAGView.swift
@@ -214,6 +214,7 @@ struct DAGView: View {
                         }
                         .padding(.vertical, 6)
                     }
+                    .scrollIndicators(.never)
                     .coordinateSpace(name: DAGRebaseCoordinateSpace.name)
                     .background(
                         LinearGradient(

--- a/shell/mac/Sources/JayJay/Settings/AboutView.swift
+++ b/shell/mac/Sources/JayJay/Settings/AboutView.swift
@@ -67,12 +67,15 @@ struct AboutView: View {
                     Link(destination: AppMetadata.sponsorURL) {
                         Label("Sponsor", systemImage: "heart.fill")
                     }
+                    .buttonStyle(.bordered)
                     .controlSize(.small)
                     Link(destination: AppMetadata.githubURL) {
                         Label("Star on GitHub", systemImage: "star.fill")
                     }
+                    .buttonStyle(.bordered)
                     .controlSize(.small)
                 }
+                .focusEffectDisabled()
             }
         }
         .animation(.easeInOut(duration: 0.3), value: showEasterEgg)

--- a/shell/mac/project.yml
+++ b/shell/mac/project.yml
@@ -59,8 +59,8 @@ targets:
       base:
         ASSETCATALOG_COMPILER_APPICON_NAME: app
         PRODUCT_BUNDLE_IDENTIFIER: dev.hewig.jayjay
-        MARKETING_VERSION: "0.2.17"
-        CURRENT_PROJECT_VERSION: 21
+        MARKETING_VERSION: "0.2.18"
+        CURRENT_PROJECT_VERSION: 22
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_CFBundleDisplayName: JayJay
         INFOPLIST_KEY_LSApplicationCategoryType: public.app-category.developer-tools


### PR DESCRIPTION
## Summary
- Foldable directories + side-by-side/unified toggle in the diff header; quieter scrollbars in the DAG and file lists.
- Fix duplicate folder rows in the tree file list (directory entries now carry their full path).
- Move DAG lane assignment to `jayjay_core::dag` and split `jayjay-uniffi` into per-feature modules.

## Test plan
- [ ] `just build` succeeds
- [ ] `just test` (Rust + new dag/file_tree tests) green
- [ ] `just test-app` green
- [ ] Manual: open a repo with nested folders, confirm tree-list folds and shows no duplicate folder rows
- [ ] Manual: toggle Side-by-side / Unified in diff header
- [ ] Manual: scrollbars no longer permanently visible in DAG / file list