### PR TITLE
refactor(gpui): start AnyElement → impl IntoElement sweep

### DIFF
--- a/Roadmap.md
+++ b/Roadmap.md
@@ -25,8 +25,6 @@ JayJay now covers most common jj history, diff, bookmark, conflict, and Git flow
     - [x] Reveal-to-changeId — `LogView::reveal_change_id` scrolls + selects, used by file-history and bookmark clicks
     - [x] Bookmark bar in sidebar header + workspace pill in status bar (read-only; switching is a write-action, deferred)
     - [x] Persistent file review (space to toggle, `n / total reviewed` count, mtime-based auto-invalidation so a re-edited file flips back to unreviewed) — `jayjay_core::review::ReviewStore` is the canonical impl; SwiftUI's UserDefaults-backed copy is the next migration target.
-  - [ ] Adopt `gpui-component` widgets — replace hand-rolled `ui/` primitives (avatar, icon, context_menu, popover, scrollbar) with `longbridge/gpui-component`. Blocked on tree-sitter PR [#2327](https://github.com/longbridge/gpui-component/pull/2327) so jj-diff's `tree-sitter = 0.26` doesn't conflict with the component crate's pin.
-  - [ ] Migrate render helpers from `AnyElement` to `impl IntoElement` — the largest stylistic delta from upstream gpui. Returning `AnyElement` boxes every render helper; `impl IntoElement` keeps the concrete type and avoids the allocation. Defer to a sweep so the split-by-file `pub(super) fn helper(...) -> AnyElement` callsites can be migrated together.
   - [ ] Write milestone — first set of mutating actions, all routed through the existing `RepoViewModel::refresh()` so the FS watcher + review store stay coherent:
     - [ ] Describe + commit box (edit working-copy description, AI message generation reusing `jayjay_core::COMMIT_MESSAGE_PROMPT`)
     - [ ] `jj new` button on the toolbar

--- a/shell/gpui/src/diff/diff_view/mod.rs
+++ b/shell/gpui/src/diff/diff_view/mod.rs
@@ -57,7 +57,7 @@ pub fn diff_view(
     let t = theme(cx).clone();
 
     let Some(hunk) = state.hunk else {
-        return placeholder("Select a file", &t);
+        return placeholder("Select a file", &t).into_any_element();
     };
 
     let is_annotating = matches!(state.detail_mode, DetailMode::Annotate);
@@ -74,15 +74,15 @@ pub fn diff_view(
 
     let body: AnyElement = if is_annotating {
         if state.loading_annotate {
-            placeholder_inner("Loading annotations…", &t)
+            placeholder_inner("Loading annotations…", &t).into_any_element()
         } else if let Some(lines) = state.annotate_lines {
             if lines.is_empty() {
-                placeholder_inner("No annotations available", &t)
+                placeholder_inner("No annotations available", &t).into_any_element()
             } else {
                 crate::diff::annotate_view::annotate_body(lines, t.clone(), scroll.clone())
             }
         } else {
-            placeholder_inner("Annotations unavailable", &t)
+            placeholder_inner("Annotations unavailable", &t).into_any_element()
         }
     } else if crate::diff::image_diff::hunk_is_image(hunk) {
         crate::diff::image_diff::image_diff_view(hunk, &t)
@@ -93,6 +93,7 @@ pub fn diff_view(
             "This submodule has working-copy changes, but JayJay does not render an inline text diff for submodule contents. Open or commit the submodule in its own repository.",
             &t,
         )
+        .into_any_element()
     } else if hunk_is_git_lfs(hunk) {
         placeholder_card(
             glyph::HARD_DRIVE,
@@ -100,11 +101,13 @@ pub fn diff_view(
             "This file is tracked through Git LFS. JayJay does not render an inline text diff between the committed pointer and the local binary object.",
             &t,
         )
+        .into_any_element()
     } else {
         match (state.file_diff, state.view_mode) {
-            (None, _) => placeholder_inner("Loading diff…", &t),
+            (None, _) => placeholder_inner("Loading diff…", &t).into_any_element(),
             (Some(fd), _) if fd.lines.is_empty() => {
                 placeholder_inner("No textual diff (binary, identical, or empty)", &t)
+                    .into_any_element()
             }
             (Some(fd), DiffViewMode::Unified) => {
                 unified_body(fd, t.clone(), query.clone(), scroll.clone())

--- a/shell/gpui/src/diff/diff_view/placeholders.rs
+++ b/shell/gpui/src/diff/diff_view/placeholders.rs
@@ -1,4 +1,4 @@
-use gpui::{AnyElement, IntoElement, ParentElement, Styled, div, px, rgb};
+use gpui::{IntoElement, ParentElement, Styled, div, px, rgb};
 
 use crate::app::theme::Theme;
 use crate::ui::icons;
@@ -8,7 +8,7 @@ pub(super) fn placeholder_card(
     title: &'static str,
     body: &'static str,
     t: &Theme,
-) -> AnyElement {
+) -> impl IntoElement {
     div()
         .flex()
         .flex_col()
@@ -26,10 +26,9 @@ pub(super) fn placeholder_card(
                 .text_color(rgb(t.fg_dim))
                 .child(body),
         )
-        .into_any_element()
 }
 
-pub(super) fn placeholder(text: &'static str, t: &Theme) -> AnyElement {
+pub(super) fn placeholder(text: &'static str, t: &Theme) -> impl IntoElement {
     div()
         .flex()
         .flex_1()
@@ -39,10 +38,9 @@ pub(super) fn placeholder(text: &'static str, t: &Theme) -> AnyElement {
         .bg(rgb(t.detail_bg))
         .text_color(rgb(t.fg_dim))
         .child(text)
-        .into_any_element()
 }
 
-pub(super) fn placeholder_inner(text: &'static str, t: &Theme) -> AnyElement {
+pub(super) fn placeholder_inner(text: &'static str, t: &Theme) -> impl IntoElement {
     div()
         .flex()
         .size_full()
@@ -50,5 +48,4 @@ pub(super) fn placeholder_inner(text: &'static str, t: &Theme) -> AnyElement {
         .justify_center()
         .text_color(rgb(t.fg_dim))
         .child(text)
-        .into_any_element()
 }

--- a/shell/gpui/src/windows/command_palette/render.rs
+++ b/shell/gpui/src/windows/command_palette/render.rs
@@ -4,7 +4,7 @@ use super::actions::{ACTIONS, PaletteAction};
 use crate::app::theme::Theme;
 use crate::ui::icons::{self, glyph};
 
-pub(super) fn query_box(query: &str, t: &Theme) -> AnyElement {
+pub(super) fn query_box(query: &str, t: &Theme) -> impl IntoElement {
     let display = if query.is_empty() {
         SharedString::from("Type to search…")
     } else {
@@ -22,15 +22,10 @@ pub(super) fn query_box(query: &str, t: &Theme) -> AnyElement {
         .text_color(rgb(color))
         .child(icons::icon(glyph::SEARCH, 14., t.fg_dim))
         .child(display)
-        .into_any_element()
 }
 
-pub(super) fn divider(t: &Theme) -> AnyElement {
-    div()
-        .h(px(1.))
-        .w_full()
-        .bg(rgb(t.border))
-        .into_any_element()
+pub(super) fn divider(t: &Theme) -> impl IntoElement {
+    div().h(px(1.)).w_full().bg(rgb(t.border))
 }
 
 pub(super) fn action_list(visible: &[usize], selected: usize, t: &Theme) -> AnyElement {
@@ -52,7 +47,7 @@ pub(super) fn action_list(visible: &[usize], selected: usize, t: &Theme) -> AnyE
     col.into_any_element()
 }
 
-fn action_row(action: &'static PaletteAction, is_selected: bool, t: &Theme) -> AnyElement {
+fn action_row(action: &'static PaletteAction, is_selected: bool, t: &Theme) -> impl IntoElement {
     let (bg, fg, glyph_color) = if is_selected {
         (t.selected_bg, t.fg, t.toggle_active_fg)
     } else {
@@ -70,5 +65,4 @@ fn action_row(action: &'static PaletteAction, is_selected: bool, t: &Theme) -> A
         .text_size(px(13.))
         .child(icons::icon(action.glyph_str, 14., glyph_color))
         .child(SharedString::from(action.name))
-        .into_any_element()
 }

--- a/shell/gpui/src/windows/settings/about.rs
+++ b/shell/gpui/src/windows/settings/about.rs
@@ -1,5 +1,5 @@
 use gpui::{
-    AnyElement, ClickEvent, InteractiveElement, IntoElement, ParentElement, SharedString,
+    ClickEvent, InteractiveElement, IntoElement, ParentElement, SharedString,
     StatefulInteractiveElement, Styled, div, px, rgb,
 };
 
@@ -11,7 +11,7 @@ const TAGLINE: &str = "A native GUI for Jujutsu";
 const SPONSOR_URL: &str = "https://github.com/sponsors/hewigovens";
 const GITHUB_URL: &str = "https://github.com/hewigovens/jayjay";
 
-pub(super) fn about_section(t: &Theme) -> AnyElement {
+pub(super) fn about_section(t: &Theme) -> impl IntoElement {
     let version = format!("Version {} (GPUI Alpha)", env!("CARGO_PKG_VERSION"));
 
     div()
@@ -60,10 +60,9 @@ pub(super) fn about_section(t: &Theme) -> AnyElement {
                     t,
                 )),
         )
-        .into_any_element()
 }
 
-fn app_icon(t: &Theme) -> AnyElement {
+fn app_icon(t: &Theme) -> impl IntoElement {
     div()
         .flex()
         .items_center()
@@ -73,7 +72,6 @@ fn app_icon(t: &Theme) -> AnyElement {
         .rounded_full()
         .bg(rgb(t.toggle_active_bg))
         .child(icons::icon(glyph::GIT_BRANCH, 36., t.toggle_active_fg))
-        .into_any_element()
 }
 
 fn link_button(
@@ -82,7 +80,7 @@ fn link_button(
     label: &'static str,
     url: &'static str,
     t: &Theme,
-) -> AnyElement {
+) -> impl IntoElement {
     div()
         .id(SharedString::from(id))
         .flex()
@@ -102,5 +100,4 @@ fn link_button(
         })
         .child(icons::icon(glyph_str, 12., t.toggle_inactive_fg))
         .child(label)
-        .into_any_element()
 }

--- a/shell/gpui/src/windows/settings/mod.rs
+++ b/shell/gpui/src/windows/settings/mod.rs
@@ -305,6 +305,6 @@ fn section_body(
         SettingsSection::Tools => tools::tools_section(cfg, t, cx),
         SettingsSection::Features => features::features_section(cfg, t),
         SettingsSection::Config => config::config_section(t),
-        SettingsSection::About => about::about_section(t),
+        SettingsSection::About => about::about_section(t).into_any_element(),
     }
 }


### PR DESCRIPTION
## Summary

Two things in one PR:

1. **Roadmap**: drop the \"Adopt \`gpui-component\` widgets\" bullet (paused until [longbridge/gpui-component#2327](https://github.com/longbridge/gpui-component/pull/2327) lands) and the \`AnyElement\` → \`impl IntoElement\` bullet (now in active rolling work, not roadmap material).
2. **Kick off** the \`AnyElement\` → \`impl IntoElement\` migration on 3 representative files. Returning \`AnyElement\` boxes every render helper; \`impl IntoElement\` keeps the concrete type and avoids the allocation.

## Migration pattern (codified)

**Leaf helper, single return** — switch the helper, no caller change needed:
```rust
- pub(super) fn placeholder(text: &'static str, t: &Theme) -> AnyElement {
+ pub(super) fn placeholder(text: &'static str, t: &Theme) -> impl IntoElement {
      div().flex()...
-         .into_any_element()
  }
```

**Branching caller** (match arm / \`if/else if\` chain) — keep the outer binding as \`AnyElement\`, push \`.into_any_element()\` to each branch:
```rust
  let body: AnyElement = if cond {
-     placeholder_inner(\"Loading…\", &t)
+     placeholder_inner(\"Loading…\", &t).into_any_element()
  } else if other {
      ...
  };
```

**Helpers with diverging early-return types** (e.g. \`command_palette::action_list\`, \`settings::*::dropdown_overlay\`) stay on \`AnyElement\` — \`impl IntoElement\` can't unify two different \`Div\` configurations in one fn.

## Files migrated this PR

| Helper | File |
|---|---|
| \`placeholder\`, \`placeholder_inner\`, \`placeholder_card\` | \`diff/diff_view/placeholders.rs\` |
| \`query_box\`, \`divider\`, \`action_row\` | \`windows/command_palette/render.rs\` |
| \`about_section\`, \`app_icon\`, \`link_button\` | \`windows/settings/about.rs\` |
| Caller updates | \`diff/diff_view/mod.rs\`, \`windows/settings/mod.rs\` |

~9 helpers down, ~40 to go. Follow-up PRs will sweep each remaining feature dir (\`diff/\`, \`log/\`, \`repo/\`, \`windows/\`) one at a time so review diffs stay focused.

## Test plan
- [x] \`cargo build -p jayjay-gpui\` — clean
- [x] \`cargo clippy -p jayjay-gpui --all-targets -- -D warnings\` — clean
- [ ] gpui-ci.yml runs (Linux clippy/test + Windows build) — auto-triggered by this PR now that #37 is on main
- [ ] Smoke-test the migrated surfaces: empty diff selection, command palette open, Settings → About