### PR TITLE
feat(mac): polish command palette (Spotlight UI, cheatsheet, theme), SwiftUI polish (Liquid Glass surfaces, commit box)

### DIFF
--- a/shell/justfile
+++ b/shell/justfile
@@ -132,6 +132,8 @@ ui-test-setup:
   # Identity for the fixture commits; silences jj's "Name and email not configured" on CI.
   export JJ_USER="JayJay CI" JJ_EMAIL="ci@jayjay.local"
   defaults write {{bundle_id}} jayjay.hasCompletedOnboarding -bool YES
+  # Start each run with the command palette at its default (centered) position.
+  defaults delete {{bundle_id}} commandPalette.frameOrigin 2>/dev/null || true
 
   root=/tmp/jayjay-test-fixtures
   rm -rf "$root"

--- a/shell/mac/Sources/JayJay/Repo/CommitBox.swift
+++ b/shell/mac/Sources/JayJay/Repo/CommitBox.swift
@@ -1,9 +1,7 @@
 import JayJayCore
 import SwiftUI
 
-/// GitHub-Desktop-style commit box: a single-line Summary + an optional
-/// Description. They combine into jj's one change description (`summary\n\nbody`),
-/// so the first line becomes the PR title and the body becomes the PR body.
+/// Commit box: Summary line + optional Description, combined into jj's `summary\n\nbody` description.
 struct CommitBox: View {
     let description: String
     @Binding var summary: String
@@ -21,11 +19,7 @@ struct CommitBox: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text("Summary")
-                .jayjayFont(11, weight: .semibold)
-                .foregroundStyle(.secondary)
-
-            TextField("Summary", text: $summary)
+            TextField("Summary (required)", text: $summary)
                 .textFieldStyle(.plain)
                 .jayjayFont(13, design: .monospaced)
                 .padding(6)
@@ -36,13 +30,23 @@ struct CommitBox: View {
                 )
                 .accessibilityIdentifier(AID.CommitBox.summary)
 
-            Text("Description")
-                .jayjayFont(11, weight: .semibold)
-                .foregroundStyle(.secondary)
-
+            // TextEditor has no native placeholder; overlay one while empty.
             TextEditor(text: $details)
                 .jayjayFont(13, design: .monospaced)
                 .scrollContentBackground(.hidden)
+                .accessibilityIdentifier(AID.CommitBox.draft)
+                .overlay(alignment: .topLeading) {
+                    if details.isEmpty {
+                        Text("Description")
+                            .jayjayFont(13, design: .monospaced)
+                            .foregroundStyle(.tertiary)
+                            // Match the TextEditor's text origin so the placeholder aligns with the cursor.
+                            .padding(.leading, 5)
+                            .padding(.top, 0)
+                            .allowsHitTesting(false)
+                            .accessibilityHidden(true)
+                    }
+                }
                 .padding(6)
                 .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
                 .overlay(
@@ -50,7 +54,6 @@ struct CommitBox: View {
                         .stroke(Color.primary.opacity(0.1), lineWidth: 1)
                 )
                 .frame(minHeight: 50, maxHeight: 100)
-                .accessibilityIdentifier(AID.CommitBox.draft)
 
             HStack(spacing: 8) {
                 Spacer()
@@ -106,8 +109,7 @@ struct CommitBox: View {
         }
     }
 
-    /// Seed the fields from an existing description (first line → summary, rest →
-    /// details), but only when the user hasn't started typing.
+    /// Seed the fields from an existing description, unless the user has started typing.
     private func prefillIfEmpty(_ message: String) {
         guard summary.isEmpty, details.isEmpty else { return }
         split(message)

--- a/shell/mac/Sources/JayJay/Repo/DAGRow.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAGRow.swift
@@ -316,8 +316,7 @@ struct DAGRow: View {
 
     private static let relativeFormatter = RelativeDateTimeFormatter()
 
-    /// "10 days ago" — jj's change id is the stable identifier shown above, so the
-    /// meta line favors when the change last moved over the git commit hash.
+    /// Relative time the change last moved; the change id shown above is the stable identifier.
     private func relativeDate(_ millis: Int64) -> String {
         let date = Date(timeIntervalSince1970: Double(millis) / 1000)
         let now = Date()
@@ -348,7 +347,7 @@ struct DAGRow: View {
             viewModel.isRebaseHoverTarget ? Color.accentColor.opacity(0.14) : Color.clear,
             in: Capsule()
         )
-        .background(.regularMaterial, in: Capsule())
+        .glassEffect(in: Capsule())
         .overlay(
             Capsule()
                 .stroke(Color.accentColor.opacity(viewModel.isRebaseHoverTarget ? 0.5 : 0.2), lineWidth: 1)

--- a/shell/mac/Sources/JayJay/Repo/DAGView+RebaseDrag.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAGView+RebaseDrag.swift
@@ -247,7 +247,7 @@ private struct DAGRebaseGhost: View {
         .foregroundStyle(.primary)
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
-        .background(.regularMaterial, in: Capsule())
+        .glassEffect(in: Capsule())
         .overlay(
             Capsule()
                 .stroke(Color.accentColor.opacity(0.25), lineWidth: 1)
@@ -291,8 +291,7 @@ extension DAGView {
     @ViewBuilder
     var bookmarkDragOverlay: some View {
         if let bookmarkDrag, bookmarkDrag.phase == .dragging {
-            // Anchor the ghost's bottom-right just up-left of the cursor (size-
-            // independent), so it sits to the top-left of the pointer.
+            // Anchor the ghost to the top-left of the pointer, independent of its size.
             Color.clear
                 .frame(width: 0, height: 0)
                 .overlay(alignment: .bottomTrailing) {
@@ -417,7 +416,7 @@ private struct BookmarkDragGhost: View {
         }
         .frame(width: 18, height: 18)
         .padding(6)
-        .background(.regularMaterial, in: Circle())
+        .glassEffect(in: Circle())
         .overlay(Circle().stroke(Color.primary.opacity(0.12), lineWidth: 1))
         .shadow(color: .black.opacity(0.12), radius: 6, y: 3)
     }

--- a/shell/mac/Sources/JayJay/Repo/RepoContentView+CommandPalette.swift
+++ b/shell/mac/Sources/JayJay/Repo/RepoContentView+CommandPalette.swift
@@ -5,7 +5,9 @@ extension RepoContentView {
         var items: [CommandPaletteItem] = []
         let selection = viewModel.selectedChangeId
 
-        items.append(CommandPaletteItem(title: "Refresh", icon: "arrow.triangle.2.circlepath", category: "View") {
+        items.append(CommandPaletteItem(
+            title: "Refresh", icon: "arrow.triangle.2.circlepath", category: "View", shortcut: "⌘R"
+        ) {
             viewModel.refresh()
         })
         items.append(CommandPaletteItem(
@@ -31,6 +33,19 @@ extension RepoContentView {
             icon: "externaldrive",
             category: "View"
         ) { settings.hideGitLfsDiffs.toggle() })
+
+        for (mode, label, icon) in [
+            (AppSettings.AppearanceMode.system, "System", "circle.lefthalf.filled"),
+            (.light, "Light", "sun.max"),
+            (.dark, "Dark", "moon")
+        ] {
+            items.append(CommandPaletteItem(
+                title: "Theme: \(label)",
+                icon: icon,
+                category: "View",
+                keywords: ["theme", "appearance", "mode", "color", "scheme"]
+            ) { settings.appearanceMode = mode })
+        }
 
         for (label, revset) in [
             ("Show All", "all()"),
@@ -62,7 +77,8 @@ extension RepoContentView {
         items.append(CommandPaletteItem(
             title: "Bookmark Manager",
             icon: "bookmark",
-            category: "Repository"
+            category: "Repository",
+            shortcut: "⇧⌘B"
         ) { modal = .bookmarkManager })
         items.append(CommandPaletteItem(
             title: "Clean Up Stale Bookmarks",
@@ -123,20 +139,25 @@ extension RepoContentView {
         items.append(CommandPaletteItem(
             title: "Zoom In",
             icon: "plus.magnifyingglass",
-            category: "View"
+            category: "View",
+            shortcut: "⌘+"
         ) { settings.fontSize = min(24, settings.fontSize + 1) })
         items.append(CommandPaletteItem(
             title: "Zoom Out",
             icon: "minus.magnifyingglass",
-            category: "View"
+            category: "View",
+            shortcut: "⌘−"
         ) { settings.fontSize = max(9, settings.fontSize - 1) })
         items.append(CommandPaletteItem(
             title: "Reset Zoom",
             icon: "1.magnifyingglass",
-            category: "View"
+            category: "View",
+            shortcut: "⌘0"
         ) { settings.fontSize = 12 })
 
-        items.append(CommandPaletteItem(title: "Show in Finder", icon: "folder", category: "Tools") {
+        items.append(CommandPaletteItem(
+            title: "Show in Finder", icon: "folder", category: "Tools", shortcut: "⌥⌘F"
+        ) {
             RepositoryActions.showInFinder(repoPath: viewModel.repoPath)
         })
         items.append(CommandPaletteItem(
@@ -160,11 +181,36 @@ extension RepoContentView {
         items.append(CommandPaletteItem(
             title: "Undo (Operation Log)",
             icon: "arrow.uturn.backward.circle",
-            category: "Repository"
+            category: "Repository",
+            shortcut: "⇧⌘U"
         ) { showUndo() })
-        items.append(CommandPaletteItem(title: "Settings", icon: "gearshape", category: "App") {
+        items.append(CommandPaletteItem(
+            title: "Settings", icon: "gearshape", category: "App", shortcut: "⌘,"
+        ) {
             openSettings()
         })
+
+        // Searchable keybind cheatsheet — info-only rows for keys that aren't commands (issue #87).
+        items.append(.keybind(
+            title: "Command Palette", icon: "command", shortcut: "⇧⌘P",
+            keywords: ["palette", "command", "search"]
+        ))
+        items.append(.keybind(
+            title: "Next / Previous Change", icon: "arrow.up.arrow.down", shortcut: "J / K",
+            keywords: ["move", "select", "next", "previous", "down", "up", "navigate", "ctrl", "n", "p"]
+        ))
+        items.append(.keybind(
+            title: "Mark File Reviewed", icon: "checkmark.circle", shortcut: "Space",
+            keywords: ["review", "reviewed", "check", "diff"]
+        ))
+        items.append(.keybind(
+            title: "Find in Diff", icon: "magnifyingglass", shortcut: "⌘F",
+            keywords: ["find", "search", "diff"]
+        ))
+        items.append(.keybind(
+            title: "Open Repository", icon: "folder.badge.plus", shortcut: "⌘O",
+            keywords: ["open", "repository", "repo"]
+        ))
 
         commandPanel.show(
             items: items,

--- a/shell/mac/Sources/JayJay/Repo/RepoSidebar.swift
+++ b/shell/mac/Sources/JayJay/Repo/RepoSidebar.swift
@@ -94,7 +94,7 @@ extension RepoContentView {
             .help("Dismiss")
         }
         .padding(.horizontal, 12).padding(.vertical, 6)
-        .background(.regularMaterial)
+        .glassEffect(in: RoundedRectangle(cornerRadius: 8))
     }
 
     func revsetChip(_ label: String, revset: String) -> some View {

--- a/shell/mac/Sources/JayJay/Repo/RepoToast.swift
+++ b/shell/mac/Sources/JayJay/Repo/RepoToast.swift
@@ -36,10 +36,6 @@ struct RepoToastView: View {
         }
         .padding(.horizontal, 24)
         .padding(.vertical, 14)
-        .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(colorScheme == .dark ? Color.black.opacity(0.75) : Color.white.opacity(0.9))
-                .shadow(color: .black.opacity(0.2), radius: 12, y: 6)
-        )
+        .glassEffect(in: RoundedRectangle(cornerRadius: 14, style: .continuous))
     }
 }

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+ChangeActions.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+ChangeActions.swift
@@ -81,7 +81,14 @@ extension RepoViewModel {
     }
 
     func newChange(parent: String, message: String = "") {
-        perform { try $0.newChange(parent: parent, message: message) }
+        // A new change starts empty, so clear the commit-box draft instead of
+        // carrying the previous change's message into it.
+        perform(beforeRefresh: { viewModel in
+            viewModel.commitSummaryDraft = ""
+            viewModel.commitDescriptionDraft = ""
+        }, {
+            try $0.newChange(parent: parent, message: message)
+        })
     }
 
     func abandon(rev: String) {

--- a/shell/mac/Sources/JayJay/Shared/CommandPalette.swift
+++ b/shell/mac/Sources/JayJay/Shared/CommandPalette.swift
@@ -8,20 +8,46 @@ struct CommandPaletteItem: Identifiable {
     let icon: String
     let category: String
     let keywords: [String]
-    let action: () -> Void
+    /// Native shortcut glyphs to show on the row, e.g. "⇧⌘P". Optional.
+    let shortcut: String?
+    /// Nil for info-only "cheatsheet" rows that document a keybind but run nothing.
+    let action: (() -> Void)?
+
+    var isInfo: Bool {
+        action == nil
+    }
 
     init(
         title: String,
         icon: String,
         category: String,
         keywords: [String] = [],
-        action: @escaping () -> Void
+        shortcut: String? = nil,
+        action: (() -> Void)? = nil
     ) {
         self.title = title
         self.icon = icon
         self.category = category
         self.keywords = keywords
+        self.shortcut = shortcut
         self.action = action
+    }
+
+    /// An info-only row that surfaces a keybind in the palette without executing.
+    static func keybind(
+        title: String,
+        icon: String = "keyboard",
+        shortcut: String,
+        keywords: [String] = []
+    ) -> CommandPaletteItem {
+        CommandPaletteItem(
+            title: title,
+            icon: icon,
+            category: "Shortcut",
+            keywords: keywords,
+            shortcut: shortcut,
+            action: nil
+        )
     }
 }
 
@@ -40,6 +66,19 @@ final class CommandPalettePanel: NSPanel {
         isOpaque = false
         backgroundColor = .clear
         hidesOnDeactivate = true
+        // Remember the position whenever the user drags the panel.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(saveFrameOrigin),
+            name: NSWindow.didMoveNotification,
+            object: self
+        )
+    }
+
+    static let originKey = "commandPalette.frameOrigin"
+
+    @objc private func saveFrameOrigin() {
+        UserDefaults.standard.set(NSStringFromPoint(frame.origin), forKey: Self.originKey)
     }
 
     func show(
@@ -60,10 +99,15 @@ final class CommandPalettePanel: NSPanel {
             appearance = NSApp.effectiveAppearance
         }
         setContentSize(NSSize(width: 520, height: 360))
-
-        let parentFrame = NSApp.windows.first(where: { $0.isKeyWindow && $0 !== self })?.frame
-            ?? NSScreen.main?.frame ?? .zero
-        setFrameOrigin(NSPoint(x: parentFrame.midX - 260, y: parentFrame.midY + 40))
+        // Restore the last position the user dragged to; only center on first use.
+        let saved = UserDefaults.standard.string(forKey: Self.originKey).map(NSPointFromString)
+        if let origin = saved, origin != .zero {
+            setFrameOrigin(origin)
+        } else {
+            let parentFrame = NSApp.windows.first(where: { $0.isKeyWindow && $0 !== self })?.frame
+                ?? NSScreen.main?.frame ?? .zero
+            setFrameOrigin(NSPoint(x: parentFrame.midX - 260, y: parentFrame.midY + 10))
+        }
         makeKeyAndOrderFront(nil)
     }
 
@@ -79,6 +123,15 @@ final class CommandPalettePanel: NSPanel {
     override var canBecomeKey: Bool {
         true
     }
+
+    override func resignKey() {
+        super.resignKey()
+        // Dismiss on focus loss (e.g. a click outside), unless it immediately regains key.
+        DispatchQueue.main.async { [weak self] in
+            guard let self, !self.isKeyWindow else { return }
+            dismiss()
+        }
+    }
 }
 
 struct PaletteRoot: View {
@@ -89,6 +142,7 @@ struct PaletteRoot: View {
 
     @State var query = ""
     @State var selectedIndex = 0
+    @State var hoveredIndex: Int?
     @State var jjResult: JjCommandResult?
     @State var jjError: String?
     @State var isRunning = false
@@ -122,8 +176,8 @@ struct PaletteRoot: View {
             resultArea
         }
         .frame(width: 520, height: 360)
-        .background(.regularMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .glassEffect(in: RoundedRectangle(cornerRadius: 16))
+        .clipShape(RoundedRectangle(cornerRadius: 16))
         .onKeyPress(.upArrow) {
             if isJJ {
                 recallHistory(older: true)
@@ -158,6 +212,7 @@ struct PaletteRoot: View {
             isSearchFocused = true
         }
         .onChange(of: query) { selectedIndex = 0
+            hoveredIndex = nil
             jjResult = nil
             jjError = nil
             if isRecallingHistory {
@@ -179,30 +234,57 @@ struct PaletteRoot: View {
                 ScrollView {
                     LazyVStack(spacing: 0) {
                         ForEach(Array(visible.enumerated()), id: \.element.id) { index, item in
-                            Button { item.action()
-                                onDismiss()
+                            Button {
+                                if let action = item.action {
+                                    action()
+                                    onDismiss()
+                                }
                             } label: {
                                 HStack(spacing: 10) {
-                                    Image(systemName: item.icon).frame(width: 18).foregroundStyle(.secondary)
+                                    Image(systemName: item.icon)
+                                        .frame(width: 18)
+                                        .foregroundStyle(item.isInfo ? .tertiary : .secondary)
                                     VStack(alignment: .leading, spacing: 1) {
                                         Text(item.title).font(.system(size: 13))
                                         Text(item.category).font(.system(size: 10)).foregroundStyle(.tertiary)
                                     }
                                     Spacer()
+                                    if let shortcut = item.shortcut {
+                                        Text(shortcut)
+                                            .font(.system(size: 11, weight: .medium))
+                                            .foregroundStyle(.secondary)
+                                            .padding(.horizontal, 6)
+                                            .padding(.vertical, 2)
+                                            .background(
+                                                Color.secondary.opacity(0.12),
+                                                in: RoundedRectangle(cornerRadius: 5)
+                                            )
+                                    }
                                 }
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.horizontal, 12)
-                                .padding(.vertical, 6)
+                                .padding(.vertical, 5)
                                 .contentShape(Rectangle())
                             }
                             .buttonStyle(.plain)
                             .accessibilityIdentifier(AID.Palette.item(item.title))
+                            // Hover only highlights; it never moves the selection or scrolls (VS Code style).
                             .onHover { hovering in
-                                if hovering, selectedIndex != index {
-                                    selectedIndex = index
+                                if hovering {
+                                    hoveredIndex = index
+                                } else if hoveredIndex == index {
+                                    hoveredIndex = nil
                                 }
                             }
-                            .background(index == selectedIndex ? Color.accentColor.opacity(0.15) : .clear)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill(
+                                        index == selectedIndex
+                                            ? Color.accentColor.opacity(0.15)
+                                            : (index == hoveredIndex ? Color.primary.opacity(0.08) : .clear)
+                                    )
+                                    .padding(.horizontal, 6)
+                            )
                             .id(item.id)
                         }
                     }
@@ -227,8 +309,8 @@ struct PaletteRoot: View {
     private func execute() {
         if isJJ {
             executeJJ()
-        } else if !filtered.isEmpty, selectedIndex < filtered.count {
-            filtered[selectedIndex].action()
+        } else if filtered.indices.contains(selectedIndex), let action = filtered[selectedIndex].action {
+            action()
             onDismiss()
         }
     }

--- a/shell/mac/Sources/JayJay/Shared/CommandPaletteSupport.swift
+++ b/shell/mac/Sources/JayJay/Shared/CommandPaletteSupport.swift
@@ -24,7 +24,7 @@ enum CommandPaletteSearch {
     /// Fuzzy-rank items against the query, best match first.
     static func rank(query: String, items: [CommandPaletteItem]) -> [CommandPaletteItem] {
         let candidates = items.map { item in
-            ([item.title, item.category] + item.keywords).joined(separator: " ")
+            ([item.title, item.category, item.shortcut ?? ""] + item.keywords).joined(separator: " ")
         }
         return fuzzyRank(query: query, candidates: candidates).map { items[Int($0)] }
     }

--- a/shell/mac/Tests/JayJayTests/CommandPaletteSupportTests.swift
+++ b/shell/mac/Tests/JayJayTests/CommandPaletteSupportTests.swift
@@ -39,4 +39,26 @@ final class CommandPaletteSupportTests: XCTestCase {
         )
         XCTAssertTrue(CommandPaletteSearch.rank(query: "bookmark", items: items).isEmpty)
     }
+
+    func testKeybindRowsAreInfoOnlyAndShortcutsAreSearchable() {
+        let items = [
+            CommandPaletteItem(
+                title: "Refresh", icon: "arrow.triangle.2.circlepath", category: "View", shortcut: "⌘R"
+            ) {},
+            CommandPaletteItem.keybind(
+                title: "Mark File Reviewed", icon: "checkmark.circle", shortcut: "Space",
+                keywords: ["review", "reviewed", "check", "diff"]
+            )
+        ]
+
+        // Keybind rows are info-only (the row never executes); commands carry an action.
+        XCTAssertFalse(items[0].isInfo)
+        XCTAssertTrue(items[1].isInfo)
+
+        // The keybind row is findable by its shortcut text, not just its title.
+        XCTAssertEqual(
+            CommandPaletteSearch.rank(query: "space", items: items).map(\.title),
+            ["Mark File Reviewed"]
+        )
+    }
 }

--- a/shell/mac/Tests/JayJayUITests/Scenes/CommandPaletteScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/CommandPaletteScene.swift
@@ -2,13 +2,33 @@ import AppKit
 import XCTest
 
 final class CommandPaletteScene: SceneBase {
-    func testOpenAndSearch() throws {
+    /// Trigger → move → reopen → type: remembers a dragged position across reopen, and filters.
+    func testMovePersistsThenSearch() throws {
         let app = try XCTUnwrap(app)
-        keyStroke("p", modifiers: [.command, .shift])
 
+        // Trigger.
+        keyStroke("p", modifiers: [.command, .shift])
         let field = app.textFields[AID.Palette.textField]
         XCTAssertTrue(field.waitForExistence(timeout: 5), "Command palette did not open")
+        let original = field.frame.origin
 
+        // Move — drag the panel by its background (the padding above the search field).
+        let handle = field.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0))
+            .withOffset(CGVector(dx: 0, dy: -8))
+        handle.press(forDuration: 0.4, thenDragTo: handle.withOffset(CGVector(dx: 150, dy: 120)))
+        let moved = field.frame.origin
+        XCTAssertNotEqual(moved, original, "Palette did not move when dragged")
+
+        // Trigger again — close and reopen; it must reappear where we left it, not re-center.
+        keyStroke(.escape)
+        XCTAssertTrue(field.waitForNonExistence(timeout: 3), "Palette did not close")
+        keyStroke("p", modifiers: [.command, .shift])
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "Palette did not reopen")
+        let reopened = field.frame.origin
+        XCTAssertEqual(reopened.x, moved.x, accuracy: 6, "Palette x reset after reopen")
+        XCTAssertEqual(reopened.y, moved.y, accuracy: 6, "Palette y reset after reopen")
+
+        // Type — search filters the list.
         let query = "toggle tr"
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(query, forType: .string)


### PR DESCRIPTION
- Liquid Glass material, Spotlight-style rounded rows and shortcut glyphs (#87).
- Searchable keybind cheatsheet rows (info-only) for keys that are not commands.
- Theme: System/Light/Dark commands wired to settings.appearanceMode.
- Remember the dragged panel position across opens; dismiss on click-outside.
- Hover highlights without moving the keyboard selection.
- Merge the palette UI tests into one trigger -> move -> reopen -> type flow.
- Liquid Glass material on floating surfaces: rebase/bookmark drag ghosts, drag-target bubble, sidebar banner, toast.
- Commit box: Summary + Description placeholders (GitHub-Desktop style) with the placeholder aligned to the cursor.