### PR TITLE
feat(setup): one-command dev bootstrap (scripts/setup.sh)

### DIFF
--- a/.jj-config.toml
+++ b/.jj-config.toml
@@ -1,13 +1,14 @@
-# jj fix configuration — copy to .jj/repo/config.toml or ~/.config/jj/config.toml
+# jj fix configuration. `./scripts/setup.sh` copies this to .jj/repo/config.toml
+# if it isn't there; you can also copy it to ~/.config/jj/config.toml by hand.
 # See: jj help -k config "Code formatting and other file content transformations"
 #
-# Use absolute paths so `jj fix` works regardless of the shell PATH it inherits.
-# Adjust for your machine (rustup usually installs rustfmt at ~/.cargo/bin).
+# rustfmt ships with rustup; swiftformat comes from Homebrew. Both are on PATH
+# after running ./scripts/setup.sh, so bare command names resolve fine.
 
 [fix.tools.rustfmt]
-command = ["/Users/hewig/.cargo/bin/rustfmt", "--edition", "2024"]
+command = ["rustfmt", "--edition", "2024"]
 patterns = ["glob:'**/*.rs'"]
 
 [fix.tools.swiftformat]
-command = ["/opt/homebrew/bin/swiftformat", "--stdinpath", "$path", "stdin"]
+command = ["swiftformat", "--stdinpath", "$path", "stdin"]
 patterns = ["glob:'**/*.swift'"]

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,10 @@
+# JayJay dev dependencies. Install with `just setup` (or `brew bundle`).
+# Rust (rustup) and Xcode are not Homebrew-managed — see CONTRIBUTING.md.
+
+brew "jj"          # Jujutsu — the VCS JayJay is a GUI for
+brew "just"        # Task runner for this repo
+brew "xcodegen"    # Generates the Xcode project from project.yml
+brew "xcbeautify"  # Prettifies xcodebuild output
+brew "swiftlint"   # Swift linter (just lint)
+brew "swiftformat" # Swift formatter (just format)
+brew "gh"          # GitHub CLI — PR status, checks, optional PR creation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,22 @@ This project uses [Jujutsu](https://github.com/jj-vcs/jj) for version control, n
 | Dependency | Version | Notes |
 |------------|---------|-------|
 | macOS | 15+ (Sequoia) | |
-| Rust | 1.85+ | |
+| Rust | 1.93+ | |
 | Xcode | 16+ | |
 | jj | latest | |
 | just | latest | |
 | xcodegen | latest | |
 | xcbeautify | latest | |
+
+## Setup
+
+Bootstrap a clean machine with one command:
+
+```bash
+./scripts/setup.sh
+```
+
+It installs Homebrew (if missing), Rust via rustup, and the Homebrew tools from the repo [Brewfile](Brewfile) — `jj`, `just`, `xcodegen`, `xcbeautify`, `swiftlint`, `swiftformat`, `gh`. It also configures `jj fix` by copying [.jj-config.toml](.jj-config.toml) into this clone (if not already set). It's idempotent and safe to re-run. Xcode is the one piece it can't install (not Homebrew-managed); the script prints instructions if it's missing.
 
 ## Development loop
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.93"
 license = "Apache-2.0"
 repository = "https://github.com/hewigovens/jayjay"
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Browse your DAG, review side-by-side diffs, resolve conflicts, and run every jj 
 [![CI](https://github.com/hewigovens/jayjay/actions/workflows/ci.yml/badge.svg)](https://github.com/hewigovens/jayjay/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/hewigovens/jayjay?include_prereleases)](https://github.com/hewigovens/jayjay/releases)
 ![macOS](https://img.shields.io/badge/macOS-26-blue)
-![Rust](https://img.shields.io/badge/rust-1.85%2B-orange)
+![Rust](https://img.shields.io/badge/rust-1.93%2B-orange)
 ![License](https://img.shields.io/badge/license-BSL--1.1-green)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/hewigovens/jayjay)
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Dev bootstrap: brew + rust + Brewfile tools, configure jj fix, check Xcode.
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+os="$(uname -s)"
+
+# have <cmd> <label> <install-fn>: report if present, else run the install fn.
+have() {
+  if command -v "$1" >/dev/null 2>&1; then
+    echo "✓ $2 already installed"
+  else
+    echo "→ installing $2"
+    "$3"
+  fi
+}
+
+install_brew() {
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  # brew isn't on PATH right after install; source it from the per-platform prefix.
+  for path in /opt/homebrew/bin/brew /usr/local/bin/brew /home/linuxbrew/.linuxbrew/bin/brew "$HOME/.linuxbrew/bin/brew"; do
+    [ -x "$path" ] && eval "$("$path" shellenv)" && break
+  done
+}
+
+brew_bundle() {
+  HOMEBREW_NO_AUTO_UPDATE=1 brew bundle --quiet --file "$root/Brewfile"
+}
+
+install_rust() {
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  # shellcheck disable=SC1091
+  . "$HOME/.cargo/env"
+}
+
+configure_jj_fix() {
+  # A git clone has no .jj yet — colocate a jj workspace so jj works here.
+  if [ ! -d "$root/.jj/repo" ]; then
+    echo "→ initializing jj workspace (colocated with git)"
+    (cd "$root" && jj git init --colocate)
+  fi
+  if [ -f "$root/.jj/repo/config.toml" ]; then
+    echo "✓ jj fix already configured (.jj/repo/config.toml)"
+  else
+    cp "$root/.jj-config.toml" "$root/.jj/repo/config.toml"
+    echo "✓ configured jj fix (copied .jj-config.toml)"
+  fi
+}
+
+check_xcode() {
+  [ "$os" = "Darwin" ] || return 0
+  if xcodebuild -version >/dev/null 2>&1; then
+    echo "✓ Xcode command-line build available"
+  else
+    echo "✗ Xcode not found or not selected. Install Xcode 16+ from the App Store, then:"
+    echo "    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer"
+    echo "    sudo xcodebuild -license accept"
+  fi
+}
+
+have brew Homebrew install_brew
+have cargo Rust install_rust
+brew_bundle
+configure_jj_fix
+check_xcode
+
+echo
+echo "Setup complete. Try: just build"


### PR DESCRIPTION
Closes #73.

Adds a single bootstrap command for new contributors:

```bash
./scripts/setup.sh
```

It installs Homebrew (if missing), Rust via rustup, and the Homebrew tools from a new `Brewfile` (`jj`, `just`, `xcodegen`, `xcbeautify`, `swiftlint`, `swiftformat`, `gh`), configures `jj fix` for the clone, and checks Xcode. Idempotent and safe to re-run.

### Details
- **`Brewfile`** — declarative tool list, installed via `brew bundle` (quiet, no auto-update noise).
- **Cross-platform** — uses the per-platform Homebrew prefix and skips the Xcode check on Linux so GPUI-shell contributors aren't blocked.
- **`jj fix`** — copies `.jj-config.toml` into `.jj/repo/config.toml` if not already set. Made the template portable (bare `rustfmt`/`swiftformat` command names) so a clone gets working formatters without editing absolute paths.
- **Docs** — `CONTRIBUTING.md` Setup section; bumped documented Rust to **1.93+** (`Cargo.toml`, README badge, CONTRIBUTING).