### PR TITLE
feat(ui): toggle the file column between tree and flat list

### DIFF
--- a/shell/gpui/src/diff/diff_view/header.rs
+++ b/shell/gpui/src/diff/diff_view/header.rs
@@ -1,6 +1,6 @@
 use gpui::{
     AnyElement, ClickEvent, Context, InteractiveElement, IntoElement, ParentElement, SharedString,
-    StatefulInteractiveElement, Styled, Window, div, px, rgb,
+    StatefulInteractiveElement, Styled, div, px, rgb,
 };
 use jayjay_core::DiffHunk;
 
@@ -11,7 +11,7 @@ use crate::diff::file_status;
 use crate::diff::line::tag_for_hunk;
 use crate::repo::window::RepoWindow;
 use crate::ui::icons::{self, glyph};
-use crate::ui::primitives::capsule;
+use crate::ui::primitives::{capsule, toggle_button};
 
 pub(super) fn file_header(
     hunk: &DiffHunk,
@@ -118,41 +118,6 @@ fn mode_tooltip(mode: DiffViewMode) -> &'static str {
         DiffViewMode::Unified => "Unified",
         DiffViewMode::SideBySide => "Side-by-side",
     }
-}
-
-fn toggle_button<F>(
-    glyph_str: &'static str,
-    tooltip: &'static str,
-    id: &'static str,
-    active: bool,
-    t: &Theme,
-    on_click: F,
-) -> AnyElement
-where
-    F: Fn(&ClickEvent, &mut Window, &mut gpui::App) + 'static,
-{
-    let (bg, fg) = if active {
-        (t.toggle_active_bg, t.toggle_active_fg)
-    } else {
-        (t.toggle_inactive_bg, t.toggle_inactive_fg)
-    };
-    div()
-        .id(SharedString::from(format!("toggle-{id}")))
-        .flex()
-        .flex_row()
-        .items_center()
-        .gap(px(6.))
-        .px(px(8.))
-        .py(px(3.))
-        .rounded_sm()
-        .bg(rgb(bg))
-        .text_size(px(11.))
-        .text_color(rgb(fg))
-        .cursor_pointer()
-        .on_click(on_click)
-        .child(icons::icon(glyph_str, 14., fg))
-        .child(tooltip)
-        .into_any_element()
 }
 
 fn path_copy_button(

--- a/shell/gpui/src/diff/file_column/header.rs
+++ b/shell/gpui/src/diff/file_column/header.rs
@@ -1,12 +1,16 @@
 use gpui::{IntoElement, ParentElement, SharedString, Styled, div, px, rgb};
 
+use crate::app::config;
 use crate::app::theme::{FONT_META, Theme};
+use crate::ui::icons::glyph;
+use crate::ui::primitives::toggle_button;
 
 pub(super) fn file_column_header(
     reviewed: usize,
     count: usize,
     loading: bool,
     show_review: bool,
+    tree_mode: bool,
     t: &Theme,
 ) -> impl IntoElement {
     let label = if loading {
@@ -18,13 +22,33 @@ pub(super) fn file_column_header(
     } else {
         format!("{count} files")
     };
+    let (tree_glyph, tree_label) = if tree_mode {
+        (glyph::FOLDER, "Tree")
+    } else {
+        (glyph::ROWS, "Flat")
+    };
     div()
+        .flex()
+        .flex_row()
+        .items_center()
         .px(px(12.))
         .py(px(6.))
         .bg(rgb(t.header_bg))
         .border_b_1()
         .border_color(rgb(t.border))
-        .text_size(px(FONT_META))
-        .text_color(rgb(t.fg_dim))
-        .child(SharedString::from(label))
+        .child(
+            div()
+                .text_size(px(FONT_META))
+                .text_color(rgb(t.fg_dim))
+                .child(SharedString::from(label)),
+        )
+        .child(div().flex_1())
+        .child(toggle_button(
+            tree_glyph,
+            tree_label,
+            "file-tree",
+            tree_mode,
+            t,
+            |_, _, cx| config::update(cx, |c| c.diff.tree_file_list ^= true),
+        ))
 }

--- a/shell/gpui/src/diff/file_column/mod.rs
+++ b/shell/gpui/src/diff/file_column/mod.rs
@@ -69,7 +69,14 @@ pub fn file_column(state: FileColumnState<'_>, cx: &mut Context<RepoWindow>) -> 
                 .flex_col()
                 .size_full()
                 .bg(rgb(t.sidebar_bg))
-                .child(file_column_header(0, 0, loading, show_review, &t))
+                .child(file_column_header(
+                    0,
+                    0,
+                    loading,
+                    show_review,
+                    tree_mode,
+                    &t,
+                ))
                 .child(
                     div()
                         .flex()
@@ -122,6 +129,7 @@ pub fn file_column(state: FileColumnState<'_>, cx: &mut Context<RepoWindow>) -> 
             count,
             loading,
             show_review,
+            tree_mode,
             &t,
         ))
         .child(body)

--- a/shell/gpui/src/ui/primitives.rs
+++ b/shell/gpui/src/ui/primitives.rs
@@ -1,10 +1,47 @@
 use gpui::{
-    Div, InteractiveElement, IntoElement, ParentElement, SharedString, Stateful,
-    StatefulInteractiveElement, Styled, UniformList, div, px, rgb,
+    AnyElement, App, ClickEvent, Div, InteractiveElement, IntoElement, ParentElement, SharedString,
+    Stateful, StatefulInteractiveElement, Styled, UniformList, Window, div, px, rgb,
 };
 
 use crate::app::theme::Theme;
 use crate::ui::icons;
+
+/// A small labeled toggle button (icon + text) with active/inactive styling.
+/// Shared by the diff view-mode toggle and the file-column tree/flat toggle.
+pub fn toggle_button<F>(
+    glyph_str: &'static str,
+    tooltip: &'static str,
+    id: &'static str,
+    active: bool,
+    t: &Theme,
+    on_click: F,
+) -> AnyElement
+where
+    F: Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+{
+    let (bg, fg) = if active {
+        (t.toggle_active_bg, t.toggle_active_fg)
+    } else {
+        (t.toggle_inactive_bg, t.toggle_inactive_fg)
+    };
+    div()
+        .id(SharedString::from(format!("toggle-{id}")))
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap(px(6.))
+        .px(px(8.))
+        .py(px(3.))
+        .rounded_sm()
+        .bg(rgb(bg))
+        .text_size(px(11.))
+        .text_color(rgb(fg))
+        .cursor_pointer()
+        .on_click(on_click)
+        .child(icons::icon(glyph_str, 14., fg))
+        .child(tooltip)
+        .into_any_element()
+}
 
 /// uniform_list reserves a 15px gutter for an OS scrollbar by default. We
 /// don't render a scrollbar, so the gutter just leaves a thick gap on the

--- a/shell/mac/Sources/JayJay/Detail/FileColumn.swift
+++ b/shell/mac/Sources/JayJay/Detail/FileColumn.swift
@@ -45,6 +45,27 @@ extension ChangeDetailView {
                     .help(hideReviewedFiles ? "Showing only unreviewed files" : "Hide reviewed files")
                 }
                 Button {
+                    appSettings.treeFileList.toggle()
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: appSettings.treeFileList ? "list.bullet.indent" : "list.bullet")
+                            .jayjayFont(11)
+                        Text(appSettings.treeFileList ? "Tree" : "Flat")
+                            .jayjayFont(11)
+                    }
+                    .foregroundStyle(appSettings.treeFileList ? Color.accentColor : .secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 3)
+                    .background(
+                        appSettings.treeFileList
+                            ? AnyShapeStyle(Color.accentColor.opacity(0.14))
+                            : AnyShapeStyle(Color.primary.opacity(0.06)),
+                        in: RoundedRectangle(cornerRadius: 4, style: .continuous)
+                    )
+                }
+                .buttonStyle(.plain)
+                .help(appSettings.treeFileList ? "Showing files as a tree" : "Showing files as a flat list")
+                Button {
                     showFileFilter.toggle()
                     if !showFileFilter { fileFilter = "" }
                 } label: {


### PR DESCRIPTION
The diff file column switches between a nested tree and a flat path list in both the SwiftUI and GPUI shells, matching the side-by-side / unified diff toggle style.