### PR TITLE
fix(gpui): align file-column separator with the filename

### DIFF
--- a/shell/gpui/src/diff/file_column/flat.rs
+++ b/shell/gpui/src/diff/file_column/flat.rs
@@ -174,7 +174,6 @@ where
         ));
     }
     row.child(status_dot(hunk, t))
-        .child(content)
-        .child(super::row_separator(t.row_border))
+        .child(super::name_with_separator(content, t.row_border))
         .into_any_element()
 }

--- a/shell/gpui/src/diff/file_column/mod.rs
+++ b/shell/gpui/src/diff/file_column/mod.rs
@@ -15,17 +15,26 @@ use crate::app::config;
 use crate::app::theme::theme;
 use crate::repo::window::{FileTreeCacheSlot, RepoWindow};
 
-/// An inset bottom separator for a file row — leading space so it reads like the
-/// SwiftUI file list rather than a full-width rule. The row must be `relative()`;
-/// the line is absolutely positioned, so fixed-height rows keep their height.
-pub(super) fn row_separator(border: u32) -> impl IntoElement {
+/// Wrap a row's name so the bottom separator starts at the filename, not the checkbox/dot/chevron.
+pub(super) fn name_with_separator(name: impl IntoElement, border: u32) -> impl IntoElement {
     div()
-        .absolute()
-        .bottom_0()
-        .left(px(12.))
-        .right_0()
-        .h(px(1.))
-        .bg(rgb(border))
+        .flex_1()
+        .h_full()
+        .relative()
+        .flex()
+        .flex_row()
+        .items_center()
+        .min_w_0()
+        .child(name)
+        .child(
+            div()
+                .absolute()
+                .bottom_0()
+                .left_0()
+                .right_0()
+                .h(px(1.))
+                .bg(rgb(border)),
+        )
 }
 
 use flat::flat_body;

--- a/shell/gpui/src/diff/file_column/tree.rs
+++ b/shell/gpui/src/diff/file_column/tree.rs
@@ -165,7 +165,7 @@ where
         ));
     }
     row.child(status_dot(hunk, t))
-        .child(
+        .child(super::name_with_separator(
             div()
                 .flex_1()
                 .min_w_0()
@@ -174,8 +174,8 @@ where
                 .text_size(px(12.))
                 .text_color(rgb(name_color))
                 .child(SharedString::from(name)),
-        )
-        .child(super::row_separator(t.row_border))
+            t.row_border,
+        ))
         .into_any_element()
 }
 
@@ -210,7 +210,7 @@ where
         .on_click(on_click)
         .child(icons::icon(chevron_glyph, 10., t.fg_faint))
         .child(icons::icon(glyph::FOLDER_SIMPLE, 12., t.fg_dim))
-        .child(
+        .child(super::name_with_separator(
             div()
                 .flex_1()
                 .min_w_0()
@@ -218,7 +218,7 @@ where
                 .text_size(px(12.))
                 .text_color(rgb(t.fg_dim))
                 .child(SharedString::from(entry.name.clone())),
-        )
-        .child(super::row_separator(t.row_border))
+            t.row_border,
+        ))
         .into_any_element()
 }

--- a/shell/gpui/src/repo/window/dag_row.rs
+++ b/shell/gpui/src/repo/window/dag_row.rs
@@ -304,10 +304,9 @@ fn format_relative(ts_millis: i64) -> String {
         Some(dt) => dt,
         None => return String::new(),
     };
-    let secs = Local::now().signed_duration_since(dt).num_seconds();
-    if secs < 60 {
-        return "just now".to_owned();
-    }
+    // Floor to whole minutes so a fresh change reads "1 minute ago" instead of ticking
+    // per second; clamping also reads a clock-skewed future timestamp as "1 minute ago".
+    let secs = Local::now().signed_duration_since(dt).num_seconds().max(60);
     let ago = |n: i64, unit: &str| {
         if n == 1 {
             format!("1 {unit} ago")
@@ -327,4 +326,20 @@ fn format_relative(ts_millis: i64) -> String {
 
 pub(super) fn first_line(s: &str) -> String {
     s.lines().next().unwrap_or("").trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_relative;
+    use chrono::Local;
+
+    #[test]
+    fn format_relative_floors_sub_minute_to_one_minute() {
+        let now = Local::now().timestamp_millis();
+        // Fresh and sub-minute changes read as whole minutes, never per-second.
+        assert_eq!(format_relative(now), "1 minute ago");
+        assert_eq!(format_relative(now - 30_000), "1 minute ago");
+        // Coarser units are unaffected.
+        assert_eq!(format_relative(now - 2 * 3_600_000), "2 hours ago");
+    }
 }

--- a/shell/mac/Sources/JayJay/Repo/DAGRow.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAGRow.swift
@@ -320,8 +320,10 @@ struct DAGRow: View {
     private func relativeDate(_ millis: Int64) -> String {
         let date = Date(timeIntervalSince1970: Double(millis) / 1000)
         let now = Date()
-        // A clock-skewed future timestamp should read as "now", not "in N days".
-        return Self.relativeFormatter.localizedString(for: min(date, now), relativeTo: now)
+        // Floor to whole minutes: a per-second count ("19s, 20s, …") on fresh changes is
+        // distracting, and a clock-skewed future timestamp then reads as "1 minute ago".
+        let reference = min(date, now.addingTimeInterval(-60))
+        return Self.relativeFormatter.localizedString(for: reference, relativeTo: now)
     }
 
     private var pullRequestLabel: String {


### PR DESCRIPTION
Wrap each row name in a full-height column so the bottom separator starts at the filename (after the checkbox, status dot, or tree chevron) instead of a fixed inset — correct for flat rows, tree files, and tree dirs.