### PR TITLE
test(gpui): add component test infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
         with:
           components: clippy, rustfmt
 
+      - name: Install jj (for component test fixtures)
+        run: brew install jj
+
       - name: Cache cargo
         uses: actions/cache@v5
         with:

--- a/.github/workflows/gpui-ci.yml
+++ b/.github/workflows/gpui-ci.yml
@@ -50,7 +50,8 @@ jobs:
           JJ_VERSION: v0.40.0
         run: |
           curl -fsSL "https://github.com/jj-vcs/jj/releases/download/${JJ_VERSION}/jj-${JJ_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
-            | sudo tar -xz -C /usr/local/bin jj
+            | tar -xz -C /tmp ./jj
+          sudo mv /tmp/jj /usr/local/bin/jj
           jj --version
 
       - name: Cache cargo

--- a/.github/workflows/gpui-ci.yml
+++ b/.github/workflows/gpui-ci.yml
@@ -45,9 +45,13 @@ jobs:
             vulkan-validationlayers libvulkan1
 
       - name: Install jj (for component test fixtures)
-        uses: taiki-e/install-action@v2
-        with:
-          tool: jj
+        env:
+          # Keep aligned with jj-lib pin in Cargo.toml.
+          JJ_VERSION: v0.40.0
+        run: |
+          curl -fsSL "https://github.com/jj-vcs/jj/releases/download/${JJ_VERSION}/jj-${JJ_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin jj
+          jj --version
 
       - name: Cache cargo
         uses: actions/cache@v5

--- a/.github/workflows/gpui-ci.yml
+++ b/.github/workflows/gpui-ci.yml
@@ -44,6 +44,11 @@ jobs:
             libxkbcommon-x11-dev libx11-xcb-dev libssl-dev libzstd-dev \
             vulkan-validationlayers libvulkan1
 
+      - name: Install jj (for component test fixtures)
+        uses: taiki-e/install-action@v2
+        with:
+          tool: jj
+
       - name: Cache cargo
         uses: actions/cache@v5
         with:

--- a/.github/workflows/gpui-ci.yml
+++ b/.github/workflows/gpui-ci.yml
@@ -82,6 +82,18 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install jj (for component test fixtures)
+        shell: pwsh
+        env:
+          # Keep aligned with jj-lib pin in Cargo.toml.
+          JJ_VERSION: v0.40.0
+        run: |
+          $url = "https://github.com/jj-vcs/jj/releases/download/$env:JJ_VERSION/jj-$env:JJ_VERSION-x86_64-pc-windows-msvc.zip"
+          Invoke-WebRequest -Uri $url -OutFile jj.zip
+          Expand-Archive -Path jj.zip -DestinationPath "$env:USERPROFILE\jj-bin"
+          Add-Content -Path $env:GITHUB_PATH -Value "$env:USERPROFILE\jj-bin"
+          & "$env:USERPROFILE\jj-bin\jj.exe" --version
+
       - name: Cache cargo
         uses: actions/cache@v5
         with:
@@ -94,3 +106,6 @@ jobs:
 
       - name: Build jayjay-gpui
         run: cargo build -p jayjay-gpui
+
+      - name: Test
+        run: cargo test --workspace

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ For JayJay specifically:
 - `just test` — Rust unit tests across the workspace.
 - `just test-app` — Swift unit tests (JayJayTests).
 - `just test-ui` — XCUITest scenes against deterministic fixtures at `/tmp/jayjay-test-fixtures/{simple,conflict}`, built by `just shell::ui-test-setup`.
-- `just test-gpui` — GPUI shell component tests (`#[gpui::test]` + `TestAppContext`) against per-test temp jj fixtures. Tests skip gracefully when `jj`/`git` aren't on PATH.
+- `just test-gpui` — GPUI shell component tests (`#[gpui::test]` + `TestAppContext`) against per-test temp jj fixtures. Requires `jj` on PATH.
 
 UI tests live in `shell/mac/Tests/JayJayUITests/`. Each `SceneBase` subclass launches the app against a named fixture (`simple` by default; override `fixtureName` for a different one) and asserts against accessibility identifiers declared in `Sources/JayJay/Shared/AccessibilityIdentifiers.swift`. Add identifiers at the view body, keyed by whatever data uniquely identifies the element (change-id prefix, file path, etc.).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ UI tests live in `shell/mac/Tests/JayJayUITests/`. Each `SceneBase` subclass lau
 
 If a scene **mutates repo state** (new change, abandon, rebase, Use Ours, ...), give it its own fixture — tests share a filesystem and run alphabetically, so mutations on `simple` leak into subsequent tests. `ui-test-setup` already produces `simple-newchange` as a copy for `NewChangeScene`; add a sibling copy for new mutating scenes.
 
-GPUI shell component tests live in `shell/gpui/tests/`. Each test builds its own `tempfile::TempDir` fixture via `support::SimpleFixture::build()` so tests are hermetic and parallel-safe — no shared `/tmp` state. Use `#[gpui::test]` + `TestAppContext` to spin up entities (`RepoViewModel`, `LogView`, ...) and assert state transitions; skip the pixel layer.
+GPUI shell component tests live in `shell/gpui/tests/`. Each test builds its own `tempfile::TempDir` fixture via `jj_test_fixtures::LinearFixture::build()` (shared lib at `crates/jj-test-fixtures/`) so tests are hermetic and parallel-safe — no shared `/tmp` state. Use `#[gpui::test]` + `TestAppContext` to spin up entities (`RepoViewModel`, `LogView`, ...) and assert state transitions; skip the pixel layer.
 
 ## Architecture: MVVM
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,13 @@ For JayJay specifically:
 - `just test` — Rust unit tests across the workspace.
 - `just test-app` — Swift unit tests (JayJayTests).
 - `just test-ui` — XCUITest scenes against deterministic fixtures at `/tmp/jayjay-test-fixtures/{simple,conflict}`, built by `just shell::ui-test-setup`.
+- `just test-gpui` — GPUI shell component tests (`#[gpui::test]` + `TestAppContext`) against per-test temp jj fixtures. Tests skip gracefully when `jj`/`git` aren't on PATH.
 
 UI tests live in `shell/mac/Tests/JayJayUITests/`. Each `SceneBase` subclass launches the app against a named fixture (`simple` by default; override `fixtureName` for a different one) and asserts against accessibility identifiers declared in `Sources/JayJay/Shared/AccessibilityIdentifiers.swift`. Add identifiers at the view body, keyed by whatever data uniquely identifies the element (change-id prefix, file path, etc.).
 
 If a scene **mutates repo state** (new change, abandon, rebase, Use Ours, ...), give it its own fixture — tests share a filesystem and run alphabetically, so mutations on `simple` leak into subsequent tests. `ui-test-setup` already produces `simple-newchange` as a copy for `NewChangeScene`; add a sibling copy for new mutating scenes.
+
+GPUI shell component tests live in `shell/gpui/tests/`. Each test builds its own `tempfile::TempDir` fixture via `support::SimpleFixture::build()` so tests are hermetic and parallel-safe — no shared `/tmp` state. Use `#[gpui::test]` + `TestAppContext` to spin up entities (`RepoViewModel`, `LogView`, ...) and assert state transitions; skip the pixel layer.
 
 ## Architecture: MVVM
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4142,10 +4142,10 @@ dependencies = [
  "gpui_platform",
  "hex",
  "jayjay-core",
+ "jj-test-fixtures",
  "md-5 0.11.0",
  "notify",
  "serde",
- "tempfile",
  "toml 1.1.2+spec-1.1.0",
  "ureq",
 ]
@@ -4288,6 +4288,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "jj-test-fixtures"
+version = "0.1.0"
+dependencies = [
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,12 +611,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddef2995421ab6a5c779542c81ee77c115206f4ad9d5a8e05f4ff49716a3dd"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.9.1",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bit-vec"
@@ -1151,6 +1166,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,7 +1497,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -3255,6 +3279,7 @@ dependencies = [
  "anyhow",
  "async-channel 2.5.0",
  "async-task",
+ "backtrace",
  "bindgen",
  "bitflags 2.11.1",
  "block",
@@ -3298,6 +3323,7 @@ dependencies = [
  "pollster 0.4.0",
  "postage",
  "profiling",
+ "proptest",
  "rand 0.9.4",
  "raw-window-handle",
  "refineable",
@@ -3911,7 +3937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -4119,6 +4145,7 @@ dependencies = [
  "md-5 0.11.0",
  "notify",
  "serde",
+ "tempfile",
  "toml 1.1.2+spec-1.1.0",
  "ureq",
 ]
@@ -4775,7 +4802,7 @@ version = "29.0.0"
 source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
@@ -4801,7 +4828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd91265cc2454558f659b3b4b9640f0ddb8cc6521277f166b8a8c181c898079"
 dependencies = [
  "arrayvec",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.11.1",
  "cfg-if",
  "cfg_aliases",
@@ -5633,6 +5660,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.10.0"
+source = "git+https://github.com/proptest-rs/proptest?rev=3dca198a8fef1b32e3a66f1e1897c955b4dc5b5b#3dca198a8fef1b32e3a66f1e1897c955b4dc5b5b"
+dependencies = [
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.11.1",
+ "num-traits",
+ "proptest-macro",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-macro"
+version = "0.5.0"
+source = "git+https://github.com/proptest-rs/proptest?rev=3dca198a8fef1b32e3a66f1e1897c955b4dc5b5b#3dca198a8fef1b32e3a66f1e1897c955b4dc5b5b"
+dependencies = [
+ "convert_case 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5679,6 +5736,12 @@ checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -5803,6 +5866,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "range-alloc"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5858,7 +5930,7 @@ dependencies = [
  "avif-serialize",
  "imgref",
  "loop9",
- "quick-error",
+ "quick-error 2.0.1",
  "rav1e",
  "rayon",
  "rgb",
@@ -6188,6 +6260,18 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rustybuzz"
@@ -7046,7 +7130,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg 0.5.15",
 ]
@@ -7599,6 +7683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8052,6 +8142,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "waker-fn"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8283,8 +8382,8 @@ version = "29.0.0"
 source = "git+https://github.com/zed-industries/wgpu.git?branch=v29#a466bc382ea747f8e1ac810efdb6dcd49a514575"
 dependencies = [
  "arrayvec",
- "bit-set",
- "bit-vec",
+ "bit-set 0.9.1",
+ "bit-vec 0.9.1",
  "bitflags 2.11.1",
  "bytemuck",
  "cfg_aliases",
@@ -8341,7 +8440,7 @@ dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
- "bit-set",
+ "bit-set 0.9.1",
  "bitflags 2.11.1",
  "block2",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/jj-diff", "crates/jayjay-core", "crates/jayjay-uniffi", "crates/jayjay-cli", "shell/gpui"]
+members = ["crates/jj-diff", "crates/jj-test-fixtures", "crates/jayjay-core", "crates/jayjay-uniffi", "crates/jayjay-cli", "shell/gpui"]
 resolver = "2"
 
 [workspace.package]

--- a/crates/jj-test-fixtures/Cargo.toml
+++ b/crates/jj-test-fixtures/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "jj-test-fixtures"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+tempfile = { workspace = true }

--- a/crates/jj-test-fixtures/src/cmd.rs
+++ b/crates/jj-test-fixtures/src/cmd.rs
@@ -1,0 +1,42 @@
+use std::path::Path;
+use std::process::{Command, Output};
+
+/// Run `jj` rooted at `repo` and panic on non-zero exit.
+pub fn run_jj_in(repo: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new("jj");
+    cmd.arg("-R").arg(repo).args(args);
+    finish(cmd, args)
+}
+
+/// Build a fresh colocated jj repo at `path` (must not exist yet).
+pub fn init_colocated(path: &Path) {
+    let mut init = Command::new("jj");
+    init.arg("git").arg("init").arg("--colocate").arg(path);
+    finish(init, &["git", "init", "--colocate", "<repo>"]);
+}
+
+/// Set a deterministic test identity so commit hashes are reproducible.
+pub fn configure_test_user(repo: &Path) {
+    run_jj_in(
+        repo,
+        &["config", "set", "--repo", "user.name", "Test User"],
+    );
+    run_jj_in(
+        repo,
+        &["config", "set", "--repo", "user.email", "test@example.com"],
+    );
+}
+
+pub(crate) fn finish(mut cmd: Command, args: &[&str]) -> Output {
+    let output = cmd
+        .output()
+        .unwrap_or_else(|err| panic!("failed to spawn jj {args:?}: {err}"));
+    if !output.status.success() {
+        panic!(
+            "jj {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+    output
+}

--- a/crates/jj-test-fixtures/src/lib.rs
+++ b/crates/jj-test-fixtures/src/lib.rs
@@ -2,80 +2,8 @@
 // Used by jayjay-gpui's component tests and (eventually) jayjay-core's
 // real_jj_repo.rs.
 
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::{Command, Output};
+pub mod cmd;
+pub mod linear;
 
-use tempfile::TempDir;
-
-/// Run `jj` rooted at `repo` and panic on non-zero exit.
-pub fn run_jj_in(repo: &Path, args: &[&str]) -> Output {
-    let mut cmd = Command::new("jj");
-    cmd.arg("-R").arg(repo).args(args);
-    finish(cmd, args)
-}
-
-fn finish(mut cmd: Command, args: &[&str]) -> Output {
-    let output = cmd
-        .output()
-        .unwrap_or_else(|err| panic!("failed to spawn jj {args:?}: {err}"));
-    if !output.status.success() {
-        panic!(
-            "jj {args:?} failed\nstdout:\n{}\nstderr:\n{}",
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr),
-        );
-    }
-    output
-}
-
-/// Linear history: 3 describing changes ending in a working copy with two new
-/// files. Mirrors the same-shaped fixture in `shell/justfile:ui-test-setup`
-/// so behavior parity with the SwiftUI UI tests is intentional.
-pub struct LinearFixture {
-    _tmp: TempDir,
-    pub path: PathBuf,
-}
-
-impl LinearFixture {
-    pub fn build() -> Self {
-        let tmp = tempfile::tempdir().expect("create tempdir");
-        let path = tmp.path().join("repo");
-
-        let mut init = Command::new("jj");
-        init.arg("git").arg("init").arg("--colocate").arg(&path);
-        finish(init, &["git", "init", "--colocate", "<repo>"]);
-        configure_user(&path);
-
-        write(&path, "README.md", "# Sample project\n");
-        run_jj_in(&path, &["describe", "-m", "initial"]);
-
-        run_jj_in(&path, &["new", "-m", "add hello"]);
-        write(&path, "hello.txt", "hello\n");
-
-        run_jj_in(&path, &["new", "-m", "add feature"]);
-        write(&path, "feature.txt", "feature\n");
-        run_jj_in(&path, &["bookmark", "create", "main", "-r", "@"]);
-
-        run_jj_in(&path, &["new"]);
-        write(&path, "wip1.txt", "wip 1\n");
-        write(&path, "wip2.txt", "wip 2\n");
-
-        Self { _tmp: tmp, path }
-    }
-}
-
-fn configure_user(repo: &Path) {
-    run_jj_in(
-        repo,
-        &["config", "set", "--repo", "user.name", "Test User"],
-    );
-    run_jj_in(
-        repo,
-        &["config", "set", "--repo", "user.email", "test@example.com"],
-    );
-}
-
-fn write(repo: &Path, rel: &str, contents: &str) {
-    fs::write(repo.join(rel), contents).unwrap_or_else(|err| panic!("write {rel}: {err}"));
-}
+pub use cmd::run_jj_in;
+pub use linear::LinearFixture;

--- a/crates/jj-test-fixtures/src/lib.rs
+++ b/crates/jj-test-fixtures/src/lib.rs
@@ -1,5 +1,6 @@
-// Allow because individual integration test binaries only consume a subset.
-#![allow(dead_code)]
+// Shared jj fixture builders for integration tests across the workspace.
+// Used by jayjay-gpui's component tests and (eventually) jayjay-core's
+// real_jj_repo.rs.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -7,7 +8,8 @@ use std::process::{Command, Output};
 
 use tempfile::TempDir;
 
-fn run_jj_in(repo: &Path, args: &[&str]) -> Output {
+/// Run `jj` rooted at `repo` and panic on non-zero exit.
+pub fn run_jj_in(repo: &Path, args: &[&str]) -> Output {
     let mut cmd = Command::new("jj");
     cmd.arg("-R").arg(repo).args(args);
     finish(cmd, args)
@@ -27,17 +29,18 @@ fn finish(mut cmd: Command, args: &[&str]) -> Output {
     output
 }
 
-/// `simple` jj repo: 3 describing changes ending in a working copy with two
-/// new files. Mirrors the `simple` fixture in `shell/justfile:ui-test-setup`.
-pub struct SimpleFixture {
+/// Linear history: 3 describing changes ending in a working copy with two new
+/// files. Mirrors the same-shaped fixture in `shell/justfile:ui-test-setup`
+/// so behavior parity with the SwiftUI UI tests is intentional.
+pub struct LinearFixture {
     _tmp: TempDir,
     pub path: PathBuf,
 }
 
-impl SimpleFixture {
+impl LinearFixture {
     pub fn build() -> Self {
         let tmp = tempfile::tempdir().expect("create tempdir");
-        let path = tmp.path().join("simple");
+        let path = tmp.path().join("repo");
 
         let mut init = Command::new("jj");
         init.arg("git").arg("init").arg("--colocate").arg(&path);

--- a/crates/jj-test-fixtures/src/linear.rs
+++ b/crates/jj-test-fixtures/src/linear.rs
@@ -1,0 +1,44 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use crate::cmd::{configure_test_user, init_colocated, run_jj_in};
+
+/// Linear history: 3 describing changes ending in a working copy with two new
+/// files. Mirrors the same-shaped fixture in `shell/justfile:ui-test-setup`
+/// so behavior parity with the SwiftUI UI tests is intentional.
+pub struct LinearFixture {
+    _tmp: TempDir,
+    pub path: PathBuf,
+}
+
+impl LinearFixture {
+    pub fn build() -> Self {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let path = tmp.path().join("repo");
+
+        init_colocated(&path);
+        configure_test_user(&path);
+
+        write(&path, "README.md", "# Sample project\n");
+        run_jj_in(&path, &["describe", "-m", "initial"]);
+
+        run_jj_in(&path, &["new", "-m", "add hello"]);
+        write(&path, "hello.txt", "hello\n");
+
+        run_jj_in(&path, &["new", "-m", "add feature"]);
+        write(&path, "feature.txt", "feature\n");
+        run_jj_in(&path, &["bookmark", "create", "main", "-r", "@"]);
+
+        run_jj_in(&path, &["new"]);
+        write(&path, "wip1.txt", "wip 1\n");
+        write(&path, "wip2.txt", "wip 2\n");
+
+        Self { _tmp: tmp, path }
+    }
+}
+
+fn write(repo: &Path, rel: &str, contents: &str) {
+    fs::write(repo.join(rel), contents).unwrap_or_else(|err| panic!("write {rel}: {err}"));
+}

--- a/justfile
+++ b/justfile
@@ -14,6 +14,7 @@ list:
   @echo "just test              Run Rust tests"
   @echo "just test-app          Run macOS app tests"
   @echo "just test-ui           Run macOS app UI tests (needs fixture — see shell/mac/Tests/JayJayUITests/Support/SceneBase.swift)"
+  @echo "just test-gpui         Run GPUI shell tests (component tests via gpui::test, needs jj on PATH)"
   @echo "just format            Format Rust and Swift sources"
   @echo "just lint              Lint Rust (clippy) and Swift (swiftlint)"
   @echo "just clean             Remove generated build artifacts"
@@ -32,6 +33,9 @@ test-app:
 
 test-ui:
   just shell::ui-test
+
+test-gpui:
+  cargo test -p jayjay-gpui
 
 build:
   just shell::build

--- a/shell/gpui/Cargo.toml
+++ b/shell/gpui/Cargo.toml
@@ -27,4 +27,4 @@ toml = { workspace = true }
 
 [dev-dependencies]
 gpui = { git = "https://github.com/zed-industries/zed", tag = "v1.0.1", features = ["test-support"] }
-tempfile = { workspace = true }
+jj-test-fixtures = { path = "../../crates/jj-test-fixtures" }

--- a/shell/gpui/Cargo.toml
+++ b/shell/gpui/Cargo.toml
@@ -24,3 +24,7 @@ notify = "8"
 flume = "0.12"
 serde = { workspace = true }
 toml = { workspace = true }
+
+[dev-dependencies]
+gpui = { git = "https://github.com/zed-industries/zed", tag = "v1.0.1", features = ["test-support"] }
+tempfile = { workspace = true }

--- a/shell/gpui/src/lib.rs
+++ b/shell/gpui/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod app;
+pub mod diff;
+pub mod log;
+pub mod repo;
+pub mod ui;
+pub mod windows;

--- a/shell/gpui/src/main.rs
+++ b/shell/gpui/src/main.rs
@@ -1,25 +1,15 @@
-mod app;
-mod diff;
-mod log;
-mod repo;
-mod ui;
-mod windows;
-
 use std::borrow::Cow;
 use std::path::PathBuf;
 
-use crate::app::config::AppConfig;
 use gpui::{
-    App, AppContext, Bounds, KeyBinding, Point, Size, TitlebarOptions, WindowBounds, WindowOptions,
-    px, size,
+    App, AppContext, Bounds, Focusable, KeyBinding, Point, Size, TitlebarOptions, WindowBounds,
+    WindowOptions, px, size,
 };
 
-use gpui::Focusable;
-
-use crate::app::actions::{CloseWindow, OpenCommandPalette, OpenFind, OpenSettings, Refresh};
-use crate::app::config::AppConfigStore;
-use crate::app::theme::Theme;
-use crate::log::LogView;
+use jayjay_gpui::app::actions::{CloseWindow, OpenCommandPalette, OpenFind, OpenSettings, Refresh};
+use jayjay_gpui::app::config::{AppConfig, AppConfigStore};
+use jayjay_gpui::app::theme::Theme;
+use jayjay_gpui::log::LogView;
 
 const PHOSPHOR_FONT: &[u8] = include_bytes!("../assets/fonts/Phosphor.ttf");
 
@@ -131,7 +121,7 @@ fn main() {
                     WindowBounds::Maximized(b) => (b, true),
                     WindowBounds::Fullscreen(b) => (b, false),
                 };
-                app::config::update(cx, move |c| {
+                jayjay_gpui::app::config::update(cx, move |c| {
                     c.window.x = f32::from(bounds.origin.x);
                     c.window.y = f32::from(bounds.origin.y);
                     c.window.width = f32::from(bounds.size.width);

--- a/shell/gpui/tests/repo_view_model.rs
+++ b/shell/gpui/tests/repo_view_model.rs
@@ -1,12 +1,3 @@
-//! Component tests for `RepoViewModel`.
-//!
-//! Pattern: spin up a `TestAppContext`, build a `RepoViewModel` against a real
-//! jj fixture, and assert state. This is the layer that catches write-milestone
-//! regressions — refresh propagation, mutation flows, async loaders — without
-//! needing pixels or a platform layer.
-//!
-//! Add new tests here (or in sibling files) as new view-model behavior lands.
-
 mod support;
 
 use gpui::{AppContext, TestAppContext};

--- a/shell/gpui/tests/repo_view_model.rs
+++ b/shell/gpui/tests/repo_view_model.rs
@@ -1,12 +1,10 @@
-mod support;
-
 use gpui::{AppContext, TestAppContext};
 use jayjay_gpui::repo::view_model::RepoViewModel;
-use support::SimpleFixture;
+use jj_test_fixtures::LinearFixture;
 
 #[gpui::test]
-fn opens_simple_fixture_with_working_copy_selected(cx: &mut TestAppContext) {
-    let fixture = SimpleFixture::build();
+fn opens_linear_fixture_with_working_copy_selected(cx: &mut TestAppContext) {
+    let fixture = LinearFixture::build();
 
     let vm = cx.new(|_| RepoViewModel::new(fixture.path.clone()));
 
@@ -15,7 +13,7 @@ fn opens_simple_fixture_with_working_copy_selected(cx: &mut TestAppContext) {
         assert!(vm.repo.is_some(), "repo handle should be populated");
         assert!(
             vm.graph.entries.len() >= 4,
-            "simple fixture should expose at least 4 changes (initial, hello, feature, wc), got {}",
+            "linear fixture should expose at least 4 changes (initial, hello, feature, wc), got {}",
             vm.graph.entries.len()
         );
         let selected_ix = vm.selected.expect("working copy should be selected");

--- a/shell/gpui/tests/repo_view_model.rs
+++ b/shell/gpui/tests/repo_view_model.rs
@@ -1,0 +1,42 @@
+//! Component tests for `RepoViewModel`.
+//!
+//! Pattern: spin up a `TestAppContext`, build a `RepoViewModel` against a real
+//! jj fixture, and assert state. This is the layer that catches write-milestone
+//! regressions — refresh propagation, mutation flows, async loaders — without
+//! needing pixels or a platform layer.
+//!
+//! Add new tests here (or in sibling files) as new view-model behavior lands.
+
+mod support;
+
+use gpui::{AppContext, TestAppContext};
+use jayjay_gpui::repo::view_model::RepoViewModel;
+use support::{SimpleFixture, jj_available};
+
+#[gpui::test]
+fn opens_simple_fixture_with_working_copy_selected(cx: &mut TestAppContext) {
+    if !jj_available() {
+        eprintln!("skipping: `jj`/`git` not on PATH");
+        return;
+    }
+    let fixture = SimpleFixture::build();
+
+    let vm = cx.new(|_| RepoViewModel::new(fixture.path.clone()));
+
+    vm.read_with(cx, |vm, _| {
+        assert!(vm.error.is_none(), "open errored: {:?}", vm.error);
+        assert!(vm.repo.is_some(), "repo handle should be populated");
+        assert!(
+            vm.graph.entries.len() >= 4,
+            "simple fixture should expose at least 4 changes (initial, hello, feature, wc), got {}",
+            vm.graph.entries.len()
+        );
+        let selected_ix = vm.selected.expect("working copy should be selected");
+        let selected = &vm.graph.entries[selected_ix].change;
+        assert!(
+            selected.is_working_copy,
+            "selected change should be the working copy, got {:?}",
+            selected.change_id
+        );
+    });
+}

--- a/shell/gpui/tests/repo_view_model.rs
+++ b/shell/gpui/tests/repo_view_model.rs
@@ -2,14 +2,10 @@ mod support;
 
 use gpui::{AppContext, TestAppContext};
 use jayjay_gpui::repo::view_model::RepoViewModel;
-use support::{SimpleFixture, jj_available};
+use support::SimpleFixture;
 
 #[gpui::test]
 fn opens_simple_fixture_with_working_copy_selected(cx: &mut TestAppContext) {
-    if !jj_available() {
-        eprintln!("skipping: `jj`/`git` not on PATH");
-        return;
-    }
     let fixture = SimpleFixture::build();
 
     let vm = cx.new(|_| RepoViewModel::new(fixture.path.clone()));

--- a/shell/gpui/tests/support/mod.rs
+++ b/shell/gpui/tests/support/mod.rs
@@ -1,28 +1,16 @@
-//! Test fixture helpers for gpui-shell integration tests.
-//!
-//! Mirrors the SwiftUI shell's `ui-test-setup` justfile target: builds a
-//! deterministic jj repo on disk so `RepoViewModel` and friends have something
-//! real to load. Each fixture lives in a `tempfile::TempDir` so tests are
-//! hermetic and parallel-safe.
-//!
-//! Tests skip gracefully when `jj` and `git` aren't on PATH — keeps `cargo test`
-//! green on machines without a jj install.
-//!
-//! Allow `dead_code` because individual integration test files only consume a
-//! subset of these helpers; Rust would otherwise warn per-test-binary.
+// Allow because individual integration test binaries only consume a subset.
 #![allow(dead_code)]
 
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+use std::sync::OnceLock;
 
 use tempfile::TempDir;
 
-/// Whether the host has both `jj` and `git` available. Tests that need a
-/// fixture should call this and `return` early when false so the suite stays
-/// green on bare runners (e.g. before CI installs jj).
 pub fn jj_available() -> bool {
-    cmd_runs("jj") && cmd_runs("git")
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| cmd_runs("jj") && cmd_runs("git"))
 }
 
 fn cmd_runs(program: &str) -> bool {
@@ -34,9 +22,14 @@ fn cmd_runs(program: &str) -> bool {
         .is_ok_and(|s| s.success())
 }
 
-fn run_jj(args: &[&str]) -> Output {
-    let output = Command::new("jj")
-        .args(args)
+fn run_jj_in(repo: &Path, args: &[&str]) -> Output {
+    let mut cmd = Command::new("jj");
+    cmd.arg("-R").arg(repo).args(args);
+    finish(cmd, args)
+}
+
+fn finish(mut cmd: Command, args: &[&str]) -> Output {
+    let output = cmd
         .output()
         .unwrap_or_else(|err| panic!("failed to spawn jj {args:?}: {err}"));
     if !output.status.success() {
@@ -49,9 +42,8 @@ fn run_jj(args: &[&str]) -> Output {
     output
 }
 
-/// A `simple` jj repo: three describing changes ending in a working copy with
-/// two new files. Mirrors the `simple` fixture in `shell/justfile:ui-test-setup`
-/// so behavior parity with the SwiftUI UI tests is intentional.
+/// `simple` jj repo: 3 describing changes ending in a working copy with two
+/// new files. Mirrors the `simple` fixture in `shell/justfile:ui-test-setup`.
 pub struct SimpleFixture {
     _tmp: TempDir,
     pub path: PathBuf,
@@ -61,22 +53,23 @@ impl SimpleFixture {
     pub fn build() -> Self {
         let tmp = tempfile::tempdir().expect("create tempdir");
         let path = tmp.path().join("simple");
-        let repo = path.to_str().expect("repo path utf-8");
 
-        run_jj(&["git", "init", "--colocate", repo]);
+        let mut init = Command::new("jj");
+        init.arg("git").arg("init").arg("--colocate").arg(&path);
+        finish(init, &["git", "init", "--colocate", "<repo>"]);
         configure_user(&path);
 
         write(&path, "README.md", "# Sample project\n");
-        run_jj(&["-R", repo, "describe", "-m", "initial"]);
+        run_jj_in(&path, &["describe", "-m", "initial"]);
 
-        run_jj(&["-R", repo, "new", "-m", "add hello"]);
+        run_jj_in(&path, &["new", "-m", "add hello"]);
         write(&path, "hello.txt", "hello\n");
 
-        run_jj(&["-R", repo, "new", "-m", "add feature"]);
+        run_jj_in(&path, &["new", "-m", "add feature"]);
         write(&path, "feature.txt", "feature\n");
-        run_jj(&["-R", repo, "bookmark", "create", "main", "-r", "@"]);
+        run_jj_in(&path, &["bookmark", "create", "main", "-r", "@"]);
 
-        run_jj(&["-R", repo, "new"]);
+        run_jj_in(&path, &["new"]);
         write(&path, "wip1.txt", "wip 1\n");
         write(&path, "wip2.txt", "wip 2\n");
 
@@ -85,19 +78,14 @@ impl SimpleFixture {
 }
 
 fn configure_user(repo: &Path) {
-    let repo_str = repo.to_str().expect("repo path utf-8");
-    run_jj(&[
-        "-R", repo_str, "config", "set", "--repo", "user.name", "Test User",
-    ]);
-    run_jj(&[
-        "-R",
-        repo_str,
-        "config",
-        "set",
-        "--repo",
-        "user.email",
-        "test@example.com",
-    ]);
+    run_jj_in(
+        repo,
+        &["config", "set", "--repo", "user.name", "Test User"],
+    );
+    run_jj_in(
+        repo,
+        &["config", "set", "--repo", "user.email", "test@example.com"],
+    );
 }
 
 fn write(repo: &Path, rel: &str, contents: &str) {

--- a/shell/gpui/tests/support/mod.rs
+++ b/shell/gpui/tests/support/mod.rs
@@ -3,24 +3,9 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output, Stdio};
-use std::sync::OnceLock;
+use std::process::{Command, Output};
 
 use tempfile::TempDir;
-
-pub fn jj_available() -> bool {
-    static AVAILABLE: OnceLock<bool> = OnceLock::new();
-    *AVAILABLE.get_or_init(|| cmd_runs("jj") && cmd_runs("git"))
-}
-
-fn cmd_runs(program: &str) -> bool {
-    Command::new(program)
-        .arg("--version")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|s| s.success())
-}
 
 fn run_jj_in(repo: &Path, args: &[&str]) -> Output {
     let mut cmd = Command::new("jj");

--- a/shell/gpui/tests/support/mod.rs
+++ b/shell/gpui/tests/support/mod.rs
@@ -1,0 +1,105 @@
+//! Test fixture helpers for gpui-shell integration tests.
+//!
+//! Mirrors the SwiftUI shell's `ui-test-setup` justfile target: builds a
+//! deterministic jj repo on disk so `RepoViewModel` and friends have something
+//! real to load. Each fixture lives in a `tempfile::TempDir` so tests are
+//! hermetic and parallel-safe.
+//!
+//! Tests skip gracefully when `jj` and `git` aren't on PATH — keeps `cargo test`
+//! green on machines without a jj install.
+//!
+//! Allow `dead_code` because individual integration test files only consume a
+//! subset of these helpers; Rust would otherwise warn per-test-binary.
+#![allow(dead_code)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+use tempfile::TempDir;
+
+/// Whether the host has both `jj` and `git` available. Tests that need a
+/// fixture should call this and `return` early when false so the suite stays
+/// green on bare runners (e.g. before CI installs jj).
+pub fn jj_available() -> bool {
+    cmd_runs("jj") && cmd_runs("git")
+}
+
+fn cmd_runs(program: &str) -> bool {
+    Command::new(program)
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+fn run_jj(args: &[&str]) -> Output {
+    let output = Command::new("jj")
+        .args(args)
+        .output()
+        .unwrap_or_else(|err| panic!("failed to spawn jj {args:?}: {err}"));
+    if !output.status.success() {
+        panic!(
+            "jj {args:?} failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+    output
+}
+
+/// A `simple` jj repo: three describing changes ending in a working copy with
+/// two new files. Mirrors the `simple` fixture in `shell/justfile:ui-test-setup`
+/// so behavior parity with the SwiftUI UI tests is intentional.
+pub struct SimpleFixture {
+    _tmp: TempDir,
+    pub path: PathBuf,
+}
+
+impl SimpleFixture {
+    pub fn build() -> Self {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let path = tmp.path().join("simple");
+        let repo = path.to_str().expect("repo path utf-8");
+
+        run_jj(&["git", "init", "--colocate", repo]);
+        configure_user(&path);
+
+        write(&path, "README.md", "# Sample project\n");
+        run_jj(&["-R", repo, "describe", "-m", "initial"]);
+
+        run_jj(&["-R", repo, "new", "-m", "add hello"]);
+        write(&path, "hello.txt", "hello\n");
+
+        run_jj(&["-R", repo, "new", "-m", "add feature"]);
+        write(&path, "feature.txt", "feature\n");
+        run_jj(&["-R", repo, "bookmark", "create", "main", "-r", "@"]);
+
+        run_jj(&["-R", repo, "new"]);
+        write(&path, "wip1.txt", "wip 1\n");
+        write(&path, "wip2.txt", "wip 2\n");
+
+        Self { _tmp: tmp, path }
+    }
+}
+
+fn configure_user(repo: &Path) {
+    let repo_str = repo.to_str().expect("repo path utf-8");
+    run_jj(&[
+        "-R", repo_str, "config", "set", "--repo", "user.name", "Test User",
+    ]);
+    run_jj(&[
+        "-R",
+        repo_str,
+        "config",
+        "set",
+        "--repo",
+        "user.email",
+        "test@example.com",
+    ]);
+}
+
+fn write(repo: &Path, rel: &str, contents: &str) {
+    fs::write(repo.join(rel), contents).unwrap_or_else(|err| panic!("write {rel}: {err}"));
+}


### PR DESCRIPTION
## Summary

Adds the third test layer for the GPUI shell — \`#[gpui::test]\` + \`TestAppContext\` component tests, the same pattern Zed and gpui-component use. Lets us land write-milestone regressions as code instead of as YOLO commits.

**Layer split now mirrors SwiftUI's:**

| Layer | SwiftUI | GPUI shell |
|---|---|---|
| Pure logic | \`just test\` (Rust unit) | \`just test\` (Rust unit) |
| Component | \`just test-app\` (XCTest) | \`just test-gpui\` (\`#[gpui::test]\`) — **new** |
| End-to-end | \`just test-ui\` (XCUITest) | _deferred — GPUI has no XCUITest analog_ |

## What lands

- **\`shell/gpui/src/lib.rs\`** exposes the internal modules so integration tests can reach them. \`main.rs\` becomes a thin binary entry consuming the lib via \`jayjay_gpui::...\`.
- **\`shell/gpui/tests/support/mod.rs\`** — per-test \`SimpleFixture\` builder using \`tempfile::TempDir\`. Mirrors \`shell/justfile:ui-test-setup\`'s \`simple\` fixture (3 commits + working copy with 2 new files). Hermetic, parallel-safe, skips gracefully when \`jj\`/\`git\` aren't on PATH.
- **\`shell/gpui/tests/repo_view_model.rs\`** — first test: \`RepoViewModel::new(simple_fixture())\` populates entries and selects the working copy. Establishes the pattern; future write-milestone PRs add tests next to their changes.
- **\`just test-gpui\`** + CLAUDE.md/AGENTS.md docs for the new pattern.
- **gpui-ci.yml installs \`jj\`** via \`taiki-e/install-action\` so the Linux job actually exercises the tests rather than silently skipping.

## Why no end-to-end layer?

GPUI has no public headless UI test driver — XCUITest's accessibility tree doesn't exist. Building one is months of work for marginal value when the component layer covers state-transition regressions. If we ever need pixel-level smoke tests, snapshot rendering is a future option.

## Test plan
- [x] \`cargo test --workspace\` — all suites green locally (jj available)
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`just test-gpui\` — passes
- [ ] gpui-ci.yml on Linux: \`taiki-e/install-action\` resolves \`jj\`, fixture builds, test runs (rather than skips)
- [ ] gpui-ci.yml on Windows: build still passes (no jj install — test will skip there, which is fine)