### PR TITLE
Animate refresh spinner in GPUI

### DIFF
--- a/agents/pull-requests.md
+++ b/agents/pull-requests.md
@@ -20,13 +20,13 @@ Keep edits in the working-copy change `@` until they are ready to publish:
 ```bash
 jj st
 jj diff
-jj describe -m "scope: concise change summary"
+jj describe -m "concise change summary"
 ```
 
 Split by responsibility when the working copy contains more than one logical change:
 
 ```bash
-jj split --paths <paths-for-one-change> -m "scope: one logical change"
+jj split --paths <paths-for-one-change> -m "one logical change"
 ```
 
 Repeat `jj split` until each PR-sized change has one clear purpose. Do not split just to mirror file boundaries; split by behavior, bug fix, or user-visible feature.
@@ -62,7 +62,7 @@ jj edit <topic>
 # edit files
 jj st
 jj diff
-jj describe -m "scope: updated summary"
+jj describe -m "updated summary"
 jj fix
 just test
 just lint

--- a/shell/gpui/assets/icons/refresh-cw.svg
+++ b/shell/gpui/assets/icons/refresh-cw.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/>
+  <path d="M21 3v5h-5"/>
+  <path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/>
+  <path d="M8 16H3v5"/>
+</svg>

--- a/shell/gpui/src/main.rs
+++ b/shell/gpui/src/main.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 use std::path::PathBuf;
 
 use gpui::{
-    App, AppContext, Bounds, Focusable, KeyBinding, Point, Size, TitlebarOptions, WindowBounds,
-    WindowOptions, px, size,
+    App, AppContext, AssetSource, Bounds, Focusable, KeyBinding, Point, SharedString, Size,
+    TitlebarOptions, WindowBounds, WindowOptions, px, size,
 };
 
 use jayjay_gpui::app::actions::{
@@ -15,6 +15,22 @@ use jayjay_gpui::repo::RepoWindow;
 use jayjay_gpui::ui::text_area;
 
 const LUCIDE_FONT: &[u8] = include_bytes!("../assets/fonts/Lucide.ttf");
+const REFRESH_CW_SVG: &[u8] = include_bytes!("../assets/icons/refresh-cw.svg");
+
+struct GpuiAssets;
+
+impl AssetSource for GpuiAssets {
+    fn load(&self, path: &str) -> gpui::Result<Option<Cow<'static, [u8]>>> {
+        match path {
+            jayjay_gpui::ui::icons::REFRESH_CW_SVG => Ok(Some(Cow::Borrowed(REFRESH_CW_SVG))),
+            _ => Ok(None),
+        }
+    }
+
+    fn list(&self, _path: &str) -> gpui::Result<Vec<SharedString>> {
+        Ok(Vec::new())
+    }
+}
 
 fn resolve_repo_path() -> PathBuf {
     let raw = std::env::args()
@@ -32,7 +48,8 @@ fn main() {
         _ => "JayJay (Alpha)".to_string(),
     };
 
-    gpui_platform::application().run(move |cx: &mut App| {
+    let app = gpui_platform::application().with_assets(GpuiAssets);
+    app.run(move |cx: &mut App| {
         match cx.text_system().add_fonts(vec![Cow::Borrowed(LUCIDE_FONT)]) {
             Ok(()) => eprintln!(
                 "[jayjay-gpui] registered Lucide font ({} bytes)",

--- a/shell/gpui/src/repo/toolbar.rs
+++ b/shell/gpui/src/repo/toolbar.rs
@@ -1,6 +1,9 @@
+use std::time::Duration;
+
 use gpui::{
-    AnyElement, ClickEvent, Context, InteractiveElement, IntoElement, MouseButton, MouseDownEvent,
-    ParentElement, SharedString, StatefulInteractiveElement, Styled, Window, div, px, rgb,
+    Animation, AnimationExt as _, AnyElement, ClickEvent, Context, InteractiveElement, IntoElement,
+    MouseButton, MouseDownEvent, ParentElement, SharedString, StatefulInteractiveElement, Styled,
+    Transformation, Window, div, percentage, px, rgb, svg,
 };
 
 use crate::app::theme::{Theme, theme};
@@ -16,6 +19,7 @@ pub fn toolbar(
     repo_path: SharedString,
     bookmark_count: usize,
     has_wc_changes: bool,
+    is_refreshing: bool,
     cx: &mut Context<RepoWindow>,
 ) -> AnyElement {
     let t = theme(cx).clone();
@@ -57,7 +61,7 @@ pub fn toolbar(
             cx,
         ))
         .child(divider(&t))
-        .child(refresh_button(has_wc_changes, &t, cx))
+        .child(refresh_button(has_wc_changes, is_refreshing, &t, cx))
         .child(coming_soon_icon_button(
             glyph::ARROW_DOWN,
             "tb-pull",
@@ -135,7 +139,12 @@ fn coming_soon_icon_button(
         .into_any_element()
 }
 
-fn refresh_button(badge: bool, t: &Theme, cx: &mut Context<RepoWindow>) -> AnyElement {
+fn refresh_button(
+    badge: bool,
+    is_refreshing: bool,
+    t: &Theme,
+    cx: &mut Context<RepoWindow>,
+) -> AnyElement {
     let mut content = div()
         .relative()
         .flex()
@@ -143,7 +152,7 @@ fn refresh_button(badge: bool, t: &Theme, cx: &mut Context<RepoWindow>) -> AnyEl
         .justify_center()
         .w(px(28.))
         .h(px(24.))
-        .child(icons::icon(glyph::ARROW_CLOCKWISE, 14., t.fg_dim));
+        .child(refresh_icon(is_refreshing, t));
     if badge {
         content = content.child(
             div()
@@ -163,6 +172,24 @@ fn refresh_button(badge: bool, t: &Theme, cx: &mut Context<RepoWindow>) -> AnyEl
         }))
         .child(content)
         .into_any_element()
+}
+
+fn refresh_icon(is_refreshing: bool, t: &Theme) -> AnyElement {
+    let icon = svg()
+        .path(icons::REFRESH_CW_SVG)
+        .w(px(14.))
+        .h(px(14.))
+        .text_color(rgb(t.fg_dim));
+    if is_refreshing {
+        icon.with_animation(
+            "refresh-spinner",
+            Animation::new(Duration::from_secs(1)).repeat(),
+            |icon, delta| icon.with_transformation(Transformation::rotate(percentage(delta))),
+        )
+        .into_any_element()
+    } else {
+        icon.into_any_element()
+    }
 }
 
 fn divider(t: &Theme) -> AnyElement {

--- a/shell/gpui/src/repo/view_model/loaders.rs
+++ b/shell/gpui/src/repo/view_model/loaders.rs
@@ -212,8 +212,9 @@ impl RepoViewModel {
         let Some(repo) = self.repo.clone() else {
             return;
         };
-        self.loading.refreshing = true;
         self.clear_error();
+        self.loading.refreshing = true;
+        cx.notify();
         let depth = self.revset_depth;
         let previous_selection = self
             .selected

--- a/shell/gpui/src/repo/view_model/mutations.rs
+++ b/shell/gpui/src/repo/view_model/mutations.rs
@@ -102,8 +102,8 @@ impl RepoViewModel {
 
     pub fn initialize_repo(&mut self, cx: &mut Context<Self>) -> gpui::Task<CoreResult<()>> {
         let path = std::path::PathBuf::from(self.repo_path.as_ref());
-        self.loading.refreshing = true;
         self.clear_error();
+        self.loading.refreshing = true;
         cx.notify();
 
         Self::core_result_task(

--- a/shell/gpui/src/repo/view_model/tasks.rs
+++ b/shell/gpui/src/repo/view_model/tasks.rs
@@ -45,8 +45,8 @@ impl RepoViewModel {
             return cx.spawn(async move |_, _| Err(Error::internal("repository is not open")));
         };
 
-        self.loading.refreshing = true;
         self.clear_error();
+        self.loading.refreshing = true;
         cx.notify();
 
         cx.spawn(async move |this, cx| {

--- a/shell/gpui/src/repo/window/render/mod.rs
+++ b/shell/gpui/src/repo/window/render/mod.rs
@@ -27,7 +27,10 @@ impl Render for RepoWindow {
         let file_column_width = self.layout.file_column_width;
         let repo_path = self.vm.read(cx).repo_path.clone();
         let bookmark_count = self.vm.read(cx).graph.bookmarks.len();
-        let has_wc_changes = self.vm.read(cx).loading.wc_changes;
+        let (has_wc_changes, is_refreshing) = {
+            let vm = self.vm.read(cx);
+            (vm.loading.wc_changes, vm.loading.refreshing)
+        };
         let init_error = {
             let vm = self.vm.read(cx);
             if vm.repo.is_none() {
@@ -131,6 +134,7 @@ impl Render for RepoWindow {
                 repo_path,
                 bookmark_count,
                 has_wc_changes,
+                is_refreshing,
                 cx,
             ))
             .child(

--- a/shell/gpui/src/ui/icons.rs
+++ b/shell/gpui/src/ui/icons.rs
@@ -7,6 +7,7 @@
 use gpui::{Div, ParentElement, SharedString, Styled, div, px, rgb};
 
 pub const FONT: &str = "lucide";
+pub const REFRESH_CW_SVG: &str = "icons/refresh-cw.svg";
 
 #[allow(dead_code)]
 pub mod glyph {

--- a/shell/mac/Sources/JayJay/Repo/RefreshSpinner.swift
+++ b/shell/mac/Sources/JayJay/Repo/RefreshSpinner.swift
@@ -1,11 +1,8 @@
 import SwiftUI
 
-/// Refresh glyph that spins while `animating`, then decelerates to an upright stop.
 struct RefreshSpinner: View {
     var animating: Bool
 
-    /// Animation state: idle at rest, spinning at constant velocity while a
-    /// refresh is in flight, then settling (decelerating to an upright stop).
     private enum Spin {
         case idle
         case spinning(since: Date)
@@ -14,14 +11,9 @@ struct RefreshSpinner: View {
 
     @State private var spin: Spin = .idle
 
-    /// Spin speed while a refresh is in flight.
     private let degreesPerSecond = 360.0
-
-    /// Floor for the settle phase; actual duration may be longer so the icon
-    /// lands at a symmetry point with velocity-matched deceleration.
     private let minSettleDuration = 0.2
 
-    /// Whether the timeline should stop ticking (no animation in flight).
     private var isResting: Bool {
         if case .idle = spin { return true }
         return false
@@ -41,7 +33,6 @@ struct RefreshSpinner: View {
         }
     }
 
-    /// Current rotation angle in degrees, derived from the spin state and clock.
     private func angle(at date: Date) -> Double {
         switch spin {
             case .idle:
@@ -50,32 +41,25 @@ struct RefreshSpinner: View {
                 return date.timeIntervalSince(since) * degreesPerSecond
             case let .settling(from, target, since, duration):
                 let progress = min(1, date.timeIntervalSince(since) / duration)
-                let eased = 1 - pow(1 - progress, 3) // ease-out cubic
+                let eased = 1 - pow(1 - progress, 3)
                 return from + (target - from) * eased
         }
     }
 
-    /// Settle target and duration. The target is the nearest 180° multiple past
-    /// a minimum coast distance, and the duration is derived so the cubic
-    /// ease-out's initial velocity matches the spin speed.
     static func settleParams(
         from angle: Double,
         degreesPerSecond: Double,
         minSettleDuration: Double
     ) -> (target: Double, duration: Double) {
-        // Minimum coast distance at the current spin velocity.
         let minCoast = degreesPerSecond * minSettleDuration / 3
         let natural = angle + minCoast
-        // The symbol has 2-fold rotational symmetry, so 0° and 180° both look
-        // upright. Target the nearest half-turn past the minimum coast point.
+        // The symbol has 2-fold rotational symmetry, so 0° and 180° both look upright.
         let target = (natural / 180).rounded(.up) * 180
         let distance = target - angle
         let duration = 3 * distance / degreesPerSecond
         return (target, duration)
     }
 
-    /// Transition from spinning to settling: captures the current angle and
-    /// schedules a return to idle after the deceleration finishes.
     private func beginSettle(from angle: Double) {
         let startedAt = Date()
         let (target, duration) = Self.settleParams(


### PR DESCRIPTION
## Summary
- add GPUI refresh spinner parity with the SwiftUI toolbar spinner
- drive the GPUI spinner from refresh task state
- trim verbose Swift spinner comments and neutralize PR workflow commit-message examples

## Tests
- cargo fmt
- just test-gpui
- cargo clippy -p jayjay-gpui