### PR TITLE
ci(nix): include assets/ in flake source filter

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -2,9 +2,6 @@ name: AppImage (Linux, nix)
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*'
 
 permissions:
   contents: read
@@ -26,6 +23,18 @@ jobs:
           extra-conf: |
             experimental-features = nix-command flakes
 
+      - name: Cache /nix/store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.nix', 'flake.lock', '**/Cargo.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 4G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+          purge-last-accessed: 0
+          purge-primary-key: never
+
       - name: Build AppImage
         run: nix build --print-build-logs .#appimage
 
@@ -36,7 +45,7 @@ jobs:
           ls -lh out/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: jayjay-gpui-x86_64.AppImage
           path: out/jayjay-gpui-x86_64.AppImage

--- a/flake.nix
+++ b/flake.nix
@@ -31,13 +31,25 @@
           zstd
         ];
 
+        # Keep cargo sources + shell/gpui/assets (include_bytes! at compile time).
+        src = pkgs.lib.cleanSourceWith {
+          src = pkgs.lib.cleanSource ./.;
+          filter = path: type:
+            (craneLib.filterCargoSources path type)
+            || (pkgs.lib.hasInfix "/assets/" path);
+          name = "source";
+        };
+
         commonArgs = {
-          src = craneLib.cleanCargoSource ./.;
+          inherit src;
           strictDeps = true;
           cargoExtraArgs = "-p jayjay-gpui";
 
           nativeBuildInputs = with pkgs; [ pkg-config clang ];
           buildInputs = runtimeDeps;
+
+          # Tests run in gpui-ci.yml; nix sandbox has no `jj` on PATH.
+          doCheck = false;
         };
 
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
@@ -46,8 +58,7 @@
           inherit cargoArtifacts;
           pname = "jayjay-gpui";
 
-          # Bake runtime lib paths into the binary so the AppImage finds Vulkan
-          # / Wayland / X11 after the closure is packaged.
+          # rpath so the AppImage finds the dlopen'd libs after bundling.
           postFixup = ''
             patchelf --set-rpath "${pkgs.lib.makeLibraryPath runtimeDeps}" \
               $out/bin/jayjay-gpui || true


### PR DESCRIPTION
## Summary

First AppImage CI run (https://github.com/hewigovens/jayjay/actions/runs/25495870533) failed at the build phase:
\`\`\`
error: couldn't read \`shell/gpui/src/../assets/fonts/Phosphor.ttf\`: No such file or directory
\`\`\`

\`craneLib.cleanCargoSource\` keeps only Rust/Cargo files and drops \`shell/gpui/assets/\`, but the binary \`include_bytes!\`s fonts at compile time. Replace with a custom \`cleanSourceWith\` filter that keeps cargo sources *and* anything under an \`assets/\` directory.

## Test plan
- [ ] CI workflow run on this branch goes green: \`gh workflow run appimage.yml --ref ci/nix-fix-assets\`
- [ ] AppImage artifact uploaded