### PR TITLE
feat(bookmarks): surface untracked remote bookmarks in Bookmark Manager

### DIFF
--- a/crates/jayjay-core/src/repo/bookmarks.rs
+++ b/crates/jayjay-core/src/repo/bookmarks.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use jj_lib::hex_util::encode_reverse_hex;
 use jj_lib::object_id::ObjectId;
@@ -13,7 +13,9 @@ impl Repo {
     pub fn list_bookmarks(&self) -> CoreResult<Vec<BookmarkInfo>> {
         let repo = self.get_repo();
         let mut bookmarks = Vec::new();
+        let mut local_names: HashSet<String> = HashSet::new();
         for (name, target) in repo.view().local_bookmarks() {
+            local_names.insert(name.as_str().to_owned());
             let remote_refs: Vec<_> = repo
                 .view()
                 .all_remote_bookmarks()
@@ -33,33 +35,64 @@ impl Repo {
                 .into_iter()
                 .collect();
 
-            let is_conflicted = target.has_conflict();
-            let is_deleted = target.is_absent();
-
-            let (change_id, description) = if let Some(commit_id) = target.as_normal() {
-                match repo.store().get_commit(commit_id) {
-                    Ok(commit) => (
-                        encode_reverse_hex(commit.change_id().as_bytes()),
-                        commit.description().lines().next().unwrap_or("").to_owned(),
-                    ),
-                    Err(_) => (String::new(), String::new()),
-                }
-            } else {
-                (String::new(), String::new())
-            };
-
+            let (change_id, description) = self.summary_at_target(target);
             bookmarks.push(BookmarkInfo {
                 name: name.as_str().to_owned(),
                 change_id,
                 description,
                 is_tracking_remote: !tracked_remotes.is_empty(),
-                is_deleted,
-                is_conflicted,
+                is_deleted: target.is_absent(),
+                is_conflicted: target.has_conflict(),
                 tracked_remotes,
                 available_remotes,
+                has_local_target: true,
             });
         }
+
+        // Synthesize entries for remote bookmarks whose name has no local target.
+        let mut orphans: BTreeMap<String, Vec<(String, RefTarget)>> = BTreeMap::new();
+        for (sym, remote_ref) in repo.view().all_remote_bookmarks() {
+            let name = sym.name.as_str();
+            if local_names.contains(name) || remote_ref.target.is_absent() {
+                continue;
+            }
+            orphans
+                .entry(name.to_owned())
+                .or_default()
+                .push((sym.remote.as_str().to_owned(), remote_ref.target.clone()));
+        }
+        for (name, mut refs) in orphans {
+            refs.sort_by(|a, b| a.0.cmp(&b.0));
+            let remotes: Vec<String> = refs.iter().map(|(r, _)| r.clone()).collect();
+            let first_target = &refs[0].1;
+            let (change_id, description) = self.summary_at_target(first_target);
+            bookmarks.push(BookmarkInfo {
+                name,
+                change_id,
+                description,
+                is_tracking_remote: false,
+                is_deleted: false,
+                is_conflicted: first_target.has_conflict(),
+                tracked_remotes: Vec::new(),
+                available_remotes: remotes,
+                has_local_target: false,
+            });
+        }
+
         Ok(bookmarks)
+    }
+
+    fn summary_at_target(&self, target: &RefTarget) -> (String, String) {
+        let Some(commit_id) = target.as_normal() else {
+            return (String::new(), String::new());
+        };
+        match self.get_repo().store().get_commit(commit_id) {
+            Ok(commit) => (
+                encode_reverse_hex(commit.change_id().as_bytes()),
+                commit.description().lines().next().unwrap_or("").to_owned(),
+            ),
+            Err(_) => (String::new(), String::new()),
+        }
     }
 
     pub fn create_bookmark(&self, name: &str, rev: &str) -> CoreResult<()> {

--- a/crates/jayjay-core/src/types/bookmark.rs
+++ b/crates/jayjay-core/src/types/bookmark.rs
@@ -8,4 +8,6 @@ pub struct BookmarkInfo {
     pub is_conflicted: bool,
     pub tracked_remotes: Vec<String>,
     pub available_remotes: Vec<String>,
+    /// False for synthesized entries from an untracked remote bookmark (e.g. `feature@origin`).
+    pub has_local_target: bool,
 }

--- a/crates/jayjay-core/tests/real_jj_repo.rs
+++ b/crates/jayjay-core/tests/real_jj_repo.rs
@@ -746,3 +746,92 @@ fn test_default_revset_not_empty() {
         "default revset should contain '@'"
     );
 }
+
+#[test]
+fn list_bookmarks_includes_untracked_remote_branch() {
+    // Alice pushes a branch to origin; bob clones and sees it as `name@origin` with no local target.
+    let work_dir = tempfile::tempdir().expect("create work dir");
+    let bare_path = work_dir.path().join("origin.git");
+    let alice_path = work_dir.path().join("alice");
+    let bob_path = work_dir.path().join("bob");
+
+    let bare_str = bare_path.to_str().expect("bare path utf-8");
+    let alice_str = alice_path.to_str().expect("alice path utf-8");
+    let bob_str = bob_path.to_str().expect("bob path utf-8");
+
+    // Bare origin
+    run_command(
+        "git",
+        &["init".into(), "--bare".into(), bare_str.into()],
+        Command::new("git").args(["init", "--bare", bare_str]),
+    );
+
+    // Alice: colocated jj+git repo, two commits, push main and feature
+    run_jj(&["git", "init", "--colocate", alice_str]);
+    run_jj(&["-R", alice_str, "config", "set", "--repo", "user.name", "Alice"]);
+    run_jj(&[
+        "-R",
+        alice_str,
+        "config",
+        "set",
+        "--repo",
+        "user.email",
+        "alice@example.com",
+    ]);
+    fs::write(alice_path.join("a.txt"), "alice initial\n").expect("write a.txt");
+    run_jj(&["-R", alice_str, "describe", "-m", "initial"]);
+    run_jj(&["-R", alice_str, "bookmark", "create", "main", "-r", "@"]);
+    run_jj(&["-R", alice_str, "new", "-m", "alice feature work"]);
+    fs::write(alice_path.join("b.txt"), "alice feature\n").expect("write b.txt");
+    run_jj(&[
+        "-R",
+        alice_str,
+        "bookmark",
+        "create",
+        "alice-feature",
+        "-r",
+        "@",
+    ]);
+    run_git(&alice_path, &["remote", "add", "origin", bare_str]);
+    run_jj(&[
+        "-R",
+        alice_str,
+        "git",
+        "push",
+        "--bookmark",
+        "main",
+        "--bookmark",
+        "alice-feature",
+        "--remote",
+        "origin",
+        "--allow-new",
+    ]);
+
+    // Bob: clone via jj; alice-feature should arrive as an untracked remote bookmark
+    run_jj(&["git", "clone", "--colocate", bare_str, bob_str]);
+
+    let repo = Repo::open(&bob_path).expect("open bob's repo");
+    let bookmarks = repo.list_bookmarks().expect("list bookmarks");
+
+    let orphan = bookmarks
+        .iter()
+        .find(|b| b.name == "alice-feature")
+        .expect("alice-feature should appear in list_bookmarks");
+    assert!(
+        !orphan.has_local_target,
+        "alice-feature has no local target in bob's repo"
+    );
+    assert!(
+        !orphan.is_tracking_remote,
+        "alice-feature is not tracked in bob's repo"
+    );
+    assert_eq!(
+        orphan.available_remotes,
+        vec!["origin".to_string()],
+        "alice-feature is available only on origin"
+    );
+    assert!(
+        !orphan.change_id.is_empty(),
+        "orphan entry should carry the change id from the remote target"
+    );
+}

--- a/crates/jayjay-uniffi/src/types.rs
+++ b/crates/jayjay-uniffi/src/types.rs
@@ -122,6 +122,7 @@ pub struct BookmarkInfo {
     pub is_conflicted: bool,
     pub tracked_remotes: Vec<String>,
     pub available_remotes: Vec<String>,
+    pub has_local_target: bool,
 }
 
 #[uniffi::remote(Record)]

--- a/shell/gpui/src/log/menu.rs
+++ b/shell/gpui/src/log/menu.rs
@@ -133,12 +133,12 @@ impl LogView {
         }
         let mut tracked: Vec<_> = bookmarks
             .iter()
-            .filter(|b| b.is_tracking_remote)
+            .filter(|b| b.has_local_target && b.is_tracking_remote)
             .cloned()
             .collect();
         let mut local: Vec<_> = bookmarks
             .iter()
-            .filter(|b| !b.is_tracking_remote)
+            .filter(|b| b.has_local_target && !b.is_tracking_remote)
             .cloned()
             .collect();
         tracked.sort_by(|a, b| a.name.cmp(&b.name));

--- a/shell/gpui/src/log/sidebar.rs
+++ b/shell/gpui/src/log/sidebar.rs
@@ -144,10 +144,11 @@ pub(super) fn sidebar(
     };
 
     let bookmarks = view.vm.read(cx).graph.bookmarks.clone();
-    let bookmark_bar_el = if bookmarks.is_empty() {
-        None
-    } else {
+    let has_local = bookmarks.iter().any(|b| b.has_local_target);
+    let bookmark_bar_el = if has_local {
         Some(bookmark_bar(bookmarks, t, cx))
+    } else {
+        None
     };
     let show_commit_box = view
         .vm
@@ -284,6 +285,9 @@ fn bookmark_bar(
         .overflow_x_scroll();
 
     for bookmark in bookmarks.iter() {
+        if !bookmark.has_local_target {
+            continue;
+        }
         let name = bookmark.name.clone();
         let target_change_id = bookmark.change_id.clone();
         let chip = div()

--- a/shell/mac/Sources/JayJay/Repo/BookmarkManagerView.swift
+++ b/shell/mac/Sources/JayJay/Repo/BookmarkManagerView.swift
@@ -32,7 +32,11 @@ struct BookmarkManagerView: View {
     }
 
     private var localOnlyCount: Int {
-        bookmarks.filter { !$0.isTrackingRemote && !$0.isDeleted }.count
+        bookmarks.filter { $0.hasLocalTarget && !$0.isTrackingRemote && !$0.isDeleted }.count
+    }
+
+    private var remoteOnlyCount: Int {
+        bookmarks.filter { !$0.hasLocalTarget }.count
     }
 
     var body: some View {
@@ -81,6 +85,9 @@ struct BookmarkManagerView: View {
             if localOnlyCount > 0 {
                 statBadge("\(localOnlyCount) local-only", color: .secondary)
             }
+            if remoteOnlyCount > 0 {
+                statBadge("\(remoteOnlyCount) remote-only", color: .blue)
+            }
             Spacer()
             Toggle("Show deleted", isOn: $showDeleted)
                 .jayjayFont(11)
@@ -102,6 +109,14 @@ struct BookmarkManagerView: View {
         .background(Color.primary.opacity(0.02))
     }
 
+    /// Untracked remotes only resolve as `name@remote` in revsets.
+    private func revsetSymbol(for bookmark: BookmarkInfo) -> String {
+        if !bookmark.hasLocalTarget, let remote = bookmark.availableRemotes.first {
+            return "\(bookmark.name)@\(remote)"
+        }
+        return bookmark.name
+    }
+
     private func statBadge(_ text: String, color: Color) -> some View {
         Text(text)
             .jayjayFont(10, weight: .semibold)
@@ -118,7 +133,7 @@ struct BookmarkManagerView: View {
             ForEach(filteredBookmarks, id: \.name) { bookmark in
                 BookmarkManagerRow(
                     bookmark: bookmark,
-                    onFilter: { onFilter(bookmark.name) },
+                    onFilter: { onFilter(revsetSymbol(for: bookmark)) },
                     onDelete: { actions?.deleteBookmark(name: bookmark.name) },
                     onForget: { actions?.deleteBookmark(name: bookmark.name) },
                     onPush: { actions?.gitPush(bookmark: bookmark.name) },
@@ -126,7 +141,10 @@ struct BookmarkManagerView: View {
                         try? repo?.moveBookmark(name: bookmark.name, toRev: "@-")
                         actions?.gitFetch() // refresh
                     },
-                    onOpenPR: { actions?.openPR(bookmark: bookmark.name) }
+                    onOpenPR: { actions?.openPR(bookmark: bookmark.name) },
+                    onTrack: { remote in
+                        actions?.trackBookmark(name: bookmark.name, remote: remote)
+                    }
                 )
             }
         }
@@ -144,9 +162,17 @@ private struct BookmarkManagerRow: View {
     let onPush: () -> Void
     let onResolve: () -> Void
     let onOpenPR: () -> Void
+    let onTrack: (String) -> Void
 
     private var canOpenPR: Bool {
         bookmark.isTrackingRemote && !bookmark.isDeleted && !isTrunkBookmark(bookmark.name)
+    }
+
+    private var remoteSuffix: String {
+        guard !bookmark.hasLocalTarget, let first = bookmark.availableRemotes.first else {
+            return ""
+        }
+        return "@\(first)"
     }
 
     var body: some View {
@@ -154,7 +180,7 @@ private struct BookmarkManagerRow: View {
             statusIcon
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
-                    Text(bookmark.name)
+                    Text(bookmark.name + remoteSuffix)
                         .jayjayFont(13, weight: .medium, design: .monospaced)
                         .lineLimit(1)
                     if bookmark.isDeleted {
@@ -163,7 +189,9 @@ private struct BookmarkManagerRow: View {
                     if bookmark.isConflicted {
                         badge("conflicted", color: .orange)
                     }
-                    if !bookmark.isTrackingRemote, !bookmark.isDeleted {
+                    if !bookmark.hasLocalTarget {
+                        badge("remote-only", color: .blue)
+                    } else if !bookmark.isTrackingRemote, !bookmark.isDeleted {
                         badge("local", color: .secondary)
                     }
                 }
@@ -200,7 +228,13 @@ private struct BookmarkManagerRow: View {
                     Label("Resolve conflict (set to @)", systemImage: "arrow.triangle.merge")
                 }
             }
-            if bookmark.isTrackingRemote, !bookmark.isDeleted {
+            if !bookmark.hasLocalTarget {
+                ForEach(bookmark.availableRemotes, id: \.self) { remote in
+                    Button { onTrack(remote) } label: {
+                        Label("Track \(bookmark.name)@\(remote)", systemImage: "arrow.down.circle")
+                    }
+                }
+            } else if bookmark.isTrackingRemote, !bookmark.isDeleted {
                 Button { onPush() } label: {
                     Label("Push", systemImage: "arrow.up.circle")
                 }
@@ -210,14 +244,16 @@ private struct BookmarkManagerRow: View {
                     Label("Pull Request on GitHub", systemImage: "arrow.up.right.square")
                 }
             }
-            Divider()
-            if bookmark.isDeleted {
-                Button { onForget() } label: {
-                    Label("Forget (remove from jj)", systemImage: "bookmark.slash")
-                }
-            } else {
-                Button(role: .destructive) { onDelete() } label: {
-                    Label("Delete", systemImage: "trash")
+            if bookmark.hasLocalTarget {
+                Divider()
+                if bookmark.isDeleted {
+                    Button { onForget() } label: {
+                        Label("Forget (remove from jj)", systemImage: "bookmark.slash")
+                    }
+                } else {
+                    Button(role: .destructive) { onDelete() } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
                 }
             }
         }
@@ -231,6 +267,9 @@ private struct BookmarkManagerRow: View {
             } else if bookmark.isConflicted {
                 Image(systemName: "exclamationmark.triangle.fill")
                     .foregroundStyle(.orange)
+            } else if !bookmark.hasLocalTarget {
+                Image(systemName: "cloud")
+                    .foregroundStyle(.blue)
             } else if bookmark.isTrackingRemote {
                 Image(systemName: "cloud.fill")
                     .foregroundStyle(.blue)

--- a/shell/mac/Sources/JayJay/Repo/BookmarkPicker.swift
+++ b/shell/mac/Sources/JayJay/Repo/BookmarkPicker.swift
@@ -6,25 +6,30 @@ struct BookmarkPicker: View {
     let actions: (any BookmarkActions)?
     let onSelect: (String) -> Void
 
+    private var localBookmarks: [BookmarkInfo] {
+        bookmarks.filter(\.hasLocalTarget)
+    }
+
     private var bookmarkLabel: String {
-        if bookmarks.isEmpty {
+        let local = localBookmarks
+        if local.isEmpty {
             return "Bookmarks"
         }
-        let untrackedCount = bookmarks.filter { !$0.isTrackingRemote }.count
+        let untrackedCount = local.filter { !$0.isTrackingRemote }.count
         if untrackedCount == 0 {
-            return "Bookmarks (\(bookmarks.count))"
+            return "Bookmarks (\(local.count))"
         }
-        return "Bookmarks (\(bookmarks.count), \(untrackedCount) local)"
+        return "Bookmarks (\(local.count), \(untrackedCount) local)"
     }
 
     private var trackedBookmarks: [BookmarkInfo] {
-        bookmarks
+        localBookmarks
             .filter(\.isTrackingRemote)
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }
 
     private var localOnlyBookmarks: [BookmarkInfo] {
-        bookmarks
+        localBookmarks
             .filter { !$0.isTrackingRemote }
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
     }


### PR DESCRIPTION
## Summary

Closes #55.

Previously the Bookmark Manager only listed bookmarks with a local target, so an untracked remote ref like `feature@origin` (fetched from a teammate's git branch) was invisible in the UI — users had to drop to `jj log` / `jj bookmark list --all` to find the names of heads in the DAG.

<img width="45%" alt="Screenshot 2026-05-24 at 07 47 44" src="https://github.com/user-attachments/assets/9bfe4478-2338-457c-bd49-821236dafbbd" /> <img width="45%" alt="Screenshot 2026-05-24 at 07 48 57" src="https://github.com/user-attachments/assets/81c2276b-fd99-44b6-83aa-af45189868e8" />


This change:

- **Core (`jayjay-core/src/repo/bookmarks.rs`)** — `list_bookmarks()` now also emits a synthetic `BookmarkInfo` for every remote bookmark name with no local target. New `has_local_target: bool` field on `BookmarkInfo`; orphan entries from multiple remotes for the same name are grouped via `available_remotes`. Extracted a `summary_at_target` helper to deduplicate the change-id/description lookup.
- **Swift Bookmark Manager** — new `N remote-only` stat in the stats bar, `cloud` (outline) icon, `remote-only` badge, `name@origin` rendered inline next to the name. Context menu for remote-only rows: `Filter in DAG` (passes the qualified `name@remote` so the revset resolves) and one `Track name@remote` item per available remote.
- **Swift Bookmark Picker** — filters out `!hasLocalTarget` entries (you can't set/move a bookmark you don't have locally).
- **GPUI shell** — sidebar chips and bookmark picker menu filter out remote-only entries so existing UX doesn't change.

## Test plan

- [x] `cargo test -p jayjay-core --test real_jj_repo` — new `list_bookmarks_includes_untracked_remote_branch` mirrors the issue's reproducer (alice pushes to bare origin, bob clones, asserts `alice-feature@origin` arrives with `has_local_target = false`)
- [x] `cargo check --workspace` clean
- [x] `just lint` (clippy + swiftlint) clean
- [x] `just build` succeeds
- [x] Manual check against [npvincent/jayjay-remote-branch](https://github.com/npvincent/jayjay-remote-branch): `another_persons_branch@origin` shows in the Bookmark Manager with the remote-only badge; `Filter in DAG` narrows the log correctly; `Track another_persons_branch@origin` converts it into a normal tracked bookmark