### PR TITLE
fix(test): set jj identity for UI test fixture build

### DIFF
--- a/shell/justfile
+++ b/shell/justfile
@@ -121,6 +121,8 @@ test: ffi sync-icon
 ui-test-setup:
   #!/usr/bin/env bash
   set -euo pipefail
+  # Identity for the fixture commits; silences jj's "Name and email not configured" on CI.
+  export JJ_USER="JayJay CI" JJ_EMAIL="ci@jayjay.local"
   defaults write {{bundle_id}} jayjay.hasCompletedOnboarding -bool YES
 
   root=/tmp/jayjay-test-fixtures


### PR DESCRIPTION
The `just test-ui` step builds jj fixtures (`ui-test-setup` in `shell/justfile`) with `jj describe`/`jj new`, but never configures a jj user identity. On CI the runner has no jj identity, so every fixture commit prints:

> Warning: Name and email not configured. Until configured, your commits will be created with the empty identity, and can't be pushed to remotes.

Export a deterministic `JJ_USER`/`JJ_EMAIL` at the top of the recipe so all fixture `jj` calls inherit it. Silences the CI noise and keeps fixture commit hashes reproducible. Scoped to the fixture builder — no change to global or repo config.