### PR TITLE
deps: update jj-lib to 0.41

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,9 +2303,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gix"
-version = "0.81.0"
+version = "0.83.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0473c64d9ccbcfb9953a133b47c8b9a335b87ac6c52b983ee4b03d49000b0f3f"
+checksum = "6ce52001b946a6249d5d0d3011df0a042ac3f8a4d013460db6476577b0b9c567"
 dependencies = [
  "gix-actor",
  "gix-archive",
@@ -2360,21 +2360,20 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5e5b518339d5e6718af108fd064d4e9ba33caf728cf487352873d76411df35"
+checksum = "272916673b83714734b15d4ef3c8b5f1ccddb15fea8ff548430b97c1ab7b7ed8"
 dependencies = [
  "bstr",
  "gix-date",
  "gix-error",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-archive"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651c99be11aac9b303483193ae50b45eb6e094da4f5ed797019b03948f51aad6"
+checksum = "9a20ec244b733338d4cb60e5e05eac700dab7fcc689647b1d1daa9396b119342"
 dependencies = [
  "bstr",
  "gix-date",
@@ -2385,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c233d6eaa098c0ca5ce03236fd7a96e27f1abe72fad74b46003fbd11fe49563c"
+checksum = "fe17c5a1c0b6f2ef1476aa1d3222ea50cdff67608016613a58bfc3e078046000"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -2411,9 +2410,9 @@ dependencies = [
 
 [[package]]
 name = "gix-blame"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77aaf9f7348f4da3ebfbfbbc35fa0d07155d98377856198dde6f695fd648705"
+checksum = "14dab9a942ab54a9661ded7397c3bf927274e7afa94494db0d75cfcbde02ca0a"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -2440,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "gix-command"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae4bb9fa74c44c93f7238b08255f7f9afc158bafea4b95af665fa535352cd73c"
+checksum = "86335306511abe43d75c866d4b1f3d90932fe202edcd43e1314036333e7384d8"
 dependencies = [
  "bstr",
  "gix-path",
@@ -2453,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "gix-commitgraph"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3196655fd1443f3c58a48c114aa480be3e4e87b393d7292daaa0d543862eb445"
+checksum = "fe3b5aa0f24e19028c261d229aeeedafcaaa52ebd71021cc15184620fc9d32eb"
 dependencies = [
  "bstr",
  "gix-chunk",
@@ -2467,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "gix-config"
-version = "0.54.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08939b4c4ed7a663d0e64be9e1e9bdf23a1fb4fcee1febdf449f12229542e50d"
+checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -2478,18 +2477,16 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "memchr",
  "smallvec",
  "thiserror 2.0.18",
  "unicode-bom",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-config-value"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378c53ec3db049919edf91ff76f56f28886a8b4b4a5a9dc633108d84afc3675"
+checksum = "13b39ed39ee4c10a3b157f9fb94bac8098d9f8e56201f0cf7dee6c187416c4b2"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -2513,31 +2510,30 @@ dependencies = [
 
 [[package]]
 name = "gix-diff"
-version = "0.61.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88f3b3475e5d3877d7c30c40827cc2441936ce890efc226e5ba4afe3a7ae33f0"
+checksum = "dc08e0fa1a91ff5f24affeab052f198056645e1de004910bde7b82b50ea5982a"
 dependencies = [
  "bstr",
  "gix-command",
  "gix-filter",
  "gix-fs",
  "gix-hash",
+ "gix-imara-diff",
  "gix-object",
  "gix-path",
  "gix-tempfile",
  "gix-trace",
  "gix-traverse",
  "gix-worktree",
- "imara-diff 0.1.8",
- "imara-diff 0.2.0",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-dir"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da4604a360988f0ba8efe6f90093ca5a844f4a7f8e1a3dcda501ec44e600ea9"
+checksum = "32a0fc06e9e1e430cbf0a313666976d90f822f461a6525320427aa9b8af5236c"
 dependencies = [
  "bstr",
  "gix-discover",
@@ -2555,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "gix-discover"
-version = "0.49.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65bd3330fe0cb9d40d875bf862fd5e8ad6fa4164ddbc4842fbeb889c3f0b2c6"
+checksum = "17852e6a501e688a1702b24ebe5b3761d4719455bc869fd29f38b0b859bcad34"
 dependencies = [
  "bstr",
  "dunce",
@@ -2579,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "gix-features"
-version = "0.46.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "752493cd4b1d5eaaa0138a7493f65c96863fefa990fc021e0e519579e389ab20"
+checksum = "af375693ad5333d0a2c66b4c5b2cbe9ccc38e34f8e8bf24e4ae42c12307fdc4f"
 dependencies = [
  "bytes",
  "crc32fast",
@@ -2600,9 +2596,9 @@ dependencies = [
 
 [[package]]
 name = "gix-filter"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d37598282a6566da6fb52667570c7fe0aedcb122ac886724a9e62a2180523e35"
+checksum = "dac917dbe9653c9b615d248db91907a365bd779750c9e1b457a9d9fdeece3a08"
 dependencies = [
  "bstr",
  "encoding_rs",
@@ -2621,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.19.2"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a964b4aec683eb0bacb87533defa80805bb4768056371a47ab38b00a2d377b72"
+checksum = "1e1967daac9848757c47c2aef0c57bcadc1a897347f559778249bf286a536c86"
 dependencies = [
  "bstr",
  "fastrand 2.4.1",
@@ -2635,9 +2631,9 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
+checksum = "08bf29249a069bf2507f5964f80997f37b134d320ea348d66527726b9be2c38c"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -2647,9 +2643,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb896a02d9ab96fa518475a5f30ad3952010f801a8de5840f633f4a6b985dfb"
+checksum = "bcf70d1e252337eed16360f8b8ebb71865ece58eab7954b39ce38b420de703d2"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -2659,9 +2655,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2664216fc5e89b51e756a4a3ac676315602ce2dac07acf1da959a22038d69b33"
+checksum = "d33b455e07b3c16d3b2eeebc7b38d2dafcbf8a653de1138ef55d4c2a1fd0b08b"
 dependencies = [
  "gix-hash",
  "hashbrown 0.16.1",
@@ -2670,9 +2666,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ignore"
-version = "0.19.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f915dcf6911e3027537166d34e13f0fe101ed12225178d2ae29cd1272cff26"
+checksum = "6bb13fbbeeafee943e52b61fcc88dfddf6a452fcaf0c4d0cdc8f218fa25bbec5"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -2682,10 +2678,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "gix-index"
-version = "0.49.0"
+name = "gix-imara-diff"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bae54ab14e4e74d5dda60b82ea7afad7c8eb3be68283d6d5f29bd2e6d47fff7"
+checksum = "39eb0623e15e4cb83c02ce6a959e48fadd1ae3b715b36b5acc01816e01388c82"
+dependencies = [
+ "bstr",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c3ef97ad08121e4327a6226bd63fed6b9e3c6b976d48bddd4356d9d41191db"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -2711,9 +2717,9 @@ dependencies = [
 
 [[package]]
 name = "gix-lock"
-version = "21.0.2"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054fbd0989700c69dc5aa80bc66944f05df1e15aa7391a9e42aca7366337905f"
+checksum = "09b3bc074e5723027b482dcd9ab99d95804a53742f6de812d0172fbba4a186c1"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -2722,9 +2728,9 @@ dependencies = [
 
 [[package]]
 name = "gix-merge"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4606747466512d22c2dffc019142e1941238f543987ea51353c938cca80c500"
+checksum = "74bbcdcc52b70a32f0a151b024dff9d0fcf56ee48f00d9503e735af9d99ea881"
 dependencies = [
  "bstr",
  "gix-command",
@@ -2732,6 +2738,7 @@ dependencies = [
  "gix-filter",
  "gix-fs",
  "gix-hash",
+ "gix-imara-diff",
  "gix-index",
  "gix-object",
  "gix-path",
@@ -2741,16 +2748,15 @@ dependencies = [
  "gix-tempfile",
  "gix-trace",
  "gix-worktree",
- "imara-diff 0.1.8",
  "nonempty",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "gix-negotiate"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea064c7595eea08fdd01c70748af747d9acc40f727b61f4c8a2145a5c5fc28c"
+checksum = "103d42bfade1b8a96ca5005933127bdad461ce588d92422b2c2daa3ff20d780c"
 dependencies = [
  "bitflags 2.11.1",
  "gix-commitgraph",
@@ -2762,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.58.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafb802bb688a7c1e69ef965612ff5ff859f046bfb616377e4a0ba4c01e43d47"
+checksum = "a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -2772,20 +2778,18 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "gix-hashtable",
- "gix-path",
  "gix-utils",
  "gix-validate",
  "itoa",
  "smallvec",
  "thiserror 2.0.18",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-odb"
-version = "0.78.0"
+version = "0.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24833ae9323b4f7079575fb9f961cf9c414b0afbec428a536ab8e7dd93bc002b"
+checksum = "aeeda12a9663120418735ecdc1250d06eeab0be75700e47b3402a981331716ba"
 dependencies = [
  "arc-swap",
  "gix-features",
@@ -2796,6 +2800,7 @@ dependencies = [
  "gix-pack",
  "gix-path",
  "gix-quote",
+ "memmap2",
  "parking_lot",
  "tempfile",
  "thiserror 2.0.18",
@@ -2803,9 +2808,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pack"
-version = "0.68.0"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3484119cd19859d7d7639413c27e192478fa354d3f4ff5f7e3c041e8040f0f4"
+checksum = "daf02e6f5c8f07a069c9ea5245f40d9b14856ada4086091dc99941b49002b4fa"
 dependencies = [
  "clru",
  "gix-chunk",
@@ -2835,9 +2840,9 @@ dependencies = [
 
 [[package]]
 name = "gix-path"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8fd1fe596dc393b538e1d5492c5585971a9311475b3255f7b889023df208476"
+checksum = "671a6059e8a4c1b7f406e24716499cefa3926e060876fb1959ef225efeee346e"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -2847,9 +2852,9 @@ dependencies = [
 
 [[package]]
 name = "gix-pathspec"
-version = "0.16.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89611f13544ca5ebeb68a502673814ef57200df60c24a61c2ce7b96f612f08b"
+checksum = "2a84a4f083dd70fb49f4377e13afa6d90df2daaa1c705c49d6ff1331fc7e8855"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -2862,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "gix-protocol"
-version = "0.59.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38666350736b5877c79f57ddae02bde07a4ce186d889adc391e831cddcbe76"
+checksum = "aa4bee82db63ec635996b96efae71cf467c155fa3f34a556184373224a26c4fd"
 dependencies = [
  "bstr",
  "gix-date",
@@ -2877,7 +2882,6 @@ dependencies = [
  "maybe-async",
  "nonempty",
  "thiserror 2.0.18",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -2893,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.61.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2159978abb99b7027c8579d15211e262ef0ef2594d5cecb3334fbcbdfe2997c"
+checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -2909,14 +2913,13 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror 2.0.18",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-refspec"
-version = "0.39.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc806ee13f437428f8a1ba4c72ecfaa3f20e14f5f0d4c2bc17d0b33e794aa6ac"
+checksum = "61755b27d57edc8940a1b1593c8c61548ca8e4c02da1ed8d5bfeda9eb2a6b761"
 dependencies = [
  "bstr",
  "gix-error",
@@ -2930,9 +2933,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revision"
-version = "0.43.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c08f1ec5d1e6a524f8ba291c41f0ccaef64e48ed0e8cf790b3461cae45f6d3d"
+checksum = "1fb5288fac706d3ea3e4e2ba9ec38b78743b8c02f422e18cb342299cfd6ab7e8"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -2948,9 +2951,9 @@ dependencies = [
 
 [[package]]
 name = "gix-revwalk"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4b2b87772b21ca449249e86d32febadba5cba32b0fcce804ab9cefc6f2111c"
+checksum = "313813706b073a12ff7f9b2896bf3e6504cdac7cfbc97b1920114724705069f0"
 dependencies = [
  "gix-commitgraph",
  "gix-date",
@@ -2964,9 +2967,9 @@ dependencies = [
 
 [[package]]
 name = "gix-sec"
-version = "0.13.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283f4a746c9bde8550be63e6f961ff4651f412ca12666e8f5615f39464960ab9"
+checksum = "f5a3a2d3e504a238136751e646a6c028252286a0ea64ea9974bf0498633407c6"
 dependencies = [
  "bitflags 2.11.1",
  "gix-path",
@@ -2976,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "gix-shallow"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf60711c9083b2364b3fac8a352444af76b17201f3682fdebe74fa66d89a772"
+checksum = "29187305521bfacf4aefd284ab28dbfa9fb74abd39a5e63dd313b1baa5808c27"
 dependencies = [
  "bstr",
  "gix-hash",
@@ -2989,9 +2992,9 @@ dependencies = [
 
 [[package]]
 name = "gix-status"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d6c598e3fdbc352fba1c5ba7e709e69402fafbc44d9295edad2e3c4738996b"
+checksum = "68c6d2a8c521ffa205fe7e268c82e6d1378ba37cd826ca10ab6129fdc29a4b65"
 dependencies = [
  "bstr",
  "filetime",
@@ -3012,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "gix-submodule"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce5c3929c5e6821f651d35e8420f72fea3cfafe9fc1e928a61e718b462c72a5"
+checksum = "9fd5fc8692890bd71a596e540fd4c364f8460eaa82c4eaaedebde6e1e3eb4d91"
 dependencies = [
  "bstr",
  "gix-config",
@@ -3027,9 +3030,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "21.0.2"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22227f6b203f511ff451c33c89899e87e4f571fc596b06f68e6e613a6508528"
+checksum = "691ea1e31435c7e7d4d04705ec9d1c0d9482c46b2acf512bc723939d8f0af7fb"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -3046,9 +3049,9 @@ checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
 
 [[package]]
 name = "gix-transport"
-version = "0.55.1"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a521e39c6235ce63ed6c001e2dd79818c830b82c3b7b59247ee7b229c39ec9bb"
+checksum = "ffd6a5c676b92d4ead5f5a2b2935024415dec69edc997b6090ca9cac010a3018"
 dependencies = [
  "bstr",
  "gix-command",
@@ -3062,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "gix-traverse"
-version = "0.55.0"
+version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963dc2afcdb611092aa587c3f9365e749ac0a0892ff27662dbc75f26c953fbec"
+checksum = "a14b7052c0786676c03e71fcfde7d7f0f8e8316e642b5cec6bb3998719b2ce5c"
 dependencies = [
  "bitflags 2.11.1",
  "gix-commitgraph",
@@ -3079,9 +3082,9 @@ dependencies = [
 
 [[package]]
 name = "gix-url"
-version = "0.35.3"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a61ead12e33fa52ae92b207ee27554f646a8e7a3dad8b78da1582ec91eda0a6"
+checksum = "35842d099e813f6f6bba529e88d4670572149c3df79b7a412952259887721ece"
 dependencies = [
  "bstr",
  "gix-path",
@@ -3111,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6bd5830cbc43c9c00918b826467d2afad685b195cb82329cde2b2d116d2c578"
+checksum = "d69955eb5e2910832f88d041964b809eee01dadd579237e0b55efec58fd406fd"
 dependencies = [
  "bstr",
  "gix-attributes",
@@ -3129,9 +3132,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-state"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644a1681f96e1be43c2a8384337d9d220e7624f50db54beda70997052aebf707"
+checksum = "8a96dccbcf9e8fe0291c55f06e08da93ebb2e691c1311276f541eefcc6d70800"
 dependencies = [
  "bstr",
  "gix-features",
@@ -3147,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "gix-worktree-stream"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e3fb70a1f650a5cec7d5b8d10d6d6fe86daf3cf15bde08ba0c70988a2932c3"
+checksum = "9a8444b8ed4662e1a0c97f3eceda29630001a1bbb2632201e50312623e594213"
 dependencies = [
  "gix-attributes",
  "gix-error",
@@ -3891,22 +3894,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ignore"
-version = "0.4.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
-dependencies = [
- "crossbeam-deque",
- "globset",
- "log",
- "memchr",
- "regex-automata",
- "same-file",
- "walkdir",
- "winapi-util",
-]
-
-[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3945,25 +3932,6 @@ name = "imagesize"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
-
-[[package]]
-name = "imara-diff"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "imara-diff"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f01d462f766df78ab820dd06f5eb700233c51f0f4c2e846520eaf4ba6aa5c5c"
-dependencies = [
- "hashbrown 0.15.5",
- "memchr",
-]
 
 [[package]]
 name = "imgref"
@@ -4235,9 +4203,9 @@ dependencies = [
 
 [[package]]
 name = "jj-lib"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8eadc56d459f48a58adcbdb66309b9d981f16816cc388cf91f27fd4fc4602a"
+checksum = "39b88d4463d0f0d5542b5b746cd0c3c3fa69d7fdbdfbe45e22bdb737fc47fa53"
 dependencies = [
  "async-trait",
  "blake2",
@@ -4250,9 +4218,9 @@ dependencies = [
  "etcetera",
  "futures",
  "gix",
+ "gix-ignore",
  "globset",
- "hashbrown 0.16.1",
- "ignore",
+ "hashbrown 0.17.0",
  "indexmap",
  "interim",
  "itertools 0.14.0",
@@ -4283,9 +4251,9 @@ dependencies = [
 
 [[package]]
 name = "jj-lib-proc-macros"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e408043812a3da5b593e791e57e06ddaeffa041ee34e99b4bea4df84c734e8e5"
+checksum = "a57bb4bbead2b2c6087d1b403e83b962d9da17a7c838aecc93646fcd047c29e4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ license = "Apache-2.0"
 repository = "https://github.com/hewigovens/jayjay"
 
 [workspace.dependencies]
-jj-lib = "0.40"
-gix = { version = "0.81", default-features = false }
+jj-lib = "0.41.0"
+gix = { version = "0.83.0", default-features = false }
 uniffi = "0.31"
 clap = { version = "4", features = ["derive"] }
 thiserror = "2"
@@ -20,7 +20,7 @@ tempfile = "3"
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha2 = "0.10"
+sha2 = "0.10.9"
 hex = "0.4"
 similar = "3"
 toml = "1.1"

--- a/crates/jayjay-core/src/repo/evolog.rs
+++ b/crates/jayjay-core/src/repo/evolog.rs
@@ -1,7 +1,9 @@
+use futures::StreamExt as _;
 use jj_lib::evolution::CommitEvolutionEntry;
 use jj_lib::evolution::walk_predecessors;
 use jj_lib::hex_util::encode_reverse_hex;
 use jj_lib::object_id::ObjectId;
+use pollster::FutureExt as _;
 
 use super::Repo;
 use crate::types::*;
@@ -12,7 +14,9 @@ impl Repo {
         let repo = self.get_repo();
         let head = self.resolve_commit(&repo, rev)?;
         let mut entries = Vec::new();
-        for result in walk_predecessors(repo.as_ref(), &[head.id().clone()]) {
+        let stream = walk_predecessors(repo.as_ref(), &[head.id().clone()]);
+        futures::pin_mut!(stream);
+        while let Some(result) = stream.as_mut().next().block_on() {
             let entry = result.map_err(|e| CoreError::Internal {
                 message: format!("walk evolog: {e}"),
             })?;
@@ -33,12 +37,7 @@ fn to_dto(entry: &CommitEvolutionEntry) -> EvologEntry {
         }
         None => (commit.author().timestamp.timestamp.0, "rewrite".to_owned()),
     };
-    let description = commit
-        .description()
-        .lines()
-        .next()
-        .unwrap_or("")
-        .to_owned();
+    let description = commit.description().lines().next().unwrap_or("").to_owned();
     EvologEntry {
         change_id,
         commit_id,

--- a/crates/jayjay-core/src/repo/log.rs
+++ b/crates/jayjay-core/src/repo/log.rs
@@ -1,12 +1,16 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use futures::StreamExt as _;
 use jj_lib::git::REMOTE_NAME_FOR_LOCAL_GIT_REPO;
 use jj_lib::object_id::ObjectId;
 use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as _;
-use jj_lib::revset::{self, RevsetDiagnostics, RevsetParseContext, SymbolResolver, UserRevsetExpression};
+use jj_lib::revset::{
+    self, RevsetDiagnostics, RevsetParseContext, SymbolResolver, UserRevsetExpression,
+};
 use jj_lib::time_util::DatePatternContext;
+use pollster::FutureExt as _;
 
 use super::Repo;
 use crate::types::*;
@@ -32,9 +36,10 @@ impl Repo {
     ) -> CoreResult<Vec<ChangeInfo>> {
         let immutable_ids = self.immutable_commit_ids(repo);
         let mut changes = Vec::new();
-        for result in revset.iter() {
+        let mut stream = revset.stream();
+        while let Some(result) = stream.next().block_on() {
             let commit_id = result.map_err(|e| CoreError::Internal {
-                message: format!("revset iter: {e}"),
+                message: format!("revset stream: {e}"),
             })?;
             let commit = repo
                 .store()
@@ -43,12 +48,7 @@ impl Repo {
                     message: format!("get commit: {e}"),
                 })?;
             if self.should_include_in_log(repo, &commit) {
-                changes.push(self.commit_to_change_info(
-                    repo,
-                    &commit,
-                    Some(&immutable_ids),
-                    None,
-                ));
+                changes.push(self.commit_to_change_info(repo, &commit, Some(&immutable_ids), None));
             }
         }
         Self::mark_divergent(&mut changes);
@@ -61,9 +61,10 @@ impl Repo {
         let revset_result = self.evaluate_revset(&repo, revset_str)?;
 
         let mut entries = Vec::new();
-        for result in revset_result.iter_graph() {
+        let mut stream = revset_result.stream_graph();
+        while let Some(result) = stream.next().block_on() {
             let (commit_id, edge_list) = result.map_err(|e| CoreError::Internal {
-                message: format!("graph iter: {e}"),
+                message: format!("graph stream: {e}"),
             })?;
             let commit = repo
                 .store()
@@ -105,15 +106,17 @@ impl Repo {
         &self,
         repo: &std::sync::Arc<jj_lib::repo::ReadonlyRepo>,
     ) -> HashSet<String> {
-        self.evaluate_revset(repo, "immutable()")
-            .map(|result| {
-                result
-                    .iter()
-                    .filter_map(|r| r.ok())
-                    .map(|id| id.hex())
-                    .collect()
-            })
-            .unwrap_or_default()
+        let Ok(result) = self.evaluate_revset(repo, "immutable()") else {
+            return HashSet::new();
+        };
+        let mut stream = result.stream();
+        let mut ids = HashSet::new();
+        while let Some(result) = stream.next().block_on() {
+            if let Ok(id) = result {
+                ids.insert(id.hex());
+            }
+        }
+        ids
     }
 
     /// Find change IDs that appear more than once in the given changes.

--- a/crates/jayjay-core/src/repo/resolve.rs
+++ b/crates/jayjay-core/src/repo/resolve.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use futures::StreamExt as _;
 use jj_lib::commit::Commit as JjCommit;
 use jj_lib::fileset::FilesetAliasesMap;
 use jj_lib::git::REMOTE_NAME_FOR_LOCAL_GIT_REPO;
@@ -17,6 +18,7 @@ use jj_lib::revset::{
 use jj_lib::settings::UserSettings;
 use jj_lib::str_util::StringExpression;
 use jj_lib::time_util::DatePatternContext;
+use pollster::FutureExt as _;
 
 use super::Repo;
 use crate::types::*;
@@ -229,14 +231,15 @@ impl Repo {
                 message: format!("revset eval: {e}"),
             })?;
 
-        let commit_id = revset
-            .iter()
+        let mut stream = revset.stream();
+        let commit_id = stream
             .next()
+            .block_on()
             .ok_or_else(|| CoreError::RevNotFound {
                 rev: rev.to_owned(),
             })?
             .map_err(|e| CoreError::Internal {
-                message: format!("revset iter: {e}"),
+                message: format!("revset stream: {e}"),
             })?;
 
         repo.store()

--- a/crates/jayjay-core/src/repo/working_copy.rs
+++ b/crates/jayjay-core/src/repo/working_copy.rs
@@ -58,11 +58,7 @@ impl Repo {
                 })?;
 
         let mut locked_ws =
-            workspace
-                .start_working_copy_mutation()
-                .map_err(|e| CoreError::Internal {
-                    message: format!("lock working copy: {e}"),
-                })?;
+            block_on_result("lock working copy", workspace.start_working_copy_mutation())?;
 
         let snapshot_options = SnapshotOptions {
             base_ignores: base_git_ignores(&repo, &self.path)?,

--- a/crates/jayjay-core/src/repo/working_copy_ignore.rs
+++ b/crates/jayjay-core/src/repo/working_copy_ignore.rs
@@ -8,7 +8,7 @@ use jj_lib::gitignore::GitIgnoreFile;
 use jj_lib::merged_tree::MergedTree;
 use jj_lib::ref_name::WorkspaceName;
 use jj_lib::repo::{ReadonlyRepo, Repo as _};
-use jj_lib::repo_path::RepoPathBuf;
+use jj_lib::repo_path::{RepoPath, RepoPathBuf};
 
 use super::environment;
 use super::support::block_on_result;
@@ -83,13 +83,15 @@ impl WorkingCopyIgnoreMatcher {
             return Ok(true);
         }
 
-        let ignores = self.ignores_for_parent_dirs(&components, cache)?;
+        let (ignores, parent_ignored) = self.ignores_for_parent_dirs(&components, cache)?;
         let path = components.join("/");
-        let matches = if event_path.is_dir() {
-            ignores.matches(&format!("{path}/"))
-        } else {
-            ignores.matches(&path)
-        };
+        let repo_path = repo_path_from_internal(&path)?;
+        let matches = parent_ignored
+            || if event_path.is_dir() {
+                ignores.matches_dir(&repo_path)
+            } else {
+                ignores.matches_file(&repo_path)
+            };
         if !matches {
             return Ok(false);
         }
@@ -116,42 +118,45 @@ impl WorkingCopyIgnoreMatcher {
         &self,
         components: &[&str],
         cache: &mut HashMap<String, Arc<GitIgnoreFile>>,
-    ) -> CoreResult<Arc<GitIgnoreFile>> {
-        let mut prefix = String::new();
-        let mut ignores = match cache.get(&prefix) {
+    ) -> CoreResult<(Arc<GitIgnoreFile>, bool)> {
+        let mut prefix_key = String::new();
+        let mut ignores = match cache.get(&prefix_key) {
             Some(cached) => cached.clone(),
             None => {
                 let chain = chain_ignore_file_at(
                     self.base_ignores.clone(),
-                    "",
+                    RepoPath::root(),
                     self.workspace_root.join(".gitignore"),
                 )?;
-                cache.insert(prefix.clone(), chain.clone());
+                cache.insert(prefix_key.clone(), chain.clone());
                 chain
             }
         };
         let mut disk_dir = self.workspace_root.clone();
 
         for component in components.iter().take(components.len().saturating_sub(1)) {
-            let dir_path = format!("{prefix}{component}/");
-            if ignores.matches(&dir_path) {
-                return Ok(ignores);
+            if !prefix_key.is_empty() {
+                prefix_key.push('/');
+            }
+            prefix_key.push_str(component);
+
+            let dir_path = repo_path_from_internal(&prefix_key)?;
+            if ignores.matches_dir(&dir_path) {
+                return Ok((ignores, true));
             }
             disk_dir.push(component);
-            prefix.push_str(component);
-            prefix.push('/');
-            ignores = match cache.get(&prefix) {
+            ignores = match cache.get(&prefix_key) {
                 Some(cached) => cached.clone(),
                 None => {
                     let chain =
-                        chain_ignore_file_at(ignores, &prefix, disk_dir.join(".gitignore"))?;
-                    cache.insert(prefix.clone(), chain.clone());
+                        chain_ignore_file_at(ignores, &dir_path, disk_dir.join(".gitignore"))?;
+                    cache.insert(prefix_key.clone(), chain.clone());
                     chain
                 }
             };
         }
 
-        Ok(ignores)
+        Ok((ignores, false))
     }
 
     fn path_is_tracked(&self, relative: &Path) -> CoreResult<bool> {
@@ -209,12 +214,12 @@ fn chain_ignore_file(
     ignores: Arc<GitIgnoreFile>,
     path: impl Into<PathBuf>,
 ) -> CoreResult<Arc<GitIgnoreFile>> {
-    chain_ignore_file_at(ignores, "", path)
+    chain_ignore_file_at(ignores, RepoPath::root(), path)
 }
 
 fn chain_ignore_file_at(
     ignores: Arc<GitIgnoreFile>,
-    prefix: &str,
+    prefix: &RepoPath,
     path: impl Into<PathBuf>,
 ) -> CoreResult<Arc<GitIgnoreFile>> {
     ignores
@@ -222,4 +227,10 @@ fn chain_ignore_file_at(
         .map_err(|e| CoreError::Internal {
             message: format!("process git ignore file: {e}"),
         })
+}
+
+fn repo_path_from_internal(path: &str) -> CoreResult<RepoPathBuf> {
+    RepoPathBuf::from_internal_string(path).map_err(|e| CoreError::Internal {
+        message: format!("parse repo path {path}: {e}"),
+    })
 }


### PR DESCRIPTION
## Summary

Updates the Rust core dependency set for `jj-lib` 0.41 and `gix` 0.83 while keeping `sha2` aligned on 0.10.9.

## Details

- Adapts revset and evolution traversal to jj-lib's stream-based APIs while keeping the UniFFI surface synchronous for these non-`Send` local streams.
- Updates working-copy mutation locking for the async jj-lib API.
- Updates gitignore handling for the new `GitIgnoreFile` API and preserves ignored-parent-directory behavior for watcher filtering.
- Avoids including the separate GPUI/Nix `flake.nix` work in this PR.

## Validation

- `cargo check --workspace`
- `just build`
- `just test`
- `just lint`
