### PR TITLE
feat(command-palette): harden raw jj commands

### DIFF
--- a/crates/jayjay-core/src/jj_command.rs
+++ b/crates/jayjay-core/src/jj_command.rs
@@ -1,0 +1,217 @@
+use std::path::Path;
+use std::process::Command;
+
+use crate::{CoreError, CoreResult, jj_binary};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JjCommand {
+    raw: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JjCommandResult {
+    pub output: String,
+    pub exit_code: i32,
+}
+
+impl JjCommand {
+    pub fn new(command: impl Into<String>) -> Self {
+        Self {
+            raw: command.into(),
+        }
+    }
+
+    pub fn from_palette_query(query: &str) -> Option<Self> {
+        let body_after = |rest: &str| Self::new(rest.trim_start());
+        if query == "jj" || query == "!" {
+            return Some(Self::new(String::new()));
+        }
+        if let Some(rest) = query.strip_prefix("jj ") {
+            return Some(body_after(rest));
+        }
+        query.strip_prefix('!').map(body_after)
+    }
+
+    pub fn raw(&self) -> &str {
+        &self.raw
+    }
+
+    pub fn into_raw(self) -> String {
+        self.raw
+    }
+
+    pub fn parse_args(&self) -> Option<Vec<String>> {
+        parse_args(&self.raw)
+    }
+
+    pub fn run_in_path(&self, path: &Path) -> CoreResult<JjCommandResult> {
+        let args = self.parse_args().ok_or_else(|| CoreError::Internal {
+            message: "Unclosed quote in jj command.".to_owned(),
+        })?;
+        if args.is_empty() {
+            return Err(CoreError::Internal {
+                message: "No jj command to run.".to_owned(),
+            });
+        }
+
+        let output = Command::new(jj_binary())
+            .args(&args)
+            .current_dir(path)
+            .output()
+            .map_err(|e| CoreError::Internal {
+                message: format!("run jj: {e}"),
+            })?;
+
+        let stdout = trim_output(&output.stdout);
+        let stderr = trim_output(&output.stderr);
+        let combined = match (stdout.is_empty(), stderr.is_empty()) {
+            (true, true) => "(no output)".to_owned(),
+            (false, true) => stdout.clone(),
+            (true, false) => stderr.clone(),
+            (false, false) => format!("{stdout}\n{stderr}"),
+        };
+
+        Ok(JjCommandResult {
+            output: combined,
+            exit_code: output.status.code().unwrap_or(-1),
+        })
+    }
+}
+
+fn parse_args(command: &str) -> Option<Vec<String>> {
+    let mut args = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    let mut escaping = false;
+    let mut arg_started = false;
+
+    let mut chars = command.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if escaping {
+            current.push(ch);
+            escaping = false;
+            arg_started = true;
+            continue;
+        }
+        if let Some(current_quote) = quote {
+            if ch == current_quote {
+                quote = None;
+            } else if current_quote == '"' && ch == '\\' {
+                match chars.peek().copied() {
+                    Some('"') | Some('\\') => current.push(chars.next().expect("peeked next char")),
+                    _ => current.push(ch),
+                }
+            } else {
+                current.push(ch);
+            }
+            arg_started = true;
+            continue;
+        }
+        if ch == '\\' {
+            escaping = true;
+            arg_started = true;
+            continue;
+        }
+        if ch == '"' || ch == '\'' {
+            quote = Some(ch);
+            arg_started = true;
+            continue;
+        }
+        if ch.is_whitespace() {
+            if arg_started {
+                args.push(std::mem::take(&mut current));
+                arg_started = false;
+            }
+            continue;
+        }
+        current.push(ch);
+        arg_started = true;
+    }
+
+    if escaping {
+        current.push('\\');
+    }
+    quote.is_none().then(|| {
+        if arg_started {
+            args.push(current);
+        }
+        args
+    })
+}
+
+fn trim_output(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).trim().to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_shell_like_args() {
+        assert_eq!(
+            JjCommand::new(r#"log -r "description(exact:'fix bug')" --limit 5"#).parse_args(),
+            Some(vec![
+                "log".to_owned(),
+                "-r".to_owned(),
+                "description(exact:'fix bug')".to_owned(),
+                "--limit".to_owned(),
+                "5".to_owned()
+            ])
+        );
+        assert_eq!(
+            JjCommand::new(r#"file\ with\ spaces"#).parse_args(),
+            Some(vec!["file with spaces".to_owned()])
+        );
+        assert_eq!(
+            JjCommand::new(r#"describe -m "a\"b""#).parse_args(),
+            Some(vec![
+                "describe".to_owned(),
+                "-m".to_owned(),
+                "a\"b".to_owned()
+            ])
+        );
+        assert_eq!(
+            JjCommand::new(r#"describe -m """#).parse_args(),
+            Some(vec!["describe".to_owned(), "-m".to_owned(), String::new()])
+        );
+        assert_eq!(
+            JjCommand::new(r#"new '' file\ with\ spaces"#).parse_args(),
+            Some(vec![
+                "new".to_owned(),
+                String::new(),
+                "file with spaces".to_owned()
+            ])
+        );
+        assert_eq!(
+            JjCommand::new(r#"describe -m 'a\b'"#).parse_args(),
+            Some(vec![
+                "describe".to_owned(),
+                "-m".to_owned(),
+                r#"a\b"#.to_owned()
+            ])
+        );
+        assert_eq!(
+            JjCommand::new(r#"log -r "description(regex:'\bfix\b')""#).parse_args(),
+            Some(vec![
+                "log".to_owned(),
+                "-r".to_owned(),
+                r#"description(regex:'\bfix\b')"#.to_owned()
+            ])
+        );
+        assert_eq!(JjCommand::new(r#"log -r "mine()"#).parse_args(), None);
+    }
+
+    #[test]
+    fn extracts_prefixed_command_body() {
+        assert_eq!(
+            JjCommand::from_palette_query("jj log").map(JjCommand::into_raw),
+            Some("log".to_owned())
+        );
+        assert_eq!(
+            JjCommand::from_palette_query("!status").map(JjCommand::into_raw),
+            Some("status".to_owned())
+        );
+        assert_eq!(JjCommand::from_palette_query("status"), None);
+    }
+}

--- a/crates/jayjay-core/src/lib.rs
+++ b/crates/jayjay-core/src/lib.rs
@@ -3,11 +3,13 @@ pub use jj_diff::syntax;
 pub mod dag;
 pub mod file_tree;
 pub mod hash;
+mod jj_command;
 mod repo;
 pub mod review;
 pub mod tools;
 mod types;
 
+pub use jj_command::{JjCommand, JjCommandResult};
 pub use repo::{
     COMMIT_MESSAGE_PROMPT, DEFAULT_REVSET, DEFAULT_REVSET_DEPTH, Repo, build_default_revset,
     check_gh_environment, check_jj_environment, detect_ai_provider, find_existing_binary,

--- a/crates/jayjay-core/src/repo/diffedit.rs
+++ b/crates/jayjay-core/src/repo/diffedit.rs
@@ -40,29 +40,20 @@ impl Repo {
         ignore_whitespace: bool,
     ) -> CoreResult<()> {
         match destination {
-            DiffEditDestination::RemoveFromSource => self.remove_diff_selection_from_source(
-                rev,
-                selections,
-                ignore_whitespace,
-            ),
+            DiffEditDestination::RemoveFromSource => {
+                self.remove_diff_selection_from_source(rev, selections, ignore_whitespace)
+            }
             DiffEditDestination::MoveToWorkingCopy => {
                 self.move_diff_selection_to_working_copy(rev, selections, ignore_whitespace)
             }
-            DiffEditDestination::NewChild => {
-                self.extract_diff_selection_as_new_child(
-                    rev,
-                    selections,
-                    message,
-                    ignore_whitespace,
-                )
-            }
+            DiffEditDestination::NewChild => self.extract_diff_selection_as_new_child(
+                rev,
+                selections,
+                message,
+                ignore_whitespace,
+            ),
             DiffEditDestination::NewParallel => {
-                self.extract_diff_selection_as_parallel(
-                    rev,
-                    selections,
-                    message,
-                    ignore_whitespace,
-                )
+                self.extract_diff_selection_as_parallel(rev, selections, message, ignore_whitespace)
             }
         }
     }
@@ -158,7 +149,10 @@ impl Repo {
                 )?;
                 let rewritten_source = block_on_result(
                     "rewrite source commit",
-                    repo_mut.rewrite_commit(commit).set_tree(remaining_tree).write(),
+                    repo_mut
+                        .rewrite_commit(commit)
+                        .set_tree(remaining_tree)
+                        .write(),
                 )?;
                 let child_tree = self.apply_selection_to_tree(
                     &source_selection,
@@ -204,7 +198,10 @@ impl Repo {
                 block_on_result("rewrite source commit", write)?;
                 let parallel_description = self.diffedit_message(message, commit);
                 let write = repo_mut
-                    .new_commit(commit.parent_ids().to_vec(), source_selection.selected_tree.clone())
+                    .new_commit(
+                        commit.parent_ids().to_vec(),
+                        source_selection.selected_tree.clone(),
+                    )
                     .set_description(&parallel_description)
                     .write();
                 block_on_result("create parallel change", write)?;
@@ -334,9 +331,16 @@ impl Repo {
     ) -> CoreResult<MergedTreeValue> {
         let metadata = self
             .resolved_file_value(source_tree, path, "load selected file metadata")?
-            .or_else(|| self.resolved_file_value(parent_tree, path, "load parent file metadata").ok().flatten())
+            .or_else(|| {
+                self.resolved_file_value(parent_tree, path, "load parent file metadata")
+                    .ok()
+                    .flatten()
+            })
             .ok_or_else(|| CoreError::Internal {
-                message: format!("selected file metadata missing for {}", path.as_internal_file_string()),
+                message: format!(
+                    "selected file metadata missing for {}",
+                    path.as_internal_file_string()
+                ),
             })?;
 
         let TreeValue::File {
@@ -372,7 +376,10 @@ impl Repo {
     ) -> CoreResult<Option<TreeValue>> {
         let value = block_on_result(context, tree.path_value(path))?;
         value.into_resolved().map_err(|_| CoreError::Internal {
-            message: format!("conflicted file values are not supported: {}", path.as_internal_file_string()),
+            message: format!(
+                "conflicted file values are not supported: {}",
+                path.as_internal_file_string()
+            ),
         })
     }
 

--- a/crates/jayjay-core/src/repo/environment.rs
+++ b/crates/jayjay-core/src/repo/environment.rs
@@ -138,7 +138,11 @@ fn resolve_login_shell_path() -> Option<String> {
 #[cfg(unix)]
 pub fn login_shell() -> String {
     login_shell_from_passwd()
-        .or_else(|| std::env::var("SHELL").ok().filter(|value| !value.is_empty()))
+        .or_else(|| {
+            std::env::var("SHELL")
+                .ok()
+                .filter(|value| !value.is_empty())
+        })
         .unwrap_or_else(|| "/bin/zsh".to_string())
 }
 

--- a/crates/jayjay-core/src/repo/github.rs
+++ b/crates/jayjay-core/src/repo/github.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 
-use super::environment::gh_binary;
 use super::Repo;
+use super::environment::gh_binary;
 use crate::types::{ChecksStatus, PrInfo, PrState};
 
 const GITHUB_HOST: &str = "github.com";
@@ -140,7 +140,10 @@ fn parse_gh_pr_json(json: &str) -> Option<PrInfo> {
     let checks = match resp.status_check_rollup.as_slice() {
         [] => ChecksStatus::None,
         runs if runs.iter().any(|c| c.status != GhCheckStatus::Completed) => ChecksStatus::Pending,
-        runs if runs.iter().all(|c| c.conclusion == GhCheckConclusion::Success) => {
+        runs if runs
+            .iter()
+            .all(|c| c.conclusion == GhCheckConclusion::Success) =>
+        {
             ChecksStatus::Passing
         }
         _ => ChecksStatus::Failing,
@@ -189,11 +192,23 @@ mod tests {
     #[test]
     fn slug_extracts_from_common_remote_forms() {
         let expected = Some("hewigovens/jayjay");
-        assert_eq!(github_slug("git@github.com:hewigovens/jayjay.git").as_deref(), expected);
-        assert_eq!(github_slug("https://github.com/hewigovens/jayjay.git\n").as_deref(), expected);
-        assert_eq!(github_slug("ssh://git@github.com/hewigovens/jayjay.git").as_deref(), expected);
+        assert_eq!(
+            github_slug("git@github.com:hewigovens/jayjay.git").as_deref(),
+            expected
+        );
+        assert_eq!(
+            github_slug("https://github.com/hewigovens/jayjay.git\n").as_deref(),
+            expected
+        );
+        assert_eq!(
+            github_slug("ssh://git@github.com/hewigovens/jayjay.git").as_deref(),
+            expected
+        );
         // HTTPS with token/userinfo (e.g., from `gh auth setup-git`).
-        assert_eq!(github_slug("https://TOKEN@github.com/hewigovens/jayjay.git").as_deref(), expected);
+        assert_eq!(
+            github_slug("https://TOKEN@github.com/hewigovens/jayjay.git").as_deref(),
+            expected
+        );
     }
 
     #[test]
@@ -205,9 +220,15 @@ mod tests {
     #[test]
     fn slug_rejects_non_github_and_malformed() {
         // Lookalike hosts must not pass — opening a bogus PR URL is the failure mode here.
-        assert_eq!(github_slug("https://github.com.evil.org/hewigovens/jayjay"), None);
+        assert_eq!(
+            github_slug("https://github.com.evil.org/hewigovens/jayjay"),
+            None
+        );
         assert_eq!(github_slug("https://evilgithub.com/foo/bar"), None);
-        assert_eq!(github_slug("https://gitlab.com/hewigovens/jayjay.git"), None);
+        assert_eq!(
+            github_slug("https://gitlab.com/hewigovens/jayjay.git"),
+            None
+        );
         assert_eq!(github_slug("https://github.com/lonely"), None);
         assert_eq!(github_slug(""), None);
     }
@@ -222,6 +243,9 @@ mod tests {
                 {"name": "deploy", "status": "IN_PROGRESS"}
             ]
         }"#;
-        assert_eq!(parse_gh_pr_json(json).unwrap().checks, ChecksStatus::Pending);
+        assert_eq!(
+            parse_gh_pr_json(json).unwrap().checks,
+            ChecksStatus::Pending
+        );
     }
 }

--- a/crates/jayjay-core/tests/real_jj_repo.rs
+++ b/crates/jayjay-core/tests/real_jj_repo.rs
@@ -773,7 +773,15 @@ fn list_bookmarks_includes_untracked_remote_branch() {
 
     // Alice: colocated jj+git repo, two commits, push main and feature
     run_jj(&["git", "init", "--colocate", alice_str]);
-    run_jj(&["-R", alice_str, "config", "set", "--repo", "user.name", "Alice"]);
+    run_jj(&[
+        "-R",
+        alice_str,
+        "config",
+        "set",
+        "--repo",
+        "user.name",
+        "Alice",
+    ]);
     run_jj(&[
         "-R",
         alice_str,

--- a/crates/jayjay-uniffi/src/diff.rs
+++ b/crates/jayjay-uniffi/src/diff.rs
@@ -17,11 +17,7 @@ pub fn wrap_diff_lines(lines: Vec<DiffLine>, cols: u32) -> Vec<WrappedDiffLine> 
 }
 
 #[uniffi::export]
-pub fn wrap_sbs_rows(
-    rows: Vec<SideBySideRow>,
-    old_cols: u32,
-    new_cols: u32,
-) -> Vec<WrappedSbsRow> {
+pub fn wrap_sbs_rows(rows: Vec<SideBySideRow>, old_cols: u32, new_cols: u32) -> Vec<WrappedSbsRow> {
     diff::wrap_sbs_rows(&rows, old_cols, new_cols)
 }
 

--- a/crates/jayjay-uniffi/src/repo.rs
+++ b/crates/jayjay-uniffi/src/repo.rs
@@ -1,44 +1,67 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use jayjay_core as core;
-use jayjay_core::{DiffStats, FetchResult, PrInfo};
+use jayjay_core::{
+    AnnotationLine, BookmarkInfo, ChangeDetail, ChangeInfo, CliStatus, DiffEditDestination,
+    DiffEditFileSelection, DiffHunk, DiffStats, EvologEntry, FetchResult, FileTreeEntry,
+    GitSubmoduleStatus, GraphEntry, JjCommand, JjCommandResult, OpLogEntry, PrInfo, Repo,
+    ToolsConfig, WorkspaceInfo,
+    diff::{self, CollapsedDiff, FileDiff},
+};
 
 use crate::error::JayJayError;
 
 #[uniffi::export]
-pub fn build_file_tree(paths: Vec<String>) -> Vec<core::FileTreeEntry> {
-    core::file_tree::build_file_tree(&paths)
+pub fn build_file_tree(paths: Vec<String>) -> Vec<FileTreeEntry> {
+    jayjay_core::file_tree::build_file_tree(&paths)
 }
 
 #[uniffi::export]
 pub fn detect_ai_provider() -> String {
-    core::detect_ai_provider()
+    jayjay_core::detect_ai_provider()
 }
 
 #[uniffi::export]
 pub fn commit_message_prompt() -> String {
-    core::COMMIT_MESSAGE_PROMPT.to_owned()
+    jayjay_core::COMMIT_MESSAGE_PROMPT.to_owned()
 }
 
 #[uniffi::export]
 pub fn default_revset() -> String {
-    core::DEFAULT_REVSET.to_owned()
+    jayjay_core::DEFAULT_REVSET.to_owned()
 }
 
 #[uniffi::export]
 pub fn default_revset_with_depth(depth: u32) -> String {
-    core::build_default_revset(depth)
+    jayjay_core::build_default_revset(depth)
 }
 
 #[uniffi::export]
-pub fn check_jj_environment() -> core::CliStatus {
-    core::check_jj_environment()
+pub fn check_jj_environment() -> CliStatus {
+    jayjay_core::check_jj_environment()
 }
 
 #[uniffi::export]
-pub fn check_gh_environment() -> core::CliStatus {
-    core::check_gh_environment()
+pub fn check_gh_environment() -> CliStatus {
+    jayjay_core::check_gh_environment()
+}
+
+#[uniffi::export]
+pub fn jj_command_body(query: String) -> Option<String> {
+    JjCommand::from_palette_query(&query).map(JjCommand::into_raw)
+}
+
+#[uniffi::export]
+pub fn parse_jj_command_args(command: String) -> Option<Vec<String>> {
+    JjCommand::new(command).parse_args()
+}
+
+#[uniffi::export]
+pub fn run_jj_command_in_repo_path(
+    repo_path: String,
+    command: String,
+) -> Result<JjCommandResult, JayJayError> {
+    Ok(JjCommand::new(command).run_in_path(&PathBuf::from(repo_path))?)
 }
 
 /// Resolve a CLI binary by walking the same fallback paths jj does. Returns
@@ -46,17 +69,17 @@ pub fn check_gh_environment() -> core::CliStatus {
 /// stripped PATH from launchd, so this avoids relying on shell PATH.
 #[uniffi::export]
 pub fn find_binary(name: String) -> Option<String> {
-    core::find_existing_binary(&name)
+    jayjay_core::find_existing_binary(&name)
 }
 
 #[uniffi::export]
 pub fn login_shell_path() -> Option<String> {
-    core::login_shell_path()
+    jayjay_core::login_shell_path()
 }
 
 #[uniffi::export]
 pub fn login_shell() -> String {
-    core::login_shell()
+    jayjay_core::login_shell()
 }
 
 /// Open a file in the user-configured external editor. Returns false on
@@ -70,10 +93,10 @@ pub fn open_in_editor(
     terminal: String,
     custom_terminal_command: String,
 ) -> bool {
-    core::open_in_editor(
+    jayjay_core::open_in_editor(
         &repo_path,
         &file_path,
-        &core::ToolsConfig {
+        &ToolsConfig {
             external_editor,
             custom_editor_command,
             terminal,
@@ -91,10 +114,10 @@ pub fn open_in_terminal(
     terminal: String,
     custom_terminal_command: String,
 ) -> bool {
-    core::open_in_terminal(
+    jayjay_core::open_in_terminal(
         &repo_path,
         command.as_deref(),
-        &core::ToolsConfig {
+        &ToolsConfig {
             terminal,
             custom_terminal_command,
             ..Default::default()
@@ -104,14 +127,14 @@ pub fn open_in_terminal(
 
 #[derive(uniffi::Object)]
 pub struct JayJayRepo {
-    inner: core::Repo,
+    inner: Repo,
 }
 
 #[uniffi::export]
 impl JayJayRepo {
     #[uniffi::constructor]
     pub fn open(path: String) -> Result<Arc<Self>, JayJayError> {
-        let repo = core::Repo::open(&PathBuf::from(&path))?;
+        let repo = Repo::open(&PathBuf::from(&path))?;
         Ok(Arc::new(Self { inner: repo }))
     }
 
@@ -130,25 +153,25 @@ impl JayJayRepo {
         Ok(self.inner.has_unignored_working_copy_paths(&paths)?)
     }
 
-    pub fn log(&self, revset: String) -> Result<Vec<core::ChangeInfo>, JayJayError> {
+    pub fn log(&self, revset: String) -> Result<Vec<ChangeInfo>, JayJayError> {
         Ok(self.inner.log(&revset)?)
     }
 
-    pub fn log_graph(&self, revset: String) -> Result<Vec<core::GraphEntry>, JayJayError> {
+    pub fn log_graph(&self, revset: String) -> Result<Vec<GraphEntry>, JayJayError> {
         Ok(self.inner.log_graph(&revset)?)
     }
 
-    pub fn show(&self, rev: String) -> Result<core::ChangeDetail, JayJayError> {
+    pub fn show(&self, rev: String) -> Result<ChangeDetail, JayJayError> {
         Ok(self.inner.show(&rev)?)
     }
 
     /// Fast: file list without content.
-    pub fn show_summary(&self, rev: String) -> Result<core::ChangeDetail, JayJayError> {
+    pub fn show_summary(&self, rev: String) -> Result<ChangeDetail, JayJayError> {
         Ok(self.inner.show_summary(&rev)?)
     }
 
     /// Single file with content.
-    pub fn show_file(&self, rev: String, path: String) -> Result<core::DiffHunk, JayJayError> {
+    pub fn show_file(&self, rev: String, path: String) -> Result<DiffHunk, JayJayError> {
         Ok(self.inner.show_file(&rev, &path)?)
     }
 
@@ -158,7 +181,7 @@ impl JayJayRepo {
         rev: String,
         old_path: String,
         new_path: String,
-    ) -> Result<core::DiffHunk, JayJayError> {
+    ) -> Result<DiffHunk, JayJayError> {
         Ok(self.inner.show_file_rename(&rev, &old_path, &new_path)?)
     }
 
@@ -167,7 +190,7 @@ impl JayJayRepo {
         &self,
         from_rev: String,
         to_rev: String,
-    ) -> Result<core::ChangeDetail, JayJayError> {
+    ) -> Result<ChangeDetail, JayJayError> {
         Ok(self.inner.interdiff_summary(&from_rev, &to_rev)?)
     }
 
@@ -177,11 +200,11 @@ impl JayJayRepo {
         from_rev: String,
         to_rev: String,
         path: String,
-    ) -> Result<core::DiffHunk, JayJayError> {
+    ) -> Result<DiffHunk, JayJayError> {
         Ok(self.inner.interdiff_file(&from_rev, &to_rev, &path)?)
     }
 
-    pub fn workspace_list(&self) -> Result<Vec<core::WorkspaceInfo>, JayJayError> {
+    pub fn workspace_list(&self) -> Result<Vec<WorkspaceInfo>, JayJayError> {
         Ok(self.inner.workspace_list()?)
     }
 
@@ -214,15 +237,15 @@ impl JayJayRepo {
         &self,
         rev: String,
         path: String,
-    ) -> Result<Vec<core::AnnotationLine>, JayJayError> {
+    ) -> Result<Vec<AnnotationLine>, JayJayError> {
         Ok(self.inner.annotate_file(&rev, &path)?)
     }
 
-    pub fn file_history(&self, path: String) -> Result<Vec<core::ChangeInfo>, JayJayError> {
+    pub fn file_history(&self, path: String) -> Result<Vec<ChangeInfo>, JayJayError> {
         Ok(self.inner.file_history(&path)?)
     }
 
-    pub fn evolog(&self, rev: String) -> Result<Vec<core::EvologEntry>, JayJayError> {
+    pub fn evolog(&self, rev: String) -> Result<Vec<EvologEntry>, JayJayError> {
         Ok(self.inner.evolog(&rev)?)
     }
 
@@ -321,7 +344,7 @@ impl JayJayRepo {
         Ok(self.inner.rebase(&rev, &dest)?)
     }
 
-    pub fn list_bookmarks(&self) -> Result<Vec<core::BookmarkInfo>, JayJayError> {
+    pub fn list_bookmarks(&self) -> Result<Vec<BookmarkInfo>, JayJayError> {
         Ok(self.inner.list_bookmarks()?)
     }
 
@@ -381,7 +404,7 @@ impl JayJayRepo {
         Ok(self.inner.changed_submodules()?)
     }
 
-    pub fn submodule_statuses(&self) -> Result<Vec<core::GitSubmoduleStatus>, JayJayError> {
+    pub fn submodule_statuses(&self) -> Result<Vec<GitSubmoduleStatus>, JayJayError> {
         Ok(self.inner.submodule_statuses()?)
     }
 
@@ -421,7 +444,7 @@ impl JayJayRepo {
         self.inner.check_user_config()
     }
 
-    pub fn op_log(&self) -> Result<Vec<core::OpLogEntry>, JayJayError> {
+    pub fn op_log(&self) -> Result<Vec<OpLogEntry>, JayJayError> {
         Ok(self.inner.op_log()?)
     }
 
@@ -435,8 +458,8 @@ impl JayJayRepo {
         old_content: String,
         new_content: String,
         ignore_whitespace: bool,
-    ) -> core::diff::FileDiff {
-        core::diff::compute_file_diff(&path, &old_content, &new_content, ignore_whitespace)
+    ) -> FileDiff {
+        diff::compute_file_diff(&path, &old_content, &new_content, ignore_whitespace)
     }
 
     pub fn compute_native_diff_full(
@@ -445,22 +468,19 @@ impl JayJayRepo {
         old_content: String,
         new_content: String,
         ignore_whitespace: bool,
-    ) -> core::diff::FileDiff {
-        core::diff::compute_file_diff_full(&path, &old_content, &new_content, ignore_whitespace)
+    ) -> FileDiff {
+        diff::compute_file_diff_full(&path, &old_content, &new_content, ignore_whitespace)
     }
 
-    pub fn collapse_diff_with_mapping(
-        &self,
-        diff: core::diff::FileDiff,
-    ) -> core::diff::CollapsedDiff {
-        core::diff::collapse_context_with_mapping(&diff)
+    pub fn collapse_diff_with_mapping(&self, diff: FileDiff) -> CollapsedDiff {
+        diff::collapse_context_with_mapping(&diff)
     }
 
     pub fn apply_diff_selection(
         &self,
         rev: String,
-        destination: core::DiffEditDestination,
-        selections: Vec<core::DiffEditFileSelection>,
+        destination: DiffEditDestination,
+        selections: Vec<DiffEditFileSelection>,
         message: String,
         ignore_whitespace: bool,
     ) -> Result<(), JayJayError> {

--- a/crates/jayjay-uniffi/src/types.rs
+++ b/crates/jayjay-uniffi/src/types.rs
@@ -8,7 +8,7 @@ use jayjay_core::{
     AnnotationLine, BookmarkInfo, ChangeDetail, ChangeInfo, ChecksStatus, CliStatus,
     DiffEditDestination, DiffEditFileSelection, DiffEditRange, DiffHunk, DiffPreview, DiffStats,
     EdgeType, EvologEntry, FetchResult, FileTreeEntry, GitSubmoduleStatus, GraphEdge, GraphEntry,
-    HunkType, OpLogEntry, PrInfo, PrState, WorkspaceInfo,
+    HunkType, JjCommandResult, OpLogEntry, PrInfo, PrState, WorkspaceInfo,
 };
 
 // --- All types use uniffi::remote — no wrapper structs or From impls ---
@@ -20,6 +20,12 @@ pub struct EvologEntry {
     pub timestamp_millis: i64,
     pub operation: String,
     pub description: String,
+}
+
+#[uniffi::remote(Record)]
+pub struct JjCommandResult {
+    pub output: String,
+    pub exit_code: i32,
 }
 
 #[uniffi::remote(Record)]

--- a/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/DiffColors.swift
+++ b/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/DiffColors.swift
@@ -84,6 +84,19 @@ public struct DiffColors {
         )
     }
 
+    var findCurrentMatchBg: NSColor {
+        isDark ? NSColor(calibratedRed: 1.0, green: 0.76, blue: 0.18, alpha: 0.86) : NSColor(
+            calibratedRed: 1.0,
+            green: 0.82,
+            blue: 0.12,
+            alpha: 0.9
+        )
+    }
+
+    var findCurrentMatchText: NSColor {
+        NSColor(calibratedWhite: 0.05, alpha: 1)
+    }
+
     /// Syntax tokens (GitHub-inspired)
     var keyword: NSColor {
         isDark ? NSColor(red: 1, green: 0.48, blue: 0.45, alpha: 1) : NSColor(

--- a/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/DiffTextSupport.swift
+++ b/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/DiffTextSupport.swift
@@ -5,6 +5,8 @@ final class DiffLayoutManager: NSLayoutManager {
     var lineStripeColors: [NSColor] = []
     var lineStripeX: CGFloat = 0
     var lineStripeWidth: CGFloat = 0
+    var selectedRangeBgColor: NSColor = .selectedTextBackgroundColor
+    var findMatchBgColor: NSColor = .findHighlightColor
 
     /// Width to fill for per-line background colors. No-wrap containers have
     /// `containerSize.width == .greatestFiniteMagnitude`, so we use the laid-out
@@ -56,13 +58,13 @@ final class DiffLayoutManager: NSLayoutManager {
     }
 
     override func drawBackground(forGlyphRange glyphsToShow: NSRange, at origin: NSPoint) {
-        guard let textStorage, textContainers.first != nil else {
+        guard let textStorage, let textContainer = textContainers.first else {
             super.drawBackground(forGlyphRange: glyphsToShow, at: origin)
             return
         }
 
         let drawWidth = lineBackgroundFillWidth
-        let selectedCharRanges: [NSRange] = (textContainers.first?.textView?.selectedRanges as? [NSValue])?
+        let selectedCharRanges: [NSRange] = (textContainer.textView?.selectedRanges as? [NSValue])?
             .map(\.rangeValue)
             .filter { $0.length > 0 } ?? []
 
@@ -118,6 +120,23 @@ final class DiffLayoutManager: NSLayoutManager {
         }
 
         super.drawBackground(forGlyphRange: glyphsToShow, at: origin)
+        if let textView = textContainer.textView as? DiffTextView,
+           textView.showsFindHighlights,
+           let findString = textView.activeFindQuery
+        {
+            drawFindMatchHighlights(
+                findMatchRanges(findString, visibleGlyphRange: glyphsToShow),
+                visibleGlyphRange: glyphsToShow,
+                in: textContainer,
+                at: origin
+            )
+        }
+        drawSelectedRangeHighlights(
+            selectedCharRanges,
+            visibleGlyphRange: glyphsToShow,
+            in: textContainer,
+            at: origin
+        )
     }
 
     /// NSLayoutManager coalesces full-line selections into a single
@@ -136,16 +155,101 @@ final class DiffLayoutManager: NSLayoutManager {
             rectCount.pointee = 0
             return nil
         }
-        let glyphsInRange = glyphRange(forCharacterRange: intersected, actualCharacterRange: nil)
-        if glyphsInRange.length == 0 {
+        let perLine = selectionRects(forCharacterRange: intersected, in: container)
+        if perLine.isEmpty {
             rectCount.pointee = 0
             return nil
         }
 
+        let buf = ensureRectBuffer(capacity: perLine.count)
+        for (i, r) in perLine.enumerated() {
+            buf[i] = r
+        }
+        rectCount.pointee = perLine.count
+        return buf.baseAddress
+    }
+
+    private func drawSelectedRangeHighlights(
+        _ ranges: [NSRange],
+        visibleGlyphRange: NSRange,
+        in container: NSTextContainer,
+        at origin: NSPoint
+    ) {
+        guard !ranges.isEmpty else { return }
+        let backgroundColor = (container.textView as? DiffTextView)?.selectionHighlightBackgroundColor
+            ?? selectedRangeBgColor
+        backgroundColor.setFill()
+        for range in ranges {
+            for rect in selectionRects(forCharacterRange: range, in: container, visibleGlyphRange: visibleGlyphRange) {
+                let drawRect = rect
+                    .offsetBy(dx: origin.x, dy: origin.y)
+                    .insetBy(dx: -1, dy: 1)
+                NSBezierPath(roundedRect: drawRect, xRadius: 2, yRadius: 2).fill()
+            }
+        }
+    }
+
+    private func drawFindMatchHighlights(
+        _ ranges: [NSRange],
+        visibleGlyphRange: NSRange,
+        in container: NSTextContainer,
+        at origin: NSPoint
+    ) {
+        guard !ranges.isEmpty else { return }
+        findMatchBgColor.setFill()
+        for range in ranges {
+            for rect in selectionRects(forCharacterRange: range, in: container, visibleGlyphRange: visibleGlyphRange) {
+                let drawRect = rect
+                    .offsetBy(dx: origin.x, dy: origin.y)
+                    .insetBy(dx: -1, dy: 1)
+                NSBezierPath(roundedRect: drawRect, xRadius: 2, yRadius: 2).fill()
+            }
+        }
+    }
+
+    func findMatchRanges(_ findString: String, visibleGlyphRange: NSRange? = nil) -> [NSRange] {
+        guard let textStorage else { return [] }
+        let text = textStorage.string as NSString
+        let findLength = (findString as NSString).length
+        guard findLength > 0, text.length >= findLength else { return [] }
+
+        let visibleCharRange = visibleGlyphRange
+            .map { characterRange(forGlyphRange: $0, actualGlyphRange: nil) }
+            ?? NSRange(location: 0, length: text.length)
+        guard visibleCharRange.location != NSNotFound, visibleCharRange.length > 0 else { return [] }
+
+        let searchStart = max(0, visibleCharRange.location - findLength + 1)
+        let searchEnd = min(text.length, NSMaxRange(visibleCharRange) + findLength - 1)
+        guard searchEnd > searchStart else { return [] }
+
+        var ranges: [NSRange] = []
+        var location = searchStart
+        while location < searchEnd {
+            let remaining = NSRange(location: location, length: searchEnd - location)
+            let found = text.range(of: findString, options: [.caseInsensitive], range: remaining)
+            guard found.location != NSNotFound else { break }
+            if NSIntersectionRange(found, visibleCharRange).length > 0 {
+                ranges.append(found)
+            }
+            location = max(NSMaxRange(found), found.location + 1)
+        }
+        return ranges
+    }
+
+    private func selectionRects(
+        forCharacterRange charRange: NSRange,
+        in container: NSTextContainer,
+        visibleGlyphRange: NSRange? = nil
+    ) -> [NSRect] {
+        let glyphsInRange = glyphRange(forCharacterRange: charRange, actualCharacterRange: nil)
+        guard glyphsInRange.length > 0 else { return [] }
+        let glyphsToDraw = visibleGlyphRange.map { NSIntersectionRange(glyphsInRange, $0) } ?? glyphsInRange
+        guard glyphsToDraw.length > 0 else { return [] }
+
         var perLine: [NSRect] = []
-        enumerateLineFragments(forGlyphRange: glyphsInRange) {
+        enumerateLineFragments(forGlyphRange: glyphsToDraw) {
             lineRect, usedRect, _, lineGlyphRange, _ in
-            let onLine = NSIntersectionRange(lineGlyphRange, glyphsInRange)
+            let onLine = NSIntersectionRange(lineGlyphRange, glyphsToDraw)
             if onLine.length == 0 { return }
 
             let firstBox = self.boundingRect(
@@ -167,13 +271,7 @@ final class DiffLayoutManager: NSLayoutManager {
                 height: lineRect.height
             ))
         }
-
-        let buf = ensureRectBuffer(capacity: perLine.count)
-        for (i, r) in perLine.enumerated() {
-            buf[i] = r
-        }
-        rectCount.pointee = perLine.count
-        return buf.baseAddress
+        return perLine
     }
 
     private func ensureRectBuffer(capacity: Int) -> UnsafeMutableBufferPointer<NSRect> {

--- a/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/DiffTextView+FindSession.swift
+++ b/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/DiffTextView+FindSession.swift
@@ -1,0 +1,288 @@
+import AppKit
+
+extension DiffTextView {
+    func findAction(_ sender: Any?) -> NSFindPanelAction? {
+        if let item = sender as? NSMenuItem {
+            return NSFindPanelAction(rawValue: UInt(item.tag))
+        }
+        if let control = sender as? NSControl {
+            return NSFindPanelAction(rawValue: UInt(control.tag))
+        }
+        if let cell = sender as? NSCell {
+            return NSFindPanelAction(rawValue: UInt(cell.tag))
+        }
+        return nil
+    }
+
+    func syncFindSelectionState(scrollToCurrent: Bool) {
+        let hasFindSelection = currentFindSelectionRange() != nil
+        hasCurrentFindSelection = showsFindHighlights && hasFindSelection
+        invalidateFindHighlights()
+        if scrollToCurrent, hasFindSelection {
+            scrollCurrentFindSelectionToVisible()
+        }
+    }
+
+    @discardableResult
+    func syncActiveFindQueryFromPasteboard(propagate: Bool) -> Bool {
+        let query = currentFindPasteboardString()
+        guard activeFindQuery != query else {
+            syncFindSelectionState(scrollToCurrent: false)
+            return false
+        }
+        activeFindQuery = query
+        if propagate {
+            findPartner?.receiveFindQuery(query, active: showsFindHighlights)
+        }
+        return true
+    }
+
+    func receiveFindQuery(_ query: String?, active: Bool) {
+        showsFindHighlights = active
+        activeFindQuery = query
+        if active {
+            startFindPasteboardMonitoring()
+        }
+        invalidateFindHighlights()
+    }
+
+    func activateFindSession(propagate: Bool) {
+        showsFindHighlights = true
+        hasObservedFindBarVisible = hasObservedFindBarVisible || enclosingScrollView?.isFindBarVisible == true
+        startFindPasteboardMonitoring()
+        syncActiveFindQueryFromPasteboard(propagate: propagate)
+        if propagate {
+            findPartner?.receiveFindQuery(activeFindQuery, active: true)
+        }
+    }
+
+    func endFindSession(propagate: Bool) {
+        pendingFindSelection?.cancel()
+        pendingFindSelection = nil
+        showsFindHighlights = false
+        if propagate {
+            findPartner?.endFindSession(propagate: false)
+        }
+    }
+
+    func startFindPasteboardMonitoring() {
+        guard findPasteboardTimer == nil else { return }
+        findPasteboardChangeCount = NSPasteboard(name: .find).changeCount
+        let timer = Timer(timeInterval: 0.1, repeats: true) { [weak self] _ in
+            self?.pollFindPasteboard()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        findPasteboardTimer = timer
+    }
+
+    func stopFindPasteboardMonitoring() {
+        findPasteboardTimer?.invalidate()
+        findPasteboardTimer = nil
+    }
+
+    func pollFindPasteboard() {
+        guard showsFindHighlights else {
+            stopFindPasteboardMonitoring()
+            return
+        }
+        guard syncFindBarVisibility() else { return }
+        let pasteboard = NSPasteboard(name: .find)
+        let queryChanged = pasteboard.changeCount != findPasteboardChangeCount ||
+            currentFindPasteboardString() != activeFindQuery
+        guard queryChanged else { return }
+
+        findPasteboardChangeCount = pasteboard.changeCount
+        if syncActiveFindQueryFromPasteboard(propagate: true) {
+            scheduleDebouncedFindSelection()
+        }
+    }
+
+    @discardableResult
+    func syncFindBarVisibility() -> Bool {
+        guard showsFindHighlights else { return false }
+        guard let scrollView = enclosingScrollView else { return true }
+
+        if scrollView.isFindBarVisible {
+            hasObservedFindBarVisible = true
+            return true
+        }
+
+        if hasObservedFindBarVisible {
+            endFindSession(propagate: true)
+            return false
+        }
+        return true
+    }
+
+    func scheduleDebouncedFindSelection() {
+        pendingFindSelection?.cancel()
+        guard showsFindHighlights, activeFindQuery != nil else { return }
+
+        let work = DispatchWorkItem { [weak self] in
+            self?.selectFindMatchAfterTyping()
+        }
+        pendingFindSelection = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18, execute: work)
+    }
+
+    func selectFindMatchAfterTyping() {
+        pendingFindSelection = nil
+        guard showsFindHighlights, activeFindQuery != nil else { return }
+        if currentFindSelectionRange() != nil {
+            scrollCurrentFindSelectionToVisible()
+            return
+        }
+        _ = selectFindMatch(direction: .forward, includePartner: true)
+    }
+
+    @discardableResult
+    func selectFindMatch(direction: DiffFindDirection, includePartner: Bool) -> Bool {
+        syncActiveFindQueryFromPasteboard(propagate: true)
+        guard let query = activeFindQuery else { return false }
+
+        if let range = findRange(query, direction: direction, wrapping: false) {
+            selectFindRange(range, scroll: true)
+            return true
+        }
+
+        if includePartner,
+           let partner = findPartner,
+           let range = partner.edgeFindRange(query, direction: direction)
+        {
+            partner.receiveFindQuery(query, active: true)
+            partner.selectFindRange(range, scroll: true)
+            window?.makeFirstResponder(partner)
+            return true
+        }
+
+        if let range = findRange(query, direction: direction, wrapping: true) {
+            selectFindRange(range, scroll: true)
+            return true
+        }
+        return false
+    }
+
+    func selectFindRange(_ range: NSRange, scroll: Bool) {
+        setSelectedRange(range)
+        hasCurrentFindSelection = true
+        if scroll {
+            scrollCurrentFindSelectionToVisible()
+        }
+    }
+
+    func findRange(_ query: String, direction: DiffFindDirection, wrapping: Bool) -> NSRange? {
+        let text = string as NSString
+        let queryLength = (query as NSString).length
+        guard queryLength > 0, text.length >= queryLength else { return nil }
+
+        let selection = selectedRanges.first?.rangeValue ?? NSRange(location: 0, length: 0)
+        let currentSelection = currentFindSelectionRange()
+        switch direction {
+            case .forward:
+                let start = currentSelection.map(NSMaxRange) ?? selection.location
+                if let range = text.firstRange(of: query, from: start) {
+                    return range
+                }
+                return wrapping ? text.firstRange(of: query, from: 0, to: start) : nil
+            case .backward:
+                let end = currentSelection?.location ?? selection.location
+                if let range = text.lastRange(of: query, upTo: end) {
+                    return range
+                }
+                return wrapping ? text.lastRange(of: query, from: end) : nil
+        }
+    }
+
+    func edgeFindRange(_ query: String, direction: DiffFindDirection) -> NSRange? {
+        let text = string as NSString
+        switch direction {
+            case .forward:
+                return text.firstRange(of: query, from: 0)
+            case .backward:
+                return text.lastRange(of: query, upTo: text.length)
+        }
+    }
+
+    func scrollCurrentFindSelectionToVisible() {
+        guard let range = currentFindSelectionRange() else { return }
+
+        guard let layoutManager, let textContainer else {
+            scrollRangeToVisible(range)
+            return
+        }
+
+        layoutManager.ensureLayout(forCharacterRange: range)
+        scrollRangeToVisible(range)
+
+        let glyphRange = layoutManager.glyphRange(forCharacterRange: range, actualCharacterRange: nil)
+        guard glyphRange.length > 0 else { return }
+
+        let matchRect = layoutManager
+            .boundingRect(forGlyphRange: glyphRange, in: textContainer)
+            .offsetBy(dx: textContainerOrigin.x, dy: textContainerOrigin.y)
+        guard let scrollView = enclosingScrollView else { return }
+
+        let clipView = scrollView.contentView
+        let visibleRect = clipView.bounds
+        let margin = min(CGFloat(24), visibleRect.height / 3)
+        if visibleRect.insetBy(dx: 0, dy: margin).contains(matchRect) {
+            return
+        }
+
+        let maxY = max(CGFloat(0), bounds.height - visibleRect.height)
+        let targetY = min(max(CGFloat(0), matchRect.midY - visibleRect.height / 2), maxY)
+        clipView.scroll(to: NSPoint(x: visibleRect.origin.x, y: targetY))
+        scrollView.reflectScrolledClipView(clipView)
+    }
+
+    func currentFindSelectionRange() -> NSRange? {
+        guard let findString = activeFindQuery ?? currentFindPasteboardString() else { return nil }
+        let findLength = (findString as NSString).length
+        guard findLength > 0 else { return nil }
+
+        let text = string as NSString
+        for value in selectedRanges {
+            let range = value.rangeValue
+            guard range.location != NSNotFound,
+                  range.length == findLength,
+                  NSMaxRange(range) <= text.length,
+                  text.compare(findString, options: [.caseInsensitive], range: range) == .orderedSame
+            else { continue }
+            return range
+        }
+        return nil
+    }
+
+    func invalidateFindHighlights() {
+        let range = NSRange(location: 0, length: (string as NSString).length)
+        layoutManager?.invalidateDisplay(forCharacterRange: range)
+        needsDisplay = true
+    }
+
+    func applySelectionAttributes() {
+        selectedTextAttributes = hasCurrentFindSelection ? findSelectionAttributes : defaultSelectionAttributes
+    }
+}
+
+enum DiffFindDirection {
+    case forward
+    case backward
+}
+
+extension NSFindPanelAction {
+    var usesDiffFindHighlights: Bool {
+        switch self {
+            case .showFindPanel, .next, .previous, .setFindString, .selectAll, .selectAllInSelection:
+                true
+            default:
+                false
+        }
+    }
+}
+
+private func currentFindPasteboardString() -> String? {
+    guard let findString = NSPasteboard(name: .find).string(forType: .string) else {
+        return nil
+    }
+    return findString.isEmpty ? nil : findString
+}

--- a/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/DiffTextView.swift
+++ b/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/DiffTextView.swift
@@ -1,0 +1,134 @@
+import AppKit
+
+final class DiffTextView: NSTextView {
+    weak var findPartner: DiffTextView?
+
+    var showsFindHighlights = false {
+        didSet {
+            if !showsFindHighlights {
+                hasCurrentFindSelection = false
+                activeFindQuery = nil
+                hasObservedFindBarVisible = false
+                stopFindPasteboardMonitoring()
+            }
+            applySelectionAttributes()
+            invalidateFindHighlights()
+        }
+    }
+
+    var activeFindQuery: String? {
+        didSet {
+            if activeFindQuery != oldValue {
+                syncFindSelectionState(scrollToCurrent: false)
+            }
+        }
+    }
+
+    var hasCurrentFindSelection = false {
+        didSet {
+            applySelectionAttributes()
+            invalidateFindHighlights()
+        }
+    }
+
+    var findPasteboardChangeCount = NSPasteboard(name: .find).changeCount
+    var findPasteboardTimer: Timer?
+    var pendingFindSelection: DispatchWorkItem?
+    var hasObservedFindBarVisible = false
+    var findSelectionBackgroundColor = NSColor.selectedTextBackgroundColor
+    var findSelectionAttributes: [NSAttributedString.Key: Any] = [
+        .backgroundColor: NSColor.selectedTextBackgroundColor,
+        .foregroundColor: NSColor.selectedTextColor
+    ]
+    let defaultSelectionAttributes: [NSAttributedString.Key: Any] = [
+        .backgroundColor: NSColor.selectedTextBackgroundColor,
+        .foregroundColor: NSColor.selectedTextColor
+    ]
+
+    func configureFindSelectionColors(_ theme: DiffColors) {
+        findSelectionBackgroundColor = theme.findCurrentMatchBg
+        findSelectionAttributes = [
+            .backgroundColor: theme.findCurrentMatchBg,
+            .foregroundColor: theme.findCurrentMatchText
+        ]
+        applySelectionAttributes()
+    }
+
+    var selectionHighlightBackgroundColor: NSColor {
+        hasCurrentFindSelection ? findSelectionBackgroundColor : .selectedTextBackgroundColor
+    }
+
+    override func performFindPanelAction(_ sender: Any?) {
+        let action = findAction(sender)
+        if action == .next || action == .previous {
+            activateFindSession(propagate: true)
+            super.performFindPanelAction(sender)
+            syncActiveFindQueryFromPasteboard(propagate: true)
+            syncFindSelectionState(scrollToCurrent: true)
+            return
+        }
+
+        let shouldTrackFind = action?.usesDiffFindHighlights ?? true
+        if shouldTrackFind {
+            activateFindSession(propagate: true)
+        }
+        super.performFindPanelAction(sender)
+        if shouldTrackFind {
+            syncActiveFindQueryFromPasteboard(propagate: true)
+            scheduleDebouncedFindSelection()
+            DispatchQueue.main.async { [weak self] in
+                self?.syncActiveFindQueryFromPasteboard(propagate: true)
+                self?.scheduleDebouncedFindSelection()
+            }
+        } else {
+            invalidateFindHighlights()
+        }
+    }
+
+    override func cancelOperation(_ sender: Any?) {
+        endFindSession(propagate: true)
+        super.cancelOperation(sender)
+    }
+
+    override func setSelectedRange(_ charRange: NSRange) {
+        super.setSelectedRange(charRange)
+        if showsFindHighlights {
+            syncFindSelectionState(scrollToCurrent: false)
+        }
+    }
+
+    override func setSelectedRange(
+        _ charRange: NSRange,
+        affinity: NSSelectionAffinity,
+        stillSelecting stillSelectingFlag: Bool
+    ) {
+        super.setSelectedRange(charRange, affinity: affinity, stillSelecting: stillSelectingFlag)
+        if showsFindHighlights, !stillSelectingFlag {
+            syncFindSelectionState(scrollToCurrent: false)
+        }
+    }
+
+    override func setSelectedRanges(
+        _ ranges: [NSValue],
+        affinity: NSSelectionAffinity,
+        stillSelecting stillSelectingFlag: Bool
+    ) {
+        super.setSelectedRanges(ranges, affinity: affinity, stillSelecting: stillSelectingFlag)
+        if showsFindHighlights, !stillSelectingFlag {
+            syncFindSelectionState(scrollToCurrent: false)
+        }
+    }
+
+    deinit {
+        pendingFindSelection?.cancel()
+        stopFindPasteboardMonitoring()
+    }
+}
+
+extension NSTextView {
+    func applyFindSelectionColors(_ theme: DiffColors) {
+        if let diffTextView = self as? DiffTextView {
+            diffTextView.configureFindSelectionColors(theme)
+        }
+    }
+}

--- a/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/NSString+SearchRanges.swift
+++ b/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/NSString+SearchRanges.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+extension NSString {
+    func firstRange(of query: String, from start: Int) -> NSRange? {
+        firstRange(of: query, from: start, to: length)
+    }
+
+    func firstRange(of query: String, from start: Int, to end: Int) -> NSRange? {
+        let safeStart = max(0, min(start, length))
+        let safeEnd = max(safeStart, min(end, length))
+        let range = NSRange(location: safeStart, length: safeEnd - safeStart)
+        let found = self.range(of: query, options: [.caseInsensitive], range: range)
+        return found.location == NSNotFound ? nil : found
+    }
+
+    func lastRange(of query: String, upTo end: Int) -> NSRange? {
+        let safeEnd = max(0, min(end, length))
+        guard safeEnd > 0 else { return nil }
+        let found = range(
+            of: query,
+            options: [.caseInsensitive, .backwards],
+            range: NSRange(location: 0, length: safeEnd)
+        )
+        return found.location == NSNotFound ? nil : found
+    }
+
+    func lastRange(of query: String, from start: Int) -> NSRange? {
+        let safeStart = max(0, min(start, length))
+        guard safeStart < length else { return nil }
+        let found = range(
+            of: query,
+            options: [.caseInsensitive, .backwards],
+            range: NSRange(location: safeStart, length: length - safeStart)
+        )
+        return found.location == NSNotFound ? nil : found
+    }
+}

--- a/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/NativeDiffView.swift
+++ b/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/NativeDiffView.swift
@@ -66,7 +66,7 @@ public struct NativeDiffView: NSViewRepresentable {
         let storage = NSTextStorage()
         storage.addLayoutManager(layoutManager)
 
-        let textView = NSTextView(frame: scrollView.bounds, textContainer: textContainer)
+        let textView = DiffTextView(frame: scrollView.bounds, textContainer: textContainer)
         textView.isEditable = false
         textView.isSelectable = true
         textView.autoresizingMask = [.width]
@@ -100,6 +100,7 @@ public struct NativeDiffView: NSViewRepresentable {
         let font = NSFont(name: fontFamily, size: fontSize) ?? .monospacedSystemFont(ofSize: fontSize, weight: .regular)
         let isDark = colorScheme == .dark
         let theme = DiffColors(isDark: isDark)
+        textView.applyFindSelectionColors(theme)
         let selectionActions = gutterActions as? any DiffGutterSelectionActions
         let reviewActions = gutterActions as? any DiffGutterReviewActions
 
@@ -196,6 +197,8 @@ public struct NativeDiffView: NSViewRepresentable {
         layoutManager.lineBgColors = contentLineBgColors
         layoutManager.lineStripeColors = []
         layoutManager.lineStripeWidth = 0
+        layoutManager.selectedRangeBgColor = .selectedTextBackgroundColor
+        layoutManager.findMatchBgColor = .findHighlightColor
         gutterTextView.menuProvider = menuProvider(selection:)
         gutterTextView.groupRangeProvider = { lineNumber in
             expandedHunkRange(containing: lineNumber ... lineNumber)

--- a/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/SideBySideDiffCoordinator.swift
+++ b/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/SideBySideDiffCoordinator.swift
@@ -62,18 +62,24 @@ public final class SideBySideCoordinator: NSObject, NSSplitViewDelegate {
     }
 
     func renderIfNeeded(force: Bool) {
-        guard let diff = diff,
-              let font = font,
-              let theme = theme,
+        guard let diff,
+              let font,
+              let theme,
               let left = leftContainer?.paneViews(),
               let right = rightContainer?.paneViews()
         else { return }
 
         // Pane content widths (post-gutter) and monospace cell advance.
         let advance = Float(("M" as NSString).size(withAttributes: [.font: font]).width)
-        let oldCols = wrapColsForWidth(width: Float(max(0, left.container.scrollView.contentSize.width)), advance: advance)
-        let newCols = wrapColsForWidth(width: Float(max(0, right.container.scrollView.contentSize.width)), advance: advance)
-        if !force && oldCols == lastOldCols && newCols == lastNewCols {
+        let oldCols = wrapColsForWidth(
+            width: Float(max(0, left.container.scrollView.contentSize.width)),
+            advance: advance
+        )
+        let newCols = wrapColsForWidth(
+            width: Float(max(0, right.container.scrollView.contentSize.width)),
+            advance: advance
+        )
+        if !force, oldCols == lastOldCols, newCols == lastNewCols {
             return
         }
         lastOldCols = oldCols
@@ -100,12 +106,30 @@ public final class SideBySideCoordinator: NSObject, NSSplitViewDelegate {
             .paragraphStyle: gutterParagraphStyle
         ]
         let trailingPadding: CGFloat = 10
+        left.textView.applyFindSelectionColors(theme)
+        left.textLayout.selectedRangeBgColor = .selectedTextBackgroundColor
+        left.textLayout.findMatchBgColor = .findHighlightColor
+        right.textView.applyFindSelectionColors(theme)
+        right.textLayout.selectedRangeBgColor = .selectedTextBackgroundColor
+        right.textLayout.findMatchBgColor = .findHighlightColor
 
         var leftAcc = PaneAccumulator(pane: left)
         var rightAcc = PaneAccumulator(pane: right)
         for row in rows {
-            leftAcc.append(row.old, font: font, theme: theme, gutterAttrs: gutterAttrs, trailingPadding: trailingPadding)
-            rightAcc.append(row.new, font: font, theme: theme, gutterAttrs: gutterAttrs, trailingPadding: trailingPadding)
+            leftAcc.append(
+                row.old,
+                font: font,
+                theme: theme,
+                gutterAttrs: gutterAttrs,
+                trailingPadding: trailingPadding
+            )
+            rightAcc.append(
+                row.new,
+                font: font,
+                theme: theme,
+                gutterAttrs: gutterAttrs,
+                trailingPadding: trailingPadding
+            )
         }
 
         if rows.isEmpty {

--- a/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/SideBySideDiffRendering.swift
+++ b/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/SideBySideDiffRendering.swift
@@ -51,7 +51,7 @@ extension SideBySideRepresentable {
         let storage = NSTextStorage()
         storage.addLayoutManager(layoutManager)
 
-        let textView = NSTextView(frame: scrollView.bounds, textContainer: textContainer)
+        let textView = DiffTextView(frame: scrollView.bounds, textContainer: textContainer)
         textView.isEditable = false
         textView.isSelectable = true
         textView.isVerticallyResizable = true
@@ -59,6 +59,9 @@ extension SideBySideRepresentable {
         textView.autoresizingMask = [.width]
         textView.textContainerInset = NSSize(width: 4, height: 6)
         textView.drawsBackground = false
+        textView.usesFindBar = true
+        textView.isIncrementalSearchingEnabled = true
+        textView.identifier = NSUserInterfaceItemIdentifier("diffTextView")
         textView.minSize = NSSize(width: 0, height: 0)
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
         scrollView.documentView = textView

--- a/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/SideBySideDiffView.swift
+++ b/shell/mac/Packages/JayJayDiffUI/Sources/JayJayDiffUI/SideBySideDiffView.swift
@@ -40,6 +40,8 @@ public struct SideBySideRepresentable: NSViewRepresentable {
 
         let left = makeContainer()
         let right = makeContainer()
+        (left.textView as? DiffTextView)?.findPartner = right.textView as? DiffTextView
+        (right.textView as? DiffTextView)?.findPartner = left.textView as? DiffTextView
         // We pre-wrap rows in Rust via `wrapSbsRows` so each visual row is shorter
         // than the pane's column count. The NSTextContainer therefore should NOT
         // wrap on its own — that would re-wrap the pre-wrapped row and desync the panes.

--- a/shell/mac/Packages/JayJayDiffUI/Tests/JayJayDiffUITests/DiffLayoutManagerTests.swift
+++ b/shell/mac/Packages/JayJayDiffUI/Tests/JayJayDiffUITests/DiffLayoutManagerTests.swift
@@ -129,6 +129,175 @@ final class DiffLayoutManagerTests: XCTestCase {
         XCTAssertEqual(width, 0, accuracy: 0.001)
     }
 
+    func test_rectArray_includesSingleFindMatch() throws {
+        let (manager, storage) = makeNoWrapLayout()
+        let prefix = "let stdout = "
+        let match = "trim_output"
+        storage.append(NSAttributedString(
+            string: "\(prefix)\(match)(&output.stdout);\n",
+            attributes: [.font: NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)]
+        ))
+        manager.ensureLayout(for: manager.textContainers[0])
+
+        let charRange = NSRange(location: prefix.utf16.count, length: match.utf16.count)
+        var count = 0
+        let rects = withUnsafeMutablePointer(to: &count) { rectCountPtr in
+            manager.rectArray(
+                forCharacterRange: charRange,
+                withinSelectedCharacterRange: charRange,
+                in: manager.textContainers[0],
+                rectCount: rectCountPtr
+            )
+        }
+
+        XCTAssertNotNil(rects)
+        XCTAssertEqual(count, 1)
+        let rect = try XCTUnwrap(rects?[0])
+        XCTAssertGreaterThan(rect.width, 20)
+        XCTAssertGreaterThan(rect.height, 8)
+    }
+
+    func test_findMatchRanges_returnsAllVisibleMatches() {
+        let (manager, storage) = makeNoWrapLayout()
+        let text = """
+        let stdout = trim_output(&output.stdout);
+        let stderr = trim_output(&output.stderr);
+        let other = no_match();
+        """
+        storage.append(NSAttributedString(
+            string: text,
+            attributes: [.font: NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)]
+        ))
+        manager.ensureLayout(for: manager.textContainers[0])
+
+        let ranges = manager.findMatchRanges("trim_output")
+
+        XCTAssertEqual(ranges.count, 2)
+        XCTAssertEqual((storage.string as NSString).substring(with: ranges[0]), "trim_output")
+        XCTAssertEqual((storage.string as NSString).substring(with: ranges[1]), "trim_output")
+    }
+
+    func test_diffTextView_usesFindSelectionColorOnlyForCurrentFindMatch() {
+        let (textView, _) = makeScrollableDiffTextView()
+        textView.textStorage?.setAttributedString(NSAttributedString(
+            string: "let stdout = trim_output(&output.stdout);\nlet other = no_match();\n",
+            attributes: [.font: NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)]
+        ))
+        let theme = DiffColors(isDark: false)
+        textView.configureFindSelectionColors(theme)
+
+        NSPasteboard(name: .find).clearContents()
+        NSPasteboard(name: .find).setString("trim_output", forType: .string)
+        textView.showsFindHighlights = true
+        textView.setSelectedRange(NSRange(location: "let stdout = ".utf16.count, length: "trim_output".utf16.count))
+
+        XCTAssertEqual(
+            textView.selectedTextAttributes[.backgroundColor] as? NSColor,
+            theme.findCurrentMatchBg
+        )
+
+        textView.setSelectedRange(NSRange(location: 0, length: "let".utf16.count))
+        XCTAssertEqual(
+            textView.selectedTextAttributes[.backgroundColor] as? NSColor,
+            NSColor.selectedTextBackgroundColor
+        )
+    }
+
+    func test_diffTextView_scrollsCurrentFindSelectionToVisible() throws {
+        let (textView, scrollView) = makeScrollableDiffTextView(height: 80)
+        let prefix = String(repeating: "context\n", count: 120)
+        let match = "trim_output"
+        let text = prefix + match + "\n"
+        textView.textStorage?.setAttributedString(NSAttributedString(
+            string: text,
+            attributes: [.font: NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)]
+        ))
+        try textView.layoutManager?.ensureLayout(for: XCTUnwrap(textView.textContainer))
+        let usedRect = try textView.layoutManager?.usedRect(for: XCTUnwrap(textView.textContainer)) ?? .zero
+        textView.frame.size.height = max(usedRect.height, scrollView.contentSize.height)
+
+        NSPasteboard(name: .find).clearContents()
+        NSPasteboard(name: .find).setString(match, forType: .string)
+        textView.showsFindHighlights = true
+        textView.setSelectedRange(NSRange(location: prefix.utf16.count, length: match.utf16.count))
+        scrollView.contentView.scroll(to: .zero)
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+
+        textView.scrollCurrentFindSelectionToVisible()
+
+        XCTAssertGreaterThan(scrollView.contentView.bounds.origin.y, 0)
+    }
+
+    func test_diffTextView_debouncesFindTypingAndSelectsFirstMatch() {
+        let (textView, _) = makeScrollableDiffTextView()
+        let prefix = "let stdout = "
+        let match = "trim_output"
+        textView.textStorage?.setAttributedString(NSAttributedString(
+            string: "\(prefix)\(match)(&output.stdout);\n",
+            attributes: [.font: NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)]
+        ))
+        textView.setSelectedRange(NSRange(location: 0, length: 0))
+
+        NSPasteboard(name: .find).clearContents()
+        NSPasteboard(name: .find).setString(match, forType: .string)
+        textView.performFindPanelAction(findMenuItem(.setFindString))
+        RunLoop.current.run(until: Date().addingTimeInterval(0.25))
+
+        XCTAssertEqual(textView.activeFindQuery, match)
+        XCTAssertEqual(
+            textView.selectedRanges.first?.rangeValue,
+            NSRange(location: prefix.utf16.count, length: match.utf16.count)
+        )
+    }
+
+    func test_diffTextView_findNavigationKeepsNativePaneScope() {
+        let (left, _) = makeScrollableDiffTextView()
+        let (right, _) = makeScrollableDiffTextView()
+        left.findPartner = right
+        right.findPartner = left
+
+        let prefix = "right side "
+        let match = "trim_output"
+        left.textStorage?.setAttributedString(NSAttributedString(
+            string: "left side has no match\n",
+            attributes: [.font: NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)]
+        ))
+        right.textStorage?.setAttributedString(NSAttributedString(
+            string: "\(prefix)\(match)\n",
+            attributes: [.font: NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)]
+        ))
+
+        NSPasteboard(name: .find).clearContents()
+        NSPasteboard(name: .find).setString(match, forType: .string)
+        left.performFindPanelAction(findMenuItem(.next))
+
+        XCTAssertEqual(left.activeFindQuery, match)
+        XCTAssertEqual(right.activeFindQuery, match)
+        XCTAssertTrue(right.showsFindHighlights)
+        XCTAssertNotEqual(right.selectedRanges.first?.rangeValue.length, match.utf16.count)
+    }
+
+    func test_diffTextView_clearsHighlightsWhenFindBarCloses() {
+        let (textView, scrollView) = makeScrollableDiffTextView()
+        let match = "trim_output"
+        textView.textStorage?.setAttributedString(NSAttributedString(
+            string: "\(match)\n",
+            attributes: [.font: NSFont.monospacedSystemFont(ofSize: 12, weight: .regular)]
+        ))
+
+        NSPasteboard(name: .find).clearContents()
+        NSPasteboard(name: .find).setString(match, forType: .string)
+        scrollView.isFindBarVisible = true
+        textView.performFindPanelAction(findMenuItem(.setFindString))
+        XCTAssertTrue(textView.showsFindHighlights)
+
+        scrollView.isFindBarVisible = false
+        textView.syncFindBarVisibility()
+
+        XCTAssertFalse(textView.showsFindHighlights)
+        XCTAssertNil(textView.activeFindQuery)
+    }
+
     // MARK: - Fixtures
 
     private func makeNoWrapLayout() -> (DiffLayoutManager, NSTextStorage) {
@@ -145,6 +314,39 @@ final class DiffLayoutManagerTests: XCTestCase {
         let storage = NSTextStorage()
         storage.addLayoutManager(manager)
         return (manager, storage)
+    }
+
+    private func findMenuItem(_ action: NSFindPanelAction) -> NSMenuItem {
+        let item = NSMenuItem()
+        item.tag = Int(action.rawValue)
+        return item
+    }
+
+    private func makeScrollableDiffTextView(
+        width: CGFloat = 240,
+        height: CGFloat = 160
+    ) -> (DiffTextView, NSScrollView) {
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+
+        let container = NSTextContainer(containerSize: NSSize(width: width, height: CGFloat.greatestFiniteMagnitude))
+        container.widthTracksTextView = true
+        container.lineFragmentPadding = 4
+
+        let manager = DiffLayoutManager()
+        manager.addTextContainer(container)
+
+        let storage = NSTextStorage()
+        storage.addLayoutManager(manager)
+
+        let textView = DiffTextView(frame: NSRect(x: 0, y: 0, width: width, height: height), textContainer: container)
+        textView.textContainerInset = .zero
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        scrollView.documentView = textView
+
+        return (textView, scrollView)
     }
 
     private func makeWrappingLayout(width: CGFloat) -> (DiffLayoutManager, NSTextStorage) {

--- a/shell/mac/Packages/JayJayDiffUI/Tests/JayJayDiffUITests/SearchRangeTests.swift
+++ b/shell/mac/Packages/JayJayDiffUI/Tests/JayJayDiffUITests/SearchRangeTests.swift
@@ -1,0 +1,39 @@
+import AppKit
+@testable import JayJayDiffUI
+import XCTest
+
+final class SearchRangeTests: XCTestCase {
+    func testLastRangeFromLengthReturnsNil() {
+        let text = "alpha beta" as NSString
+
+        XCTAssertNil(text.lastRange(of: "alpha", from: text.length))
+    }
+
+    func testLastRangeFromStartSearchesSuffixOnly() throws {
+        let text = "alpha beta alpha" as NSString
+
+        let range = try XCTUnwrap(text.lastRange(of: "alpha", from: 6))
+
+        XCTAssertEqual(range.location, 11)
+    }
+
+    func testFindMatchRangesIgnoresInvalidVisibleGlyphRange() {
+        let container = NSTextContainer(containerSize: NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        ))
+        let manager = DiffLayoutManager()
+        manager.addTextContainer(container)
+
+        let storage = NSTextStorage(string: "trim_output\n")
+        storage.addLayoutManager(manager)
+        manager.ensureLayout(for: container)
+
+        let ranges = manager.findMatchRanges(
+            "trim_output",
+            visibleGlyphRange: NSRange(location: NSNotFound, length: 1)
+        )
+
+        XCTAssertTrue(ranges.isEmpty)
+    }
+}

--- a/shell/mac/Sources/JayJay/Repo/RepoContentView+CommandPalette.swift
+++ b/shell/mac/Sources/JayJay/Repo/RepoContentView+CommandPalette.swift
@@ -48,9 +48,10 @@ extension RepoContentView {
             })
         }
 
-        items.append(CommandPaletteItem(title: "Git Pull (fetch + rebase)", icon: "arrow.down.circle", category: "Git") {
-            viewModel.gitFetch()
-        })
+        items
+            .append(CommandPaletteItem(title: "Git Pull (fetch + rebase)", icon: "arrow.down.circle", category: "Git") {
+                viewModel.gitFetch()
+            })
         items.append(CommandPaletteItem(title: "Git Push", icon: "arrow.up.circle", category: "Git") {
             viewModel.gitPush(bookmark: "")
         })
@@ -164,6 +165,13 @@ extension RepoContentView {
             openSettings()
         })
 
-        commandPanel.show(items: items, repoPath: viewModel.repoPath)
+        commandPanel.show(
+            items: items,
+            repoPath: viewModel.repoPath,
+            onJjCommandFinished: { result in
+                guard result.exitCode == 0 else { return }
+                viewModel.refresh()
+            }
+        )
     }
 }

--- a/shell/mac/Sources/JayJay/Shared/CommandPalette+RawJJ.swift
+++ b/shell/mac/Sources/JayJay/Shared/CommandPalette+RawJJ.swift
@@ -1,0 +1,158 @@
+import AppKit
+import JayJayCore
+import SwiftUI
+
+extension PaletteRoot {
+    var isJJ: Bool {
+        jjCommandBody(query: query) != nil
+    }
+
+    var jjCmd: String {
+        jjCommandBody(query: query) ?? ""
+    }
+
+    @ViewBuilder
+    var rawJjSection: some View {
+        if isRunning {
+            ProgressView()
+                .controlSize(.small)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let result = jjResult {
+            jjResultView(result, command: jjCmd)
+        } else if let jjError {
+            VStack(alignment: .leading, spacing: 10) {
+                Label(jjError, systemImage: "exclamationmark.triangle")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.red)
+                jjDiscovery
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .padding(12)
+        } else {
+            jjPreview
+        }
+    }
+
+    var jjDiscovery: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Raw jj commands run in this repository. Use ↑/↓ for history.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+            HStack(spacing: 8) {
+                ForEach(["status", "log -r @", "diff --stat", "op log"], id: \.self) { suggestion in
+                    Button("jj \(suggestion)") { query = "jj \(suggestion)" }
+                        .controlSize(.small)
+                }
+            }
+            if !history.isEmpty {
+                Text("Recent")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
+                ForEach(history.prefix(5), id: \.self) { command in
+                    Button { query = "jj \(command)" } label: {
+                        HStack {
+                            Image(systemName: "clock.arrow.circlepath")
+                                .foregroundStyle(.secondary)
+                            Text("jj \(command)")
+                                .font(.system(size: 11, design: .monospaced))
+                                .lineLimit(1)
+                            Spacer()
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    func recallHistory(older: Bool) {
+        let next = CommandPaletteHistory.recall(
+            history: history,
+            historyIndex: historyIndex,
+            older: older
+        )
+        guard let next else { return }
+        historyIndex = next.historyIndex
+        isRecallingHistory = true
+        query = next.query
+    }
+
+    private func jjResultView(_ result: JjCommandResult, command: String) -> some View {
+        let succeeded = result.exitCode == 0
+        return VStack(spacing: 0) {
+            HStack(spacing: 8) {
+                Image(systemName: succeeded ? "checkmark.circle.fill" : "xmark.circle.fill")
+                    .foregroundStyle(succeeded ? .green : .red)
+                Text("jj \(command)")
+                    .font(.system(size: 12, design: .monospaced))
+                    .lineLimit(1)
+                Spacer()
+                Text(succeeded ? "exit 0" : "exit \(result.exitCode)")
+                    .font(.system(size: 10, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                Button("Copy Output") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(result.output, forType: .string)
+                }
+                .controlSize(.small)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            Divider()
+            ScrollView {
+                Text(result.output)
+                    .font(.system(size: 11, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(12)
+            }
+        }
+    }
+
+    private var jjPreview: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("jj \(jjCmd)")
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                if !jjCmd.isEmpty {
+                    Text("Enter ↵")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            jjDiscovery
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(12)
+    }
+
+    func executeJJ() {
+        guard !jjCmd.isEmpty else { return }
+        guard parseJjCommandArgs(command: jjCmd) != nil else {
+            jjError = "Unclosed quote in jj command."
+            return
+        }
+        isRunning = true
+        jjResult = nil
+        jjError = nil
+        let path = repoPath
+        let command = jjCmd
+        MainActorTask.detached {
+            try runJjCommandInRepoPath(repoPath: path, command: command)
+        } completion: { result in
+            switch result {
+                case let .success(commandResult):
+                    jjResult = commandResult
+                    history = CommandPaletteHistory.record(command, in: history)
+                    if commandResult.exitCode == 0 {
+                        onJjCommandFinished(commandResult)
+                    }
+                case let .failure(error):
+                    jjError = error.localizedDescription
+            }
+            isRunning = false
+        }
+    }
+}

--- a/shell/mac/Sources/JayJay/Shared/CommandPalette.swift
+++ b/shell/mac/Sources/JayJay/Shared/CommandPalette.swift
@@ -10,8 +10,6 @@ struct CommandPaletteItem: Identifiable {
     let action: () -> Void
 }
 
-// MARK: - NSPanel
-
 final class CommandPalettePanel: NSPanel {
     init() {
         super.init(
@@ -29,28 +27,28 @@ final class CommandPalettePanel: NSPanel {
         hidesOnDeactivate = true
     }
 
-    func show(items: [CommandPaletteItem], repoPath: String) {
-        // Create a fresh view controller each time (guarantees fresh @State)
+    func show(
+        items: [CommandPaletteItem],
+        repoPath: String,
+        onJjCommandFinished: @escaping (JjCommandResult) -> Void = { _ in }
+    ) {
         let vc = NSHostingController(rootView: PaletteRoot(
             items: items,
             repoPath: repoPath,
+            onJjCommandFinished: onJjCommandFinished,
             onDismiss: { [weak self] in self?.dismiss() }
         ))
         contentViewController = vc
-        // Inherit dark/light appearance from the parent window
         if let parentAppearance = NSApp.windows.first(where: { $0.isKeyWindow && $0 !== self })?.appearance {
             appearance = parentAppearance
         } else {
             appearance = NSApp.effectiveAppearance
         }
-        setContentSize(NSSize(width: 480, height: 300))
+        setContentSize(NSSize(width: 520, height: 360))
 
-        // Center on parent window
         let parentFrame = NSApp.windows.first(where: { $0.isKeyWindow && $0 !== self })?.frame
             ?? NSScreen.main?.frame ?? .zero
-        let x = parentFrame.midX - 240
-        let y = parentFrame.midY + 40
-        setFrameOrigin(NSPoint(x: x, y: y))
+        setFrameOrigin(NSPoint(x: parentFrame.midX - 260, y: parentFrame.midY + 40))
         makeKeyAndOrderFront(nil)
     }
 
@@ -68,32 +66,20 @@ final class CommandPalettePanel: NSPanel {
     }
 }
 
-// MARK: - Root view (owns @State, destroyed on dismiss)
-
-private struct PaletteRoot: View {
+struct PaletteRoot: View {
     let items: [CommandPaletteItem]
     let repoPath: String
+    let onJjCommandFinished: (JjCommandResult) -> Void
     let onDismiss: () -> Void
 
-    @State private var query = ""
-    @State private var selectedIndex = 0
-    @State private var jjOutput: String?
-    @State private var isRunning = false
-
-    /// One of these prefixes means the rest of `query` is a raw jj CLI invocation.
-    private static let jjPrefixes = ["jj ", "!"]
-
-    private var isJJ: Bool {
-        query == "jj" || Self.jjPrefixes.contains(where: query.hasPrefix)
-    }
-
-    private var jjCmd: String {
-        let stripped = Self.jjPrefixes
-            .first(where: query.hasPrefix)
-            .map { String(query.dropFirst($0.count)) }
-            ?? (query == "jj" ? "" : query)
-        return stripped.trimmingCharacters(in: .whitespaces)
-    }
+    @State var query = ""
+    @State var selectedIndex = 0
+    @State var jjResult: JjCommandResult?
+    @State var jjError: String?
+    @State var isRunning = false
+    @State var history: [String] = []
+    @State var historyIndex: Int?
+    @State var isRecallingHistory = false
 
     private var filtered: [CommandPaletteItem] {
         guard !isJJ else { return [] }
@@ -108,7 +94,7 @@ private struct PaletteRoot: View {
                 Image(systemName: isJJ ? "terminal" : "magnifyingglass")
                     .foregroundStyle(.secondary)
                     .frame(width: 16)
-                TextField("Type a command or 'jj ' / '!' for jj CLI...", text: $query)
+                TextField("Search commands, type `jj status`, or use `!status`", text: $query)
                     .textFieldStyle(.plain)
                     .font(.system(size: 14))
                     .accessibilityIdentifier(AID.Palette.textField)
@@ -120,13 +106,23 @@ private struct PaletteRoot: View {
 
             resultArea
         }
-        .frame(width: 480, height: 300)
+        .frame(width: 520, height: 360)
         .background(.regularMaterial)
         .clipShape(RoundedRectangle(cornerRadius: 12))
-        .onKeyPress(.upArrow) { move(-1)
+        .onKeyPress(.upArrow) {
+            if isJJ {
+                recallHistory(older: true)
+            } else {
+                move(-1)
+            }
             return .handled
         }
-        .onKeyPress(.downArrow) { move(1)
+        .onKeyPress(.downArrow) {
+            if isJJ {
+                recallHistory(older: false)
+            } else {
+                move(1)
+            }
             return .handled
         }
         .onKeyPress { press in
@@ -144,7 +140,13 @@ private struct PaletteRoot: View {
             return .handled
         }
         .onChange(of: query) { selectedIndex = 0
-            jjOutput = nil
+            jjResult = nil
+            jjError = nil
+            if isRecallingHistory {
+                isRecallingHistory = false
+            } else {
+                historyIndex = nil
+            }
         }
     }
 
@@ -182,27 +184,8 @@ private struct PaletteRoot: View {
         }
     }
 
-    @ViewBuilder
     private var jjSection: some View {
-        if let output = jjOutput {
-            ScrollView {
-                Text(output)
-                    .font(.system(size: 11, design: .monospaced))
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(12)
-            }
-        } else if isRunning {
-            ProgressView().controlSize(.small).frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else {
-            HStack {
-                Text("jj \(jjCmd)").font(.system(size: 12, design: .monospaced)).foregroundStyle(.secondary)
-                Spacer()
-                if !jjCmd.isEmpty { Text("Enter ↵").font(.system(size: 10)).foregroundStyle(.tertiary) }
-            }
-            .padding(12)
-            Spacer()
-        }
+        rawJjSection
     }
 
     private func move(_ delta: Int) {
@@ -212,28 +195,7 @@ private struct PaletteRoot: View {
 
     private func execute() {
         if isJJ {
-            guard !jjCmd.isEmpty else { return }
-            isRunning = true
-            let args = jjCmd.components(separatedBy: " ")
-            let path = repoPath
-            Task.detached {
-                let status = checkJjEnvironment()
-                let proc = Process()
-                proc.executableURL = URL(fileURLWithPath: status.path)
-                proc.arguments = args
-                proc.currentDirectoryURL = URL(fileURLWithPath: path)
-                let pipe = Pipe()
-                proc.standardOutput = pipe
-                proc.standardError = pipe
-                try? proc.run()
-                proc.waitUntilExit()
-                let data = pipe.fileHandleForReading.readDataToEndOfFile()
-                let output = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "(no output)"
-                await MainActor.run {
-                    jjOutput = output
-                    isRunning = false
-                }
-            }
+            executeJJ()
         } else if !filtered.isEmpty, selectedIndex < filtered.count {
             filtered[selectedIndex].action()
             onDismiss()

--- a/shell/mac/Sources/JayJay/Shared/CommandPaletteSupport.swift
+++ b/shell/mac/Sources/JayJay/Shared/CommandPaletteSupport.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+enum CommandPaletteHistory {
+    private static let limit = 20
+
+    struct Recall {
+        let query: String
+        let historyIndex: Int?
+    }
+
+    static func record(_ command: String, in history: [String]) -> [String] {
+        let command = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !command.isEmpty else { return history }
+
+        var values = [command]
+        values.append(contentsOf: history.filter { $0 != command })
+        values = Array(values.prefix(limit))
+        return values
+    }
+
+    static func recall(history: [String], historyIndex: Int?, older: Bool) -> Recall? {
+        guard !history.isEmpty else { return nil }
+        let nextIndex: Int? = if older {
+            min((historyIndex ?? -1) + 1, history.count - 1)
+        } else if let historyIndex, historyIndex > 0 {
+            historyIndex - 1
+        } else {
+            nil
+        }
+        return Recall(
+            query: nextIndex.map { "jj \(history[$0])" } ?? "jj ",
+            historyIndex: nextIndex
+        )
+    }
+}

--- a/shell/mac/Sources/JayJay/Shared/MainActorTask.swift
+++ b/shell/mac/Sources/JayJay/Shared/MainActorTask.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum MainActorTask {
+    static func detached<Output>(
+        _ operation: @escaping () throws -> Output,
+        completion: @escaping @MainActor (Result<Output, any Error>) -> Void
+    ) {
+        Task.detached {
+            let result = Result { try operation() }
+            await MainActor.run {
+                completion(result)
+            }
+        }
+    }
+}

--- a/shell/mac/Tests/JayJayTests/CommandPaletteSupportTests.swift
+++ b/shell/mac/Tests/JayJayTests/CommandPaletteSupportTests.swift
@@ -1,0 +1,58 @@
+@testable import JayJay
+import JayJayCore
+import XCTest
+
+final class CommandPaletteSupportTests: XCTestCase {
+    func testParsesQuotedJjArguments() {
+        XCTAssertEqual(
+            parseJjCommandArgs(command: #"log -r "description(exact:'fix bug')" --limit 5"#),
+            ["log", "-r", "description(exact:'fix bug')", "--limit", "5"]
+        )
+    }
+
+    func testRejectsUnclosedQuote() {
+        XCTAssertNil(parseJjCommandArgs(command: #"log -r "mine()"#))
+    }
+
+    func testHistoryDedupesAndKeepsNewestFirst() {
+        var history: [String] = []
+
+        history = CommandPaletteHistory.record("status", in: history)
+        history = CommandPaletteHistory.record("log -r @", in: history)
+        history = CommandPaletteHistory.record("status", in: history)
+
+        XCTAssertEqual(Array(history.prefix(2)), ["status", "log -r @"])
+    }
+
+    func testHistoryRecallWalksOlderAndNewerEntries() {
+        let history = ["status", "log -r @", "diff --stat"]
+
+        let first = CommandPaletteHistory.recall(history: history, historyIndex: nil, older: true)
+        XCTAssertEqual(first?.query, "jj status")
+        XCTAssertEqual(first?.historyIndex, 0)
+
+        let second = CommandPaletteHistory.recall(
+            history: history,
+            historyIndex: first?.historyIndex,
+            older: true
+        )
+        XCTAssertEqual(second?.query, "jj log -r @")
+        XCTAssertEqual(second?.historyIndex, 1)
+
+        let newer = CommandPaletteHistory.recall(
+            history: history,
+            historyIndex: second?.historyIndex,
+            older: false
+        )
+        XCTAssertEqual(newer?.query, "jj status")
+        XCTAssertEqual(newer?.historyIndex, 0)
+
+        let liveQuery = CommandPaletteHistory.recall(
+            history: history,
+            historyIndex: newer?.historyIndex,
+            older: false
+        )
+        XCTAssertEqual(liveQuery?.query, "jj ")
+        XCTAssertNil(liveQuery?.historyIndex)
+    }
+}


### PR DESCRIPTION
## Summary

- Add a core `JjCommand` runner and expose raw jj execution through the command palette.
- Keep command palette history in memory only, with shared parsing/history helpers and tests.
- Fix DiffUI find highlighting so typed Cmd+F searches highlight visible matches, next/previous scroll to the current match, side-by-side search can fall through to the partner pane, and closing the native find bar clears custom highlights.
- Split DiffUI search support into focused files (`DiffTextView`, find-session behavior, and reusable NSString range helpers).

## Why

The raw jj command flow needed a smaller core API surface and less duplicated async boilerplate in Swift. Diff search also had a few AppKit integration gaps: visible text was not highlighted until relayout/scroll, the current match was hard to distinguish, and the native find bar could close without clearing custom highlights.

## Validation

- `cargo test -p jayjay-core jj_command`
- `cargo check -p jayjay-uniffi`
- `cd shell/mac/Packages/JayJayDiffUI && swift test`
- `just shell::test`