### PR TITLE
fix(core): harden against malicious-repository input (Codex security scan)

### DIFF
--- a/crates/jayjay-core/src/repo/bookmarks.rs
+++ b/crates/jayjay-core/src/repo/bookmarks.rs
@@ -150,7 +150,13 @@ impl Repo {
     }
 
     pub fn track_bookmark(&self, name: &str, remote: &str) -> CoreResult<()> {
-        self.run_jj_reload(&["bookmark", "track", name, &format!("--remote={remote}")])
+        self.run_jj_reload(&[
+            "bookmark",
+            "track",
+            &format!("--remote={remote}"),
+            "--",
+            name,
+        ])
     }
 
     /// Prune stale remote refs, then forget bookmarks that are locally deleted
@@ -171,7 +177,8 @@ impl Repo {
             .map(|s| s.to_owned())
             .collect();
         for branch in &gone_branches {
-            let _ = self.command_output("git", &["branch", "-D", branch], "delete gone branch");
+            let _ =
+                self.command_output("git", &["branch", "-D", "--", branch], "delete gone branch");
         }
 
         // Step 3: Re-import git refs so jj sees the deletions
@@ -189,7 +196,7 @@ impl Repo {
             .collect();
         let count = gone_branches.len() as u32 + stale.len() as u32;
         for name in stale {
-            self.run_jj(&["bookmark", "forget", name])?;
+            self.run_jj(&["bookmark", "forget", "--", name])?;
         }
         if count > 0 {
             self.reload()?;

--- a/crates/jayjay-core/src/repo/diff/materialize.rs
+++ b/crates/jayjay-core/src/repo/diff/materialize.rs
@@ -1,8 +1,9 @@
 use std::hash::{Hash, Hasher};
 
+use futures::AsyncReadExt as _;
 use jj_lib::conflicts::{
     ConflictMarkerStyle, ConflictMaterializeOptions, MaterializedFileConflictValue,
-    MaterializedTreeValue, materialize_merge_result_to_bytes,
+    MaterializedFileValue, MaterializedTreeValue, materialize_merge_result_to_bytes,
 };
 use jj_lib::files::FileMergeHunkLevel;
 use jj_lib::merge::SameChange;
@@ -14,6 +15,33 @@ use crate::types::*;
 
 /// Max inline image size; larger files fall back to the text placeholder.
 const MAX_IMAGE_BYTES: usize = 16 * 1024 * 1024;
+
+/// Max blob size materialized for text/conflict display. Snapshots are uncapped, so
+/// bound the allocation before reading; no realistic source file is this large.
+const MAX_DIFF_BYTES: usize = 32 * 1024 * 1024;
+
+/// Reads at most `limit + 1` bytes, capping peak allocation. Returns `(bytes, truncated)`;
+/// on truncation the buffer is cleared (the content gets a placeholder instead).
+async fn read_capped(
+    file: &mut MaterializedFileValue,
+    limit: usize,
+) -> std::io::Result<(Vec<u8>, bool)> {
+    read_to_limit(&mut file.reader, limit).await
+}
+
+async fn read_to_limit(
+    reader: impl futures::AsyncRead + Unpin,
+    limit: usize,
+) -> std::io::Result<(Vec<u8>, bool)> {
+    let mut buf = Vec::new();
+    reader.take(limit as u64 + 1).read_to_end(&mut buf).await?;
+    let truncated = buf.len() > limit;
+    if truncated {
+        buf.clear();
+        buf.shrink_to_fit();
+    }
+    Ok((buf, truncated))
+}
 
 const IMAGE_EXTENSIONS: &[&str] = &[
     "png", "jpg", "jpeg", "gif", "webp", "heic", "bmp", "tiff", "tif", "ico", "icns",
@@ -40,11 +68,11 @@ pub(super) fn extract_image_preview(
     let MaterializedTreeValue::File(mut file) = value else {
         return Ok(ImagePreviewResult::None);
     };
-    let bytes = block_on_result(
+    let (bytes, truncated) = block_on_result(
         &format!("read image {}", path.as_internal_file_string()),
-        file.read_all(path),
+        read_capped(&mut file, MAX_IMAGE_BYTES),
     )?;
-    if bytes.is_empty() || bytes.len() > MAX_IMAGE_BYTES {
+    if truncated || bytes.is_empty() {
         return Ok(ImagePreviewResult::None);
     }
 
@@ -113,11 +141,15 @@ pub(super) fn materialized_to_string(
         MaterializedTreeValue::Absent => Ok(None),
         MaterializedTreeValue::AccessDenied(err) => Ok(Some(format!("<access denied: {err}>"))),
         MaterializedTreeValue::File(mut file) => {
-            let read = file.read_all(path);
-            let bytes = block_on_result(
+            let (bytes, truncated) = block_on_result(
                 &format!("read file {}", path.as_internal_file_string()),
-                read,
+                read_capped(&mut file, MAX_DIFF_BYTES),
             )?;
+            if truncated {
+                return Ok(Some(format!(
+                    "<file too large to display (over {MAX_DIFF_BYTES} bytes)>"
+                )));
+            }
             if bytes.contains(&0) {
                 return Ok(Some(format!("<binary file ({} bytes)>", bytes.len())));
             }
@@ -140,6 +172,11 @@ pub(super) fn materialized_to_string(
 }
 
 fn materialized_file_conflict(file: MaterializedFileConflictValue) -> String {
+    // jj-lib already holds each side in memory; just avoid a second merged copy when oversized.
+    let total: usize = file.contents.iter().map(|side| side.len()).sum();
+    if total > MAX_DIFF_BYTES {
+        return format!("<conflict too large to display (over {MAX_DIFF_BYTES} bytes)>");
+    }
     let options = ConflictMaterializeOptions {
         marker_style: ConflictMarkerStyle::Diff,
         marker_len: None,
@@ -209,6 +246,34 @@ fn short_oid(oid: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn read_to_limit_sync(data: Vec<u8>, limit: usize) -> (Vec<u8>, bool) {
+        pollster::block_on(read_to_limit(futures::io::Cursor::new(data), limit))
+            .expect("read_to_limit")
+    }
+
+    #[test]
+    fn read_to_limit_passes_small_content() {
+        let (bytes, truncated) = read_to_limit_sync(vec![b'a'; 100], 1024);
+        assert_eq!(bytes.len(), 100);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn read_to_limit_keeps_content_at_the_limit() {
+        let (bytes, truncated) = read_to_limit_sync(vec![b'a'; 64], 64);
+        assert_eq!(bytes.len(), 64);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn read_to_limit_truncates_past_the_limit() {
+        // One byte over the cap: flagged truncated and the buffer is released so a
+        // hostile multi-gigabyte blob never stays resident.
+        let (bytes, truncated) = read_to_limit_sync(vec![b'a'; 65], 64);
+        assert!(truncated);
+        assert!(bytes.is_empty());
+    }
 
     #[test]
     fn parses_git_lfs_pointer_text() {

--- a/crates/jayjay-core/src/repo/git/lfs.rs
+++ b/crates/jayjay-core/src/repo/git/lfs.rs
@@ -23,12 +23,28 @@ impl Repo {
             .collect())
     }
 
-    /// Filter the provided repo-relative paths down to those matched by Git LFS attributes.
+    /// Filter repo-relative paths to those actually stored as Git LFS objects. A
+    /// `.gitattributes filter=lfs` line is repo-controlled (a source file could fake it
+    /// to hide its diff), so trust only what `git lfs ls-files` reports, not the attribute.
     pub fn git_lfs_paths(&self, paths: &[String]) -> CoreResult<Vec<String>> {
         if paths.is_empty() {
             return Ok(vec![]);
         }
+        let attr_paths = self.check_attr_lfs_paths(paths)?;
+        if attr_paths.is_empty() {
+            return Ok(vec![]);
+        }
+        let tracked: std::collections::HashSet<String> =
+            self.tracked_git_lfs_files()?.into_iter().collect();
+        Ok(attr_paths
+            .into_iter()
+            .filter(|path| tracked.contains(path))
+            .collect())
+    }
 
+    /// Paths whose `.gitattributes` set `filter=lfs`. Repository-controlled, so
+    /// callers must confirm real LFS registration before acting on the result.
+    fn check_attr_lfs_paths(&self, paths: &[String]) -> CoreResult<Vec<String>> {
         let mut child = subprocess_command("git")
             .current_dir(&self.path)
             .args(["check-attr", "--stdin", "filter"])

--- a/crates/jayjay-core/src/repo/git/sync.rs
+++ b/crates/jayjay-core/src/repo/git/sync.rs
@@ -10,7 +10,7 @@ impl Repo {
         if bookmark.is_empty() {
             self.run_jj_quiet(&["bookmark", "track", "glob:*"]);
         } else {
-            self.run_jj_quiet(&["bookmark", "track", bookmark, "--remote=origin"]);
+            self.run_jj_quiet(&["bookmark", "track", "--remote=origin", "--", bookmark]);
         }
 
         let mut args = vec!["git", "push"];
@@ -35,7 +35,7 @@ impl Repo {
             return Ok("Nothing to push.".to_owned());
         }
         for bookmark in bookmarks {
-            self.run_jj_quiet(&["bookmark", "track", bookmark, "--remote=origin"]);
+            self.run_jj_quiet(&["bookmark", "track", "--remote=origin", "--", bookmark]);
         }
         // `--bookmark` creates and tracks new remote bookmarks on its own; jj 0.42
         // has no `--allow-new` flag.
@@ -66,7 +66,7 @@ impl Repo {
     pub fn git_pull_bookmark(&self, bookmark: &str) -> CoreResult<FetchResult> {
         let tracking_before = self.tracking_bookmark_names();
         let msg = self.git_fetch_raw("", bookmark)?;
-        let _ = self.run_jj_reload(&["bookmark", "track", bookmark, "--remote=origin"]);
+        let _ = self.run_jj_reload(&["bookmark", "track", "--remote=origin", "--", bookmark]);
         self.rebase_to_trunk();
         let _ = self.reload();
         Ok(self.post_fetch_cleanup(msg, &tracking_before))

--- a/crates/jayjay-core/src/repo/mod.rs
+++ b/crates/jayjay-core/src/repo/mod.rs
@@ -14,6 +14,7 @@ mod init;
 mod log;
 mod mutations;
 mod mutations_files;
+mod path_operands;
 mod pull_requests;
 mod resolve;
 mod stacked_pr;

--- a/crates/jayjay-core/src/repo/mutations.rs
+++ b/crates/jayjay-core/src/repo/mutations.rs
@@ -1,6 +1,7 @@
 use jj_lib::repo::Repo as _;
 
 use super::Repo;
+use super::path_operands::fileset_literal;
 use super::support::block_on_result;
 use crate::types::*;
 
@@ -162,7 +163,11 @@ impl Repo {
         } else {
             args.extend(["-m", "split"]);
         }
-        args.extend(paths.iter().map(|s| s.as_str()));
+        // Literal fileset operands after `--`, so an option- or fileset-shaped filename
+        // (e.g. `--config=ui.diff-editor=...`) can't become a jj flag or expression.
+        let operands: Vec<String> = paths.iter().map(|p| fileset_literal(p)).collect();
+        args.push("--");
+        args.extend(operands.iter().map(String::as_str));
         self.run_jj_reload(&args)
     }
 }

--- a/crates/jayjay-core/src/repo/mutations_files.rs
+++ b/crates/jayjay-core/src/repo/mutations_files.rs
@@ -1,4 +1,5 @@
 use super::Repo;
+use super::path_operands::{fileset_literal, gitignore_pattern, reject_control_chars};
 use super::support::block_on_result;
 use crate::types::*;
 
@@ -14,8 +15,9 @@ impl Repo {
             .is_some_and(|id| id == commit.id());
 
         if is_wc {
-            let mut args = vec!["restore", "--from", "@-"];
-            args.extend(paths.iter().map(|s| s.as_str()));
+            let operands: Vec<String> = paths.iter().map(|p| fileset_literal(p)).collect();
+            let mut args = vec!["restore", "--from", "@-", "--"];
+            args.extend(operands.iter().map(String::as_str));
             self.run_jj_reload(&args)
         } else {
             let repo_paths = self.parse_repo_paths(paths)?;
@@ -61,12 +63,16 @@ impl Repo {
 
     /// Add paths to .gitignore and untrack them via `jj file untrack`.
     pub fn ignore_and_untrack(&self, paths: &[String]) -> CoreResult<()> {
+        // Reject control chars first: a newline would inject extra .gitignore patterns.
+        reject_control_chars(paths)?;
+
         let gitignore_path = self.path.join(".gitignore");
         let existing = std::fs::read_to_string(&gitignore_path).unwrap_or_default();
         let mut lines_to_add = Vec::new();
         for path in paths {
-            if !existing.lines().any(|line| line.trim() == path.as_str()) {
-                lines_to_add.push(path.as_str());
+            let pattern = gitignore_pattern(path);
+            if !existing.lines().any(|line| line.trim() == pattern) {
+                lines_to_add.push(pattern);
             }
         }
         if !lines_to_add.is_empty() {
@@ -88,15 +94,17 @@ impl Repo {
             }
         }
 
-        let mut args = vec!["file", "untrack"];
-        args.extend(paths.iter().map(|s| s.as_str()));
+        let operands: Vec<String> = paths.iter().map(|p| fileset_literal(p)).collect();
+        let mut args = vec!["file", "untrack", "--"];
+        args.extend(operands.iter().map(String::as_str));
         self.run_jj_reload(&args)
     }
 
     /// Move files from a change to working copy using `jj squash --from rev --into @`.
     pub fn move_to_working_copy(&self, rev: &str, paths: &[String]) -> CoreResult<()> {
-        let mut args = vec!["squash", "--from", rev, "--into", "@"];
-        args.extend(paths.iter().map(|s| s.as_str()));
+        let operands: Vec<String> = paths.iter().map(|p| fileset_literal(p)).collect();
+        let mut args = vec!["squash", "--from", rev, "--into", "@", "--"];
+        args.extend(operands.iter().map(String::as_str));
         self.run_jj_reload(&args)
     }
 }

--- a/crates/jayjay-core/src/repo/path_operands.rs
+++ b/crates/jayjay-core/src/repo/path_operands.rs
@@ -1,0 +1,86 @@
+//! Safe encodings of repository-controlled paths for jj command operands and
+//! `.gitignore` lines, so an attacker-chosen filename can't act as an option, a
+//! fileset expression, or an extra ignore rule.
+
+use crate::types::*;
+
+/// Wrap a repo-relative path as an exact-match jj fileset operand, so a filename with
+/// fileset syntax (`all()`, `glob:`) or a leading `-` is matched literally, not evaluated
+/// as an expression or parsed as an option. `root-file:` is repo-root-relative (cwd-independent).
+pub(crate) fn fileset_literal(path: &str) -> String {
+    let mut escaped = String::with_capacity(path.len() + 2);
+    for ch in path.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            _ => escaped.push(ch),
+        }
+    }
+    format!("root-file:\"{escaped}\"")
+}
+
+/// Reject paths with control characters: a newline in a filename would otherwise
+/// inject extra `.gitignore` patterns.
+pub(crate) fn reject_control_chars(paths: &[String]) -> CoreResult<()> {
+    for path in paths {
+        if path.chars().any(char::is_control) {
+            return Err(CoreError::Internal {
+                message: format!("path contains control characters: {path:?}"),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Escape a path into a literal `.gitignore` pattern: leading `!`/`#` and glob
+/// metacharacters `\ * ? [ ]` are escaped so the file is ignored verbatim, never a
+/// broader or inverted rule. Reject control chars first — gitignore has no newline escape.
+pub(crate) fn gitignore_pattern(path: &str) -> String {
+    let mut out = String::with_capacity(path.len() + 1);
+    for (i, ch) in path.chars().enumerate() {
+        match ch {
+            '\\' | '*' | '?' | '[' | ']' => {
+                out.push('\\');
+                out.push(ch);
+            }
+            '!' | '#' if i == 0 => {
+                out.push('\\');
+                out.push(ch);
+            }
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fileset_literal_wraps_and_escapes() {
+        assert_eq!(fileset_literal("a/b.txt"), "root-file:\"a/b.txt\"");
+        assert_eq!(fileset_literal("all()"), "root-file:\"all()\"");
+        assert_eq!(fileset_literal("--config=x"), "root-file:\"--config=x\"");
+        assert_eq!(fileset_literal("a\"b"), "root-file:\"a\\\"b\"");
+        assert_eq!(fileset_literal("a\\b"), "root-file:\"a\\\\b\"");
+    }
+
+    #[test]
+    fn reject_control_chars_flags_newline_and_tab() {
+        assert!(reject_control_chars(&["ok/path.txt".to_owned()]).is_ok());
+        assert!(reject_control_chars(&["evil\n*.pem".to_owned()]).is_err());
+        assert!(reject_control_chars(&["tab\there".to_owned()]).is_err());
+    }
+
+    #[test]
+    fn gitignore_pattern_escapes_special_leading_and_glob() {
+        assert_eq!(gitignore_pattern("normal.txt"), "normal.txt");
+        assert_eq!(gitignore_pattern("!important"), "\\!important");
+        assert_eq!(gitignore_pattern("#hash"), "\\#hash");
+        assert_eq!(gitignore_pattern("a*b?.txt"), "a\\*b\\?.txt");
+        assert_eq!(gitignore_pattern("x[y].txt"), "x\\[y\\].txt");
+        // `!` is only special at the start.
+        assert_eq!(gitignore_pattern("a!b"), "a!b");
+    }
+}

--- a/crates/jayjay-core/src/repo/pull_requests/github.rs
+++ b/crates/jayjay-core/src/repo/pull_requests/github.rs
@@ -83,18 +83,22 @@ enum GhCheckConclusion {
     Unknown,
 }
 
+/// `gh pr view` argv with `bookmark` after `--`, so an option-shaped name can't
+/// be parsed as a flag.
+fn pr_view_args(bookmark: &str) -> [&str; 6] {
+    [
+        "pr",
+        "view",
+        "--json",
+        "number,state,title,url,statusCheckRollup",
+        "--",
+        bookmark,
+    ]
+}
+
 pub(super) fn pr_info(repo: &Repo, bookmark: &str) -> PrLookup {
-    let Ok(output) = repo.command_output(
-        &gh_binary(),
-        &[
-            "pr",
-            "view",
-            bookmark,
-            "--json",
-            "number,state,title,url,statusCheckRollup",
-        ],
-        "gh pr view",
-    ) else {
+    let Ok(output) = repo.command_output(&gh_binary(), &pr_view_args(bookmark), "gh pr view")
+    else {
         return PrLookup::Unknown;
     };
     if !output.status.success() {
@@ -218,5 +222,24 @@ mod tests {
             ]
         }"#;
         assert_eq!(parse_pr_json(json).unwrap().checks, ChecksStatus::Pending);
+    }
+
+    #[test]
+    fn pr_view_args_put_bookmark_after_separator() {
+        assert_eq!(
+            pr_view_args("feat-x"),
+            [
+                "pr",
+                "view",
+                "--json",
+                "number,state,title,url,statusCheckRollup",
+                "--",
+                "feat-x"
+            ]
+        );
+        // An option-shaped bookmark lands after `--`, never parsed as a flag.
+        let args = pr_view_args("--repo=evil");
+        assert_eq!(args[args.len() - 2], "--");
+        assert_eq!(args[args.len() - 1], "--repo=evil");
     }
 }

--- a/crates/jayjay-core/src/repo/stacked_pr/github.rs
+++ b/crates/jayjay-core/src/repo/stacked_pr/github.rs
@@ -32,13 +32,15 @@ pub(super) fn create_or_update_pr(repo: &Repo, target: &ForgeTarget) -> Submitte
     }
 }
 
+/// `gh pr view` argv with `head` after `--`, so an option-shaped bookmark name
+/// can't be parsed as a flag.
+fn pr_view_args(head: &str) -> [&str; 6] {
+    ["pr", "view", "--json", "number,url", "--", head]
+}
+
 fn existing_pr(repo: &Repo, head: &str) -> Option<(u32, String)> {
     let out = repo
-        .command_output(
-            &gh_binary(),
-            &["pr", "view", head, "--json", "number,url"],
-            "gh pr view",
-        )
+        .command_output(&gh_binary(), &pr_view_args(head), "gh pr view")
         .ok()?;
     if !out.status.success() {
         return None;
@@ -127,5 +129,22 @@ fn create_pr(repo: &Repo, target: &ForgeTarget) -> SubmittedLayer {
         }
         Ok(out) => failed(target, Repo::stderr_text(&out)),
         Err(error) => failed(target, error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pr_view_args;
+
+    #[test]
+    fn pr_view_args_put_head_after_separator() {
+        assert_eq!(
+            pr_view_args("feat-x"),
+            ["pr", "view", "--json", "number,url", "--", "feat-x"]
+        );
+        // An option-shaped bookmark lands after `--`, never parsed as a flag.
+        let args = pr_view_args("--repo=evil");
+        assert_eq!(args[args.len() - 2], "--");
+        assert_eq!(args[args.len() - 1], "--repo=evil");
     }
 }

--- a/crates/jayjay-core/src/repo/stacked_pr/gitlab.rs
+++ b/crates/jayjay-core/src/repo/stacked_pr/gitlab.rs
@@ -32,13 +32,38 @@ pub(super) fn create_or_update_mr(repo: &Repo, target: &ForgeTarget) -> Submitte
     }
 }
 
+/// `glab mr view` argv with `head` after `--`, so an option-shaped bookmark name
+/// can't be parsed as a flag.
+fn mr_view_args(head: &str) -> [&str; 6] {
+    ["mr", "view", "-F", "json", "--", head]
+}
+
+/// `glab mr update` argv with the bookmark after `--` and all options before it.
+fn mr_update_args<'a>(
+    base: &'a str,
+    title: &'a str,
+    description: &'a str,
+    bookmark: &'a str,
+) -> [&'a str; 11] {
+    [
+        "mr",
+        "update",
+        "--target-branch",
+        base,
+        "--title",
+        title,
+        "--description",
+        description,
+        // Enforce branch retention on re-submit so already-created MRs stay stack-safe.
+        "--remove-source-branch=false",
+        "--",
+        bookmark,
+    ]
+}
+
 fn existing_mr(repo: &Repo, head: &str) -> Option<(u32, String)> {
     let out = repo
-        .command_output(
-            &glab_binary(),
-            &["mr", "view", head, "-F", "json"],
-            "glab mr view",
-        )
+        .command_output(&glab_binary(), &mr_view_args(head), "glab mr view")
         .ok()?;
     if !out.status.success() {
         return None;
@@ -59,20 +84,12 @@ fn update_target(repo: &Repo, target: &ForgeTarget, iid: u32, url: String) -> Su
     let description = non_empty_or(&target.body, &title);
     let result = repo.command_output(
         &glab_binary(),
-        &[
-            "mr",
-            "update",
-            target.bookmark.as_str(),
-            "--target-branch",
+        &mr_update_args(
             target.base.as_str(),
-            "--title",
             title.as_str(),
-            "--description",
             description.as_str(),
-            // Also enforce branch retention on re-submit so already-created MRs
-            // become stack-safe.
-            "--remove-source-branch=false",
-        ],
+            target.bookmark.as_str(),
+        ),
         "glab mr update",
     );
     let (outcome, detail) = match result {
@@ -146,4 +163,44 @@ fn mr_url_from_text(text: &str) -> String {
         .unwrap_or("")
         .trim()
         .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{mr_update_args, mr_view_args};
+
+    #[test]
+    fn mr_view_args_put_head_after_separator() {
+        assert_eq!(
+            mr_view_args("feat-x"),
+            ["mr", "view", "-F", "json", "--", "feat-x"]
+        );
+        let args = mr_view_args("--repo=evil");
+        assert_eq!(args[args.len() - 2], "--");
+        assert_eq!(args[args.len() - 1], "--repo=evil");
+    }
+
+    #[test]
+    fn mr_update_args_put_bookmark_after_separator() {
+        assert_eq!(
+            mr_update_args("main", "T", "D", "feat-x"),
+            [
+                "mr",
+                "update",
+                "--target-branch",
+                "main",
+                "--title",
+                "T",
+                "--description",
+                "D",
+                "--remove-source-branch=false",
+                "--",
+                "feat-x",
+            ]
+        );
+        // An option-shaped bookmark lands after `--`, never parsed as a flag.
+        let evil = mr_update_args("main", "T", "D", "--yes");
+        assert_eq!(evil[evil.len() - 2], "--");
+        assert_eq!(evil[evil.len() - 1], "--yes");
+    }
 }

--- a/crates/jayjay-core/tests/lfs.rs
+++ b/crates/jayjay-core/tests/lfs.rs
@@ -1,0 +1,75 @@
+//! LFS diff-hiding must follow real LFS registration, not repository-controlled
+//! `.gitattributes` — otherwise a malicious repo could mark a source file as LFS
+//! to hide its real diff from review.
+
+use std::fs;
+use std::process::Command;
+
+use jayjay_core::Repo;
+use jj_test::{init_jj_repo, run_git};
+
+fn git_lfs_available() -> bool {
+    Command::new("git")
+        .args(["lfs", "version"])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// A `.gitattributes filter=lfs` line alone (no real LFS object) must NOT cause
+/// the path to be treated as LFS — the lying attribute can't fake a stored pointer.
+#[test]
+fn attribute_only_lfs_is_not_reported() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let repo = Repo::open(&repo_path).expect("open repo");
+
+    fs::write(repo_path.join("source.txt"), "real source line\n").expect("write source");
+    fs::write(repo_path.join(".gitattributes"), "source.txt filter=lfs\n").expect("write attrs");
+
+    // The attribute really is set (so the filter, not a missing attribute, is what matters).
+    let attr = String::from_utf8_lossy(
+        &run_git(&repo_path, &["check-attr", "filter", "--", "source.txt"]).stdout,
+    )
+    .into_owned();
+    assert!(
+        attr.contains("filter: lfs"),
+        "attribute should mark lfs: {attr}"
+    );
+
+    assert!(
+        repo.git_lfs_paths(&["source.txt".to_owned()])
+            .expect("git_lfs_paths")
+            .is_empty(),
+        "a non-registered file must not be hidden as LFS"
+    );
+}
+
+/// A genuinely LFS-tracked binary must still be reported, even though its working
+/// copy holds the smudged bytes rather than a pointer.
+#[test]
+fn genuine_lfs_object_is_reported() {
+    if !git_lfs_available() {
+        eprintln!("skipping: git-lfs not installed");
+        return;
+    }
+
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let repo = Repo::open(&repo_path).expect("open repo");
+
+    run_git(&repo_path, &["config", "user.email", "test@example.com"]);
+    run_git(&repo_path, &["config", "user.name", "Test User"]);
+    run_git(&repo_path, &["lfs", "install", "--local"]);
+    run_git(&repo_path, &["lfs", "track", "*.bin"]);
+    fs::write(repo_path.join("asset.bin"), vec![0u8, 1, 2, 3, 4, 5, 6, 7]).expect("write asset");
+    run_git(&repo_path, &["add", ".gitattributes", "asset.bin"]);
+    run_git(&repo_path, &["commit", "-m", "add lfs asset"]);
+
+    assert_eq!(
+        repo.git_lfs_paths(&["asset.bin".to_owned()])
+            .expect("git_lfs_paths"),
+        vec!["asset.bin".to_owned()],
+        "a real LFS object must still be reported"
+    );
+}

--- a/crates/jayjay-core/tests/path_injection.rs
+++ b/crates/jayjay-core/tests/path_injection.rs
@@ -1,0 +1,187 @@
+//! Repository-controlled filenames must reach jj as literal paths, never as
+//! options or fileset expressions. Each test plants a hostile filename and
+//! asserts the mutation touches only that file (and launches nothing).
+
+use std::fs;
+
+use jayjay_core::Repo;
+use jj_test::{init_jj_repo, run_jj_in};
+
+/// Paths in a change's diff, for asserting exactly which files an action touched.
+fn diff_paths(repo: &Repo, rev: &str) -> Vec<String> {
+    repo.show(rev)
+        .expect("show change")
+        .diff
+        .into_iter()
+        .map(|hunk| hunk.path)
+        .collect()
+}
+
+/// Finding 1 (medium): a file named like a jj option must not be parsed as one.
+/// Without the fix, `--config=ui.diff-editor=...` makes split launch that editor
+/// (here a missing binary), so the call would error instead of splitting the file.
+#[test]
+fn split_treats_option_shaped_filename_as_literal_path() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let repo = Repo::open(&repo_path).expect("open repo");
+
+    let hostile = "--config=ui.diff-editor=jayjay-pwned-editor";
+    fs::write(repo_path.join("keep.txt"), "keep\n").expect("write keep");
+    fs::write(repo_path.join(hostile), "payload\n").expect("write hostile file");
+    repo.refresh_working_copy().expect("snapshot");
+
+    repo.split("@", &[hostile.to_owned()], "split out hostile", false)
+        .expect("split must succeed and not launch an editor");
+
+    // The split-out parent holds the named file; the child keeps the rest.
+    let parent = diff_paths(&repo, "@-");
+    let child = diff_paths(&repo, "@");
+    assert!(
+        parent.contains(&hostile.to_owned()),
+        "split-out parent must hold the named file: {parent:?}"
+    );
+    assert!(
+        !child.contains(&hostile.to_owned()) && child.contains(&"keep.txt".to_owned()),
+        "child must keep the rest and not the split-out file: {child:?}"
+    );
+}
+
+/// Finding 3: a file named `all()` must restore only itself, not every file.
+#[test]
+fn restore_working_copy_matches_only_the_named_fileset_filename() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let repo = Repo::open(&repo_path).expect("open repo");
+
+    // Parent holds the baseline for both files.
+    fs::write(repo_path.join("keep.txt"), "base\n").expect("write keep base");
+    fs::write(repo_path.join("all()"), "base\n").expect("write all() base");
+    repo.refresh_working_copy().expect("snapshot parent");
+
+    // Working copy edits both.
+    repo.new_change("@", "edits").expect("new change");
+    fs::write(repo_path.join("keep.txt"), "edited\n").expect("edit keep");
+    fs::write(repo_path.join("all()"), "edited\n").expect("edit all()");
+    repo.refresh_working_copy().expect("snapshot edits");
+
+    repo.restore_files("@", &["all()".to_owned()])
+        .expect("restore all()");
+
+    // all() reverted to baseline (out of the diff); keep.txt's edit survives.
+    let paths = diff_paths(&repo, "@");
+    assert!(
+        paths.contains(&"keep.txt".to_owned()),
+        "keep.txt must remain modified: {paths:?}"
+    );
+    assert!(
+        !paths.contains(&"all()".to_owned()),
+        "only all() should have been restored: {paths:?}"
+    );
+}
+
+/// Finding 3: untrack must drop only the named file, not every tracked file.
+#[test]
+fn ignore_and_untrack_matches_only_the_named_fileset_filename() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let repo = Repo::open(&repo_path).expect("open repo");
+
+    fs::write(repo_path.join("keep.txt"), "keep\n").expect("write keep");
+    fs::write(repo_path.join("all()"), "payload\n").expect("write all()");
+    repo.refresh_working_copy().expect("snapshot");
+
+    repo.ignore_and_untrack(&["all()".to_owned()])
+        .expect("ignore and untrack all()");
+
+    let tracked =
+        String::from_utf8_lossy(&run_jj_in(&repo_path, &["file", "list"]).stdout).into_owned();
+    assert!(
+        tracked.contains("keep.txt"),
+        "keep.txt must stay tracked: {tracked:?}"
+    );
+    assert!(
+        !tracked.contains("all()"),
+        "only all() should have been untracked: {tracked:?}"
+    );
+}
+
+/// Finding 3: move-to-working-copy (squash) must move only the named file.
+#[test]
+fn move_to_working_copy_matches_only_the_named_fileset_filename() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let repo = Repo::open(&repo_path).expect("open repo");
+
+    // Source change adds both files.
+    fs::write(repo_path.join("keep.txt"), "keep\n").expect("write keep");
+    fs::write(repo_path.join("all()"), "payload\n").expect("write all()");
+    repo.refresh_working_copy().expect("snapshot source");
+    repo.describe("@", "source").expect("describe source");
+    let source = repo
+        .log("description(\"source\")")
+        .expect("log source")
+        .into_iter()
+        .find(|c| c.description.trim() == "source")
+        .expect("find source");
+
+    // Empty working-copy child on top.
+    repo.new_change("@", "child").expect("new child");
+
+    repo.move_to_working_copy(&source.change_id, &["all()".to_owned()])
+        .expect("move all() to working copy");
+
+    // all() moved into @; keep.txt stays in the source change.
+    let child = diff_paths(&repo, "@");
+    assert!(
+        child.contains(&"all()".to_owned()),
+        "all() must move into the working copy: {child:?}"
+    );
+    let source_paths = diff_paths(&repo, &source.change_id);
+    assert!(
+        source_paths.contains(&"keep.txt".to_owned())
+            && !source_paths.contains(&"all()".to_owned()),
+        "only all() should have moved out of the source: {source_paths:?}"
+    );
+}
+
+/// Finding 2: a newline in a filename must not inject extra .gitignore patterns.
+#[test]
+fn ignore_and_untrack_rejects_control_character_paths() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let repo = Repo::open(&repo_path).expect("open repo");
+
+    let hostile = "evil\n*.pem".to_owned();
+    let result = repo.ignore_and_untrack(&[hostile]);
+    assert!(result.is_err(), "newline-bearing path must be rejected");
+
+    // No pattern was injected (.gitignore is untouched / has no *.pem line).
+    let gitignore = fs::read_to_string(repo_path.join(".gitignore")).unwrap_or_default();
+    assert!(
+        !gitignore.lines().any(|line| line.trim() == "*.pem"),
+        "no injected ignore pattern: {gitignore:?}"
+    );
+}
+
+/// A leading `!` filename must be ignored literally, not become a negation rule.
+#[test]
+fn ignore_and_untrack_escapes_negation_filename() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let repo = Repo::open(&repo_path).expect("open repo");
+
+    fs::write(repo_path.join("!important.txt"), "x\n").expect("write file");
+    repo.refresh_working_copy().expect("snapshot");
+
+    repo.ignore_and_untrack(&["!important.txt".to_owned()])
+        .expect("ignore negation-shaped filename");
+
+    let gitignore = fs::read_to_string(repo_path.join(".gitignore")).expect("read .gitignore");
+    assert!(
+        gitignore
+            .lines()
+            .any(|line| line.trim() == "\\!important.txt"),
+        "leading ! must be escaped: {gitignore:?}"
+    );
+}


### PR DESCRIPTION
Address all findings from a repository-wide Codex security scan: a malicious repo could influence the jj/git/gh commands JayJay runs or what its review UI shows.

- Pass repo-controlled filenames to jj as literal fileset operands (root-file:"...") on split/restore/untrack/squash. Finding 1 (medium): a file named --config=ui.diff-editor=... could launch an attacker binary via jj split; finding 3: a file named all() widened restore/untrack/squash. A bare -- is not enough — jj still evaluates all() as a fileset function. New repo/path_operands module centralizes this.
- Sanitize .gitignore writes (finding 2): reject control characters (no newline pattern injection) and escape leading !/# and glob metacharacters.
- Base LFS diff-hiding on real registration, not .gitattributes (finding 4): intersect git check-attr with git lfs ls-files, so a lying filter=lfs attribute cannot hide a source diff while genuine smudged binaries stay hidden.
- Bound diff materialization reads (finding 5): read at most limit+1 bytes for image/text/conflict display so an oversized blob cannot exhaust memory; snapshot max_new_file_size stays uncapped so legit large files still track.
- Add -- separators to bookmark/forge subprocess args (sweep beyond the report): gh pr view, glab mr view/update, jj bookmark track/forget, git branch -D — an option-shaped name could otherwise inject flags.

Adds regression tests for option/fileset-shaped filenames, LFS attribute spoofing, oversized reads, and forge/bookmark argv ordering (asserting untrusted names land after --).