### PR TITLE
chore: harden release archive packaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Releases are not complete after `just release` alone. The full release flow is:
 1. Bump version and build number in **all four** sources: `shell/mac/project.yml`, `shell/mac/JayJay.xcodeproj/project.pbxproj`, `crates/jayjay-cli/Cargo.toml`, and `shell/justfile` (the last one is hardcoded — easy to forget).
 2. **Write release notes to `releases/<version>.html`** (HTML body, no wrapper tags). `update-appcast.py` reads this file and embeds it as the `<description>` block in the appcast entry. Releases without a notes file print a warning and ship without a description — never acceptable for a published release.
 3. Run `just build` to verify the release version still builds cleanly.
-4. Run `just release` to build, sign, notarize, zip, produce the SHA-256, and prepend the entry to `docs/appcast.xml`. This step only touches the local repo — no GitHub or tap changes yet.
+4. Run `just release` to build, sign, notarize, zip, verify the extracted archive with `codesign`, `stapler validate`, and `spctl -av`, produce the SHA-256, and prepend the entry to `docs/appcast.xml`. This step only touches the local repo — no GitHub or tap changes yet.
 5. Commit the version bumps + `releases/<version>.html` + `docs/appcast.xml` change as `release: <version> (build N)`.
 6. Create and push the `v<version>` git tag from the release commit. `just shell::publish` uses `gh release create --verify-tag` and will abort if the tag is missing on the remote.
 7. Run `just shell::publish` to create the public GitHub release, upload the zip, verify that the Sparkle asset URL is publicly reachable, and rewrite `../tap/Casks/jayjay.rb` with the new `version "X.Y.Z,build"` and `sha256`. The release notes come from `releases/<version>.html`.

--- a/scripts/package-release-zip.sh
+++ b/scripts/package-release-zip.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: package-release-zip.sh <app_path> <zip_path>" >&2
+    exit 2
+fi
+
+app_path="$1"
+zip_path="$2"
+
+if [[ ! -d "$app_path" ]]; then
+    echo "Error: app bundle not found: $app_path" >&2
+    exit 1
+fi
+
+appledouble_file="$(find "$app_path" -name '._*' -print -quit)"
+if [[ -n "$appledouble_file" ]]; then
+    echo "Error: refusing to package AppleDouble file inside app bundle: $appledouble_file" >&2
+    exit 1
+fi
+
+macosx_dir="$(find "$app_path" -name '__MACOSX' -type d -print -quit)"
+if [[ -n "$macosx_dir" ]]; then
+    echo "Error: refusing to package metadata directory inside app bundle: $macosx_dir" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$zip_path")"
+rm -f "$zip_path"
+
+# --norsrc is required for signed app bundles: default ditto zip mode stores
+# resource-fork metadata as ._* entries, which can break nested framework seals
+# after extraction.
+COPYFILE_DISABLE=1 ditto -c -k --norsrc --keepParent "$app_path" "$zip_path"
+
+zip_listing="$(zipinfo -1 "$zip_path")"
+metadata_entry="$(
+    printf '%s\n' "$zip_listing" | grep -E '(^|/)\._|(^|/)__MACOSX(/|$)' | head -n 1 || true
+)"
+if [[ -n "$metadata_entry" ]]; then
+    echo "Error: archive contains AppleDouble metadata entry: $metadata_entry" >&2
+    exit 1
+fi
+
+echo "Created $zip_path ($(du -sh "$zip_path" | cut -f1))"
+shasum -a 256 "$zip_path"

--- a/scripts/verify-release-archive.sh
+++ b/scripts/verify-release-archive.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Usage: verify-release-archive.sh <zip_path> [signed|notarized]" >&2
+    exit 2
+fi
+
+zip_path="$1"
+mode="${2:-signed}"
+
+case "$mode" in
+    signed | notarized) ;;
+    *)
+        echo "Error: mode must be 'signed' or 'notarized', got '$mode'" >&2
+        exit 2
+        ;;
+esac
+
+if [[ ! -f "$zip_path" ]]; then
+    echo "Error: archive not found: $zip_path" >&2
+    exit 1
+fi
+
+zip_listing="$(zipinfo -1 "$zip_path")"
+metadata_entry="$(
+    printf '%s\n' "$zip_listing" | grep -E '(^|/)\._|(^|/)__MACOSX(/|$)' | head -n 1 || true
+)"
+if [[ -n "$metadata_entry" ]]; then
+    echo "Error: archive contains AppleDouble metadata entry: $metadata_entry" >&2
+    exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+ditto -x -k "$zip_path" "$tmp_dir"
+
+apps=()
+while IFS= read -r -d '' app; do
+    apps+=("$app")
+done < <(find "$tmp_dir" -maxdepth 1 -type d -name '*.app' -print0)
+
+if [[ "${#apps[@]}" -ne 1 ]]; then
+    echo "Error: expected one top-level .app in archive, found ${#apps[@]}" >&2
+    exit 1
+fi
+
+app_path="${apps[0]}"
+
+appledouble_file="$(find "$app_path" -name '._*' -print -quit)"
+if [[ -n "$appledouble_file" ]]; then
+    echo "Error: extracted app contains AppleDouble file: $appledouble_file" >&2
+    exit 1
+fi
+
+macosx_dir="$(find "$app_path" -name '__MACOSX' -type d -print -quit)"
+if [[ -n "$macosx_dir" ]]; then
+    echo "Error: extracted app contains metadata directory: $macosx_dir" >&2
+    exit 1
+fi
+
+codesign --verify --deep --strict --verbose=2 "$app_path"
+
+if [[ "$mode" == "notarized" ]]; then
+    xcrun stapler validate "$app_path"
+    spctl --assess --type execute --verbose "$app_path"
+fi
+
+echo "Verified $zip_path ($mode)"

--- a/shell/release.just
+++ b/shell/release.just
@@ -34,20 +34,18 @@ release: ffi-release
   codesign --verify --deep --strict --verbose=2 "$app_path"
   # 3. Notarize
   mkdir -p "{{release_dir}}"
-  rm -f "{{release_dir}}/{{app_name}}-{{version}}.zip"
-  ditto -c -k --keepParent "{{derived_data}}/Build/Products/Release/{{app_name}}.app" \
+  bash "{{root}}/scripts/package-release-zip.sh" "$app_path" \
     "{{release_dir}}/{{app_name}}-{{version}}.zip"
   echo "Submitting for notarization with profile ${notary_profile}..."
   xcrun notarytool submit "{{release_dir}}/{{app_name}}-{{version}}.zip" \
     --keychain-profile "${notary_profile}" --wait
-  xcrun stapler staple "{{derived_data}}/Build/Products/Release/{{app_name}}.app"
-  xcrun stapler validate "{{derived_data}}/Build/Products/Release/{{app_name}}.app"
+  xcrun stapler staple "$app_path"
+  xcrun stapler validate "$app_path"
   # 4. Re-zip stapled app + sha256
-  rm -f "{{release_dir}}/{{app_name}}-{{version}}.zip"
-  ditto -c -k --keepParent "{{derived_data}}/Build/Products/Release/{{app_name}}.app" \
+  bash "{{root}}/scripts/package-release-zip.sh" "$app_path" \
     "{{release_dir}}/{{app_name}}-{{version}}.zip"
-  echo "Created notarized {{release_dir}}/{{app_name}}-{{version}}.zip"
-  shasum -a 256 "{{release_dir}}/{{app_name}}-{{version}}.zip"
+  bash "{{root}}/scripts/verify-release-archive.sh" \
+    "{{release_dir}}/{{app_name}}-{{version}}.zip" notarized
 
   # 5. Generate Sparkle appcast
   zip_path="{{release_dir}}/{{app_name}}-{{version}}.zip"
@@ -157,7 +155,11 @@ release-dry-run: ffi-release
   cp -R "{{derived_data}}/Build/Products/Release/{{app_name}}.app" "{{release_dir}}/"
   codesign --force --sign - "{{release_dir}}/{{app_name}}.app"
   # 3. Create zip + sha256 (no notarization)
-  cd "{{release_dir}}" && ditto -c -k --keepParent "{{app_name}}.app" "{{app_name}}-{{version}}.zip"
+  bash "{{root}}/scripts/package-release-zip.sh" \
+    "{{release_dir}}/{{app_name}}.app" \
+    "{{release_dir}}/{{app_name}}-{{version}}.zip"
+  bash "{{root}}/scripts/verify-release-archive.sh" \
+    "{{release_dir}}/{{app_name}}-{{version}}.zip" signed
   shasum -a 256 "{{release_dir}}/{{app_name}}-{{version}}.zip" | cut -d' ' -f1 > "{{release_dir}}/{{app_name}}-{{version}}.zip.sha256"
   @echo "Dry run release: {{release_dir}}/{{app_name}}-{{version}}.zip"
   @cat "{{release_dir}}/{{app_name}}-{{version}}.zip.sha256"


### PR DESCRIPTION
## Summary
- Extract zip packaging and post-zip verification from `shell/release.just` into two reusable scripts:
  - `scripts/package-release-zip.sh` — wraps `ditto -c -k --keepParent` with consistent input/output handling.
  - `scripts/verify-release-archive.sh` — extracts the archive and runs `codesign --verify`, `stapler validate`, and `spctl -av` on the result (mode-gated: `signed` vs `notarized`).
- `just release` and `just release-dry` now call the scripts, so dry-run and the real release flow share packaging + verification logic.
- `AGENTS.md` release pipeline doc updated to reflect that step 4 now verifies the extracted archive before computing the SHA-256.

Carved out of #46 so we can publish a new release on top of this branch.

## Test plan
- [ ] `just release-dry` produces a verified signed zip locally.
- [ ] `just release` (notarized path) produces a verified notarized zip on the release machine.