### PR TITLE
ci: split cross-platform Rust into gpui-ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,19 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - "shell/mac/**"
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/ci.yml"
   pull_request:
+    paths:
+      - "shell/mac/**"
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/ci.yml"
 
 permissions:
   contents: read
@@ -32,9 +44,6 @@ jobs:
             target
           key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-${{ runner.os }}-
-
-      - name: Clippy
-        run: cargo clippy --workspace
 
       - name: Test
         run: cargo test --workspace

--- a/.github/workflows/gpui-ci.yml
+++ b/.github/workflows/gpui-ci.yml
@@ -55,7 +55,10 @@ jobs:
           restore-keys: cargo-gpui-${{ runner.os }}-
 
       - name: Clippy
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
+      - name: Build jayjay-gpui
+        run: cargo build -p jayjay-gpui
 
       - name: Test
         run: cargo test --workspace

--- a/.github/workflows/gpui-ci.yml
+++ b/.github/workflows/gpui-ci.yml
@@ -1,0 +1,83 @@
+name: GPUI CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "shell/gpui/**"
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/gpui-ci.yml"
+  pull_request:
+    paths:
+      - "shell/gpui/**"
+      - "crates/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/gpui-ci.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gpui-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    name: Rust (linux)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install Linux deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc g++ clang libfontconfig-dev libwayland-dev \
+            libxkbcommon-x11-dev libx11-xcb-dev libssl-dev libzstd-dev \
+            vulkan-validationlayers libvulkan1
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-gpui-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-gpui-${{ runner.os }}-
+
+      - name: Clippy
+        run: cargo clippy --workspace -- -D warnings
+
+      - name: Test
+        run: cargo test --workspace
+
+  windows:
+    name: Rust (windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-gpui-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: cargo-gpui-${{ runner.os }}-
+
+      - name: Build jayjay-gpui
+        run: cargo build -p jayjay-gpui

--- a/crates/jj-diff/src/tests.rs
+++ b/crates/jj-diff/src/tests.rs
@@ -671,7 +671,7 @@ fn test_skip_highlight_for_lock_files() {
 #[test]
 fn test_collapse_context_with_mapping_preserves_changed_lines() {
     // Build a 20-line diff with a change at line 10
-    let mut old_lines: Vec<String> = (1..=20).map(|i| format!("line {i}")).collect();
+    let old_lines: Vec<String> = (1..=20).map(|i| format!("line {i}")).collect();
     let mut new_lines = old_lines.clone();
     new_lines[9] = "CHANGED".to_string();
 


### PR DESCRIPTION
## Summary

Splits CI into two workflows so each platform owns what's actually platform-specific to it. Supersedes the original \`rust-cross\` matrix idea.

**\`ci.yml\` (macOS app)**
- \`rust\` (macos-26): \`cargo test --workspace\` for macOS-only cfg coverage (e.g. \`terminal.rs\`)
- \`swift\` (macos-26): unchanged
- \`paths:\` shell/mac, jayjay-uniffi, jayjay-cli, core, jj-diff, Cargo, this workflow

**\`gpui-ci.yml\` (cross-platform Rust — new)**
- \`rust\` (ubuntu-latest): \`cargo clippy --workspace -- -D warnings\` + \`cargo test --workspace\` — primary Rust gate, fast and cheap
- \`windows\` (windows-latest): \`cargo build -p jayjay-gpui\` smoke build
- Linux apt deps cribbed from [longbridge/gpui-component](https://github.com/longbridge/gpui-component/blob/main/script/install-linux.sh)
- \`paths:\` shell/gpui, core, jj-diff, Cargo, this workflow

**Why:**
- Linux is the cheap/fast Rust gate — clippy and test live here
- macOS rust becomes platform-coverage, not the gate
- Windows is build-only — no \`cfg(windows)\` branches exist yet, so testing there triples runtime for marginal value
- Path filters mean Swift-only PRs skip gpui-ci entirely; gpui-only PRs skip the slow macOS swift run when they don't touch core

## Test plan
- [ ] Push triggers gpui-ci.yml (touches Cargo.lock + workflow)
- [ ] Linux: clippy + test pass
- [ ] Windows: build passes
- [ ] ci.yml: macOS rust + swift continue to pass
- [ ] On a future shell/mac-only PR, gpui-ci doesn't run
- [ ] On a future shell/gpui-only PR, ci.yml doesn't run