### PR TITLE
ci: fix GPUI platform failures

### DIFF
--- a/crates/jayjay-core/src/fonts/mod.rs
+++ b/crates/jayjay-core/src/fonts/mod.rs
@@ -21,18 +21,6 @@ pub(crate) const SYSTEM_MONO: MonoFontOption = MonoFontOption {
     font_names: &[],
 };
 
-pub(crate) const MENLO: MonoFontOption = MonoFontOption {
-    id: "menlo",
-    title: "Menlo",
-    font_names: &["Menlo"],
-};
-
-pub(crate) const SF_MONO: MonoFontOption = MonoFontOption {
-    id: "sf-mono",
-    title: "SF Mono",
-    font_names: &["SF Mono"],
-};
-
 pub(crate) const JETBRAINS_MONO: MonoFontOption = MonoFontOption {
     id: "jetbrains-mono",
     title: "JetBrains Mono",
@@ -85,12 +73,6 @@ pub(crate) const IOSKELEY_MONO_NL_NERD_FONT: MonoFontOption = MonoFontOption {
     font_names: &["IoskeleyMonoNL Nerd Font", "IoskeleyMonoNLNF"],
 };
 
-pub(crate) const BERKELEY_MONO: MonoFontOption = MonoFontOption {
-    id: "berkeley-mono",
-    title: "Berkeley Mono",
-    font_names: &["Berkeley Mono", "BerkeleyMono-Regular"],
-};
-
 pub(crate) const ROBOTO_MONO: MonoFontOption = MonoFontOption {
     id: "roboto-mono",
     title: "Roboto Mono",
@@ -108,12 +90,6 @@ pub(crate) const UBUNTU_MONO: MonoFontOption = MonoFontOption {
     id: "ubuntu-mono",
     title: "Ubuntu Mono",
     font_names: &["Ubuntu Mono", "UbuntuMono-Regular"],
-};
-
-pub(crate) const MONACO: MonoFontOption = MonoFontOption {
-    id: "monaco",
-    title: "Monaco",
-    font_names: &["Monaco"],
 };
 
 #[cfg(test)]

--- a/crates/jayjay-core/src/fonts/platform/macos.rs
+++ b/crates/jayjay-core/src/fonts/platform/macos.rs
@@ -1,7 +1,31 @@
 use super::super::{
-    BERKELEY_MONO, CASCADIA_CODE, FIRA_CODE, GOOGLE_SANS_MONO, HACK, INCONSOLATA, IOSKELEY_MONO,
-    IOSKELEY_MONO_NL_NERD_FONT, JETBRAINS_MONO, MENLO, MONACO, MonoFontOption, ROBOTO_MONO,
-    SF_MONO, SOURCE_CODE_PRO, SYSTEM_MONO,
+    CASCADIA_CODE, FIRA_CODE, GOOGLE_SANS_MONO, HACK, INCONSOLATA, IOSKELEY_MONO,
+    IOSKELEY_MONO_NL_NERD_FONT, JETBRAINS_MONO, MonoFontOption, ROBOTO_MONO, SOURCE_CODE_PRO,
+    SYSTEM_MONO,
+};
+
+const MENLO: MonoFontOption = MonoFontOption {
+    id: "menlo",
+    title: "Menlo",
+    font_names: &["Menlo"],
+};
+
+const SF_MONO: MonoFontOption = MonoFontOption {
+    id: "sf-mono",
+    title: "SF Mono",
+    font_names: &["SF Mono"],
+};
+
+const BERKELEY_MONO: MonoFontOption = MonoFontOption {
+    id: "berkeley-mono",
+    title: "Berkeley Mono",
+    font_names: &["Berkeley Mono", "BerkeleyMono-Regular"],
+};
+
+const MONACO: MonoFontOption = MonoFontOption {
+    id: "monaco",
+    title: "Monaco",
+    font_names: &["Monaco"],
 };
 
 pub const MONO_FONT_OPTIONS: &[MonoFontOption] = &[

--- a/crates/jayjay-core/src/tools/mod.rs
+++ b/crates/jayjay-core/src/tools/mod.rs
@@ -175,15 +175,15 @@ mod tests {
     #[test]
     fn repo_file_url_opens_existing_repo_file() {
         let tmp = tempfile::tempdir().unwrap();
-        let file = tmp.path().join("docs").join("index page#v?.html");
+        let file = tmp.path().join("docs").join("index page#v%.html");
         std::fs::create_dir_all(file.parent().unwrap()).unwrap();
         std::fs::write(&file, "<html></html>").unwrap();
 
-        let url = repo_file_url(tmp.path().to_str().unwrap(), "docs/index page#v?.html")
+        let url = repo_file_url(tmp.path().to_str().unwrap(), "docs/index page#v%.html")
             .expect("html file should be openable");
 
         assert!(url.starts_with("file:///"), "{url}");
-        assert!(url.ends_with("/docs/index%20page%23v%3F.html"), "{url}");
+        assert!(url.ends_with("/docs/index%20page%23v%25.html"), "{url}");
     }
 
     #[test]

--- a/crates/jj-diff/src/change_groups.rs
+++ b/crates/jj-diff/src/change_groups.rs
@@ -1,0 +1,104 @@
+use super::types::{ChangeGroup, DiffLine, DiffSide, DiffSpanStyle};
+
+/// The canonical group index used by review marks and notes across SwiftUI and CLI surfaces.
+pub fn change_groups(lines: &[DiffLine]) -> Vec<ChangeGroup> {
+    change_group_ranges(lines)
+        .into_iter()
+        .map(|(index, start, end)| build_change_group(index, start, end, lines))
+        .collect()
+}
+
+/// Scans ranges first and materializes only the matching group's payload, so reconciling a note does not clone every changed line's text.
+pub fn change_group_for_anchor(
+    lines: &[DiffLine],
+    side: DiffSide,
+    line_number: u32,
+    anchor_excerpt: &str,
+) -> Option<ChangeGroup> {
+    change_group_ranges(lines)
+        .into_iter()
+        .find(|(_, start, end)| {
+            lines[*start..=*end]
+                .iter()
+                .any(|line| line_matches_anchor(line, side, line_number, anchor_excerpt))
+        })
+        .map(|(index, start, end)| build_change_group(index, start, end, lines))
+}
+
+/// 0-based inclusive (index, start, end) spans of contiguous changed lines.
+fn change_group_ranges(lines: &[DiffLine]) -> Vec<(u32, usize, usize)> {
+    let mut ranges: Vec<(u32, usize, usize)> = Vec::new();
+    let mut start: Option<usize> = None;
+
+    for (line_index, line) in lines.iter().enumerate() {
+        if line.is_changed() {
+            if start.is_none() {
+                start = Some(line_index);
+            }
+        } else if let Some(start_index) = start.take() {
+            ranges.push((ranges.len() as u32, start_index, line_index - 1));
+        }
+    }
+
+    if let Some(start_index) = start {
+        ranges.push((
+            ranges.len() as u32,
+            start_index,
+            lines.len().saturating_sub(1),
+        ));
+    }
+
+    ranges
+}
+
+fn build_change_group(
+    index: u32,
+    start_index: usize,
+    end_index: usize,
+    lines: &[DiffLine],
+) -> ChangeGroup {
+    let group_lines = &lines[start_index..=end_index];
+    let anchor = group_lines
+        .iter()
+        .find_map(anchor_for_line)
+        .expect("change group must contain a changed line with a line number");
+
+    ChangeGroup {
+        index,
+        start_line: (start_index + 1) as u32,
+        end_line: (end_index + 1) as u32,
+        anchor_side: anchor.0,
+        anchor_line: anchor.1,
+        anchor_excerpt: anchor.2,
+        anchor_context: group_lines.iter().map(DiffLine::text).collect(),
+    }
+}
+
+fn anchor_for_line(line: &DiffLine) -> Option<(DiffSide, u32, String)> {
+    match line.style {
+        DiffSpanStyle::Removed => line
+            .old_line_no
+            .map(|line_no| (DiffSide::Old, line_no, line.text())),
+        DiffSpanStyle::Added => line
+            .new_line_no
+            .map(|line_no| (DiffSide::New, line_no, line.text())),
+        _ => None,
+    }
+}
+
+fn line_matches_anchor(
+    line: &DiffLine,
+    side: DiffSide,
+    line_number: u32,
+    anchor_excerpt: &str,
+) -> bool {
+    match (side, line.style) {
+        (DiffSide::Old, DiffSpanStyle::Removed) => {
+            line.old_line_no == Some(line_number) && line.text() == anchor_excerpt
+        }
+        (DiffSide::New, DiffSpanStyle::Added) => {
+            line.new_line_no == Some(line_number) && line.text() == anchor_excerpt
+        }
+        _ => false,
+    }
+}

--- a/crates/jj-diff/src/compute.rs
+++ b/crates/jj-diff/src/compute.rs
@@ -2,10 +2,8 @@ use super::conflicts::annotate_conflict_lines;
 use super::context::collapse_context;
 use super::highlights::apply_highlights;
 use super::line_diff::{LineOp, line_diff};
-use super::types::{
-    ChangeGroup, ConflictLineKind, DiffLine, DiffSide, DiffSpan, DiffSpanStyle, FileDiff, LineMap,
-};
-use super::word_diff::word_diff_paired_line;
+use super::render_highlights::{HighlightInputs, apply_rendered_highlights, plain_spans};
+use super::types::{ConflictLineKind, DiffLine, DiffSpan, DiffSpanStyle, FileDiff, LineMap};
 use crate::syntax;
 
 /// Standalone per-line highlight for blame/annotate — do not fold back into a diff-against-empty; that produced Added spans, collapsed context, and EOF markers in blame views.
@@ -47,109 +45,6 @@ pub fn compute_file_diff_full(
     compute_file_diff_impl(path, old, new, ignore_whitespace, false)
 }
 
-/// The canonical group index used by review marks and notes across SwiftUI and CLI surfaces.
-pub fn change_groups(lines: &[DiffLine]) -> Vec<ChangeGroup> {
-    change_group_ranges(lines)
-        .into_iter()
-        .map(|(index, start, end)| build_change_group(index, start, end, lines))
-        .collect()
-}
-
-/// Scans ranges first and materializes only the matching group's payload, so reconciling a note does not clone every changed line's text.
-pub fn change_group_for_anchor(
-    lines: &[DiffLine],
-    side: DiffSide,
-    line_number: u32,
-    anchor_excerpt: &str,
-) -> Option<ChangeGroup> {
-    change_group_ranges(lines)
-        .into_iter()
-        .find(|(_, start, end)| {
-            lines[*start..=*end]
-                .iter()
-                .any(|line| line_matches_anchor(line, side, line_number, anchor_excerpt))
-        })
-        .map(|(index, start, end)| build_change_group(index, start, end, lines))
-}
-
-/// 0-based inclusive (index, start, end) spans of contiguous changed lines.
-fn change_group_ranges(lines: &[DiffLine]) -> Vec<(u32, usize, usize)> {
-    let mut ranges: Vec<(u32, usize, usize)> = Vec::new();
-    let mut start: Option<usize> = None;
-
-    for (line_index, line) in lines.iter().enumerate() {
-        if line.is_changed() {
-            if start.is_none() {
-                start = Some(line_index);
-            }
-        } else if let Some(start_index) = start.take() {
-            ranges.push((ranges.len() as u32, start_index, line_index - 1));
-        }
-    }
-
-    if let Some(start_index) = start {
-        ranges.push((
-            ranges.len() as u32,
-            start_index,
-            lines.len().saturating_sub(1),
-        ));
-    }
-
-    ranges
-}
-
-fn build_change_group(
-    index: u32,
-    start_index: usize,
-    end_index: usize,
-    lines: &[DiffLine],
-) -> ChangeGroup {
-    let group_lines = &lines[start_index..=end_index];
-    let anchor = group_lines
-        .iter()
-        .find_map(anchor_for_line)
-        .expect("change group must contain a changed line with a line number");
-
-    ChangeGroup {
-        index,
-        start_line: (start_index + 1) as u32,
-        end_line: (end_index + 1) as u32,
-        anchor_side: anchor.0,
-        anchor_line: anchor.1,
-        anchor_excerpt: anchor.2,
-        anchor_context: group_lines.iter().map(DiffLine::text).collect(),
-    }
-}
-
-fn anchor_for_line(line: &DiffLine) -> Option<(DiffSide, u32, String)> {
-    match line.style {
-        DiffSpanStyle::Removed => line
-            .old_line_no
-            .map(|line_no| (DiffSide::Old, line_no, line.text())),
-        DiffSpanStyle::Added => line
-            .new_line_no
-            .map(|line_no| (DiffSide::New, line_no, line.text())),
-        _ => None,
-    }
-}
-
-fn line_matches_anchor(
-    line: &DiffLine,
-    side: DiffSide,
-    line_number: u32,
-    anchor_excerpt: &str,
-) -> bool {
-    match (side, line.style) {
-        (DiffSide::Old, DiffSpanStyle::Removed) => {
-            line.old_line_no == Some(line_number) && line.text() == anchor_excerpt
-        }
-        (DiffSide::New, DiffSpanStyle::Added) => {
-            line.new_line_no == Some(line_number) && line.text() == anchor_excerpt
-        }
-        _ => false,
-    }
-}
-
 /// File extensions that are generated/data — skip syntax highlighting.
 const SKIP_HIGHLIGHT_EXTENSIONS: &[&str] = &["lock", "csv", "tsv", "svg"];
 
@@ -181,16 +76,6 @@ fn compute_file_diff_impl(
     let old_line_map = LineMap::from_text(old);
     let new_line_map = LineMap::from_text(new);
     let skip_highlight = should_skip_highlight(path);
-    let old_highlights = if skip_highlight {
-        vec![]
-    } else {
-        syntax::highlight(old, language)
-    };
-    let new_highlights = if skip_highlight {
-        vec![]
-    } else {
-        syntax::highlight(new, language)
-    };
 
     let old_lines: Vec<&str> = old.lines().collect();
     let new_lines: Vec<&str> = new.lines().collect();
@@ -204,18 +89,12 @@ fn compute_file_diff_impl(
     while op_pos < line_ops.len() {
         match line_ops[op_pos] {
             LineOp::Equal => {
-                if let Some((byte_start, text)) = new_line_map.get(new_idx) {
-                    let spans = apply_highlights(
-                        text,
-                        *byte_start,
-                        &new_highlights,
-                        DiffSpanStyle::Context,
-                    );
+                if let Some((_byte_start, text)) = new_line_map.get(new_idx) {
                     result_lines.push(DiffLine {
                         old_line_no: Some(old_idx),
                         new_line_no: Some(new_idx),
                         style: DiffSpanStyle::Context,
-                        spans,
+                        spans: plain_spans(text, DiffSpanStyle::Context),
                         conflict_kind: ConflictLineKind::None,
                         no_eof_newline: false,
                     });
@@ -243,22 +122,14 @@ fn compute_file_diff_impl(
                 for i in 0..paired_count {
                     let old_ln = removed_indices[i];
                     let new_ln = added_indices[i];
-                    if let (Some((old_byte, old_text)), Some((new_byte, new_text))) =
+                    if let (Some((_old_byte, old_text)), Some((_new_byte, new_text))) =
                         (old_line_map.get(old_ln), new_line_map.get(new_ln))
                     {
-                        let (rem_spans, add_spans) = word_diff_paired_line(
-                            old_text,
-                            *old_byte,
-                            &old_highlights,
-                            new_text,
-                            *new_byte,
-                            &new_highlights,
-                        );
                         result_lines.push(DiffLine {
                             old_line_no: Some(old_ln),
                             new_line_no: None,
                             style: DiffSpanStyle::Removed,
-                            spans: rem_spans,
+                            spans: plain_spans(old_text, DiffSpanStyle::Removed),
                             conflict_kind: ConflictLineKind::None,
                             no_eof_newline: false,
                         });
@@ -266,7 +137,7 @@ fn compute_file_diff_impl(
                             old_line_no: None,
                             new_line_no: Some(new_ln),
                             style: DiffSpanStyle::Added,
-                            spans: add_spans,
+                            spans: plain_spans(new_text, DiffSpanStyle::Added),
                             conflict_kind: ConflictLineKind::None,
                             no_eof_newline: false,
                         });
@@ -274,18 +145,12 @@ fn compute_file_diff_impl(
                 }
 
                 for &old_ln in &removed_indices[paired_count..] {
-                    if let Some((byte_start, text)) = old_line_map.get(old_ln) {
-                        let spans = apply_highlights(
-                            text,
-                            *byte_start,
-                            &old_highlights,
-                            DiffSpanStyle::Unchanged,
-                        );
+                    if let Some((_byte_start, text)) = old_line_map.get(old_ln) {
                         result_lines.push(DiffLine {
                             old_line_no: Some(old_ln),
                             new_line_no: None,
                             style: DiffSpanStyle::Removed,
-                            spans,
+                            spans: plain_spans(text, DiffSpanStyle::Unchanged),
                             conflict_kind: ConflictLineKind::None,
                             no_eof_newline: false,
                         });
@@ -293,18 +158,12 @@ fn compute_file_diff_impl(
                 }
 
                 for &new_ln in &added_indices[paired_count..] {
-                    if let Some((byte_start, text)) = new_line_map.get(new_ln) {
-                        let spans = apply_highlights(
-                            text,
-                            *byte_start,
-                            &new_highlights,
-                            DiffSpanStyle::Unchanged,
-                        );
+                    if let Some((_byte_start, text)) = new_line_map.get(new_ln) {
                         result_lines.push(DiffLine {
                             old_line_no: None,
                             new_line_no: Some(new_ln),
                             style: DiffSpanStyle::Added,
-                            spans,
+                            spans: plain_spans(text, DiffSpanStyle::Unchanged),
                             conflict_kind: ConflictLineKind::None,
                             no_eof_newline: false,
                         });
@@ -312,18 +171,12 @@ fn compute_file_diff_impl(
                 }
             }
             LineOp::Add => {
-                if let Some((byte_start, text)) = new_line_map.get(new_idx) {
-                    let spans = apply_highlights(
-                        text,
-                        *byte_start,
-                        &new_highlights,
-                        DiffSpanStyle::Unchanged,
-                    );
+                if let Some((_byte_start, text)) = new_line_map.get(new_idx) {
                     result_lines.push(DiffLine {
                         old_line_no: None,
                         new_line_no: Some(new_idx),
                         style: DiffSpanStyle::Added,
-                        spans,
+                        spans: plain_spans(text, DiffSpanStyle::Unchanged),
                         conflict_kind: ConflictLineKind::None,
                         no_eof_newline: false,
                     });
@@ -352,11 +205,23 @@ fn compute_file_diff_impl(
 
     annotate_conflict_lines(&mut result_lines);
 
-    let lines = if collapse {
+    let mut lines = if collapse {
         collapse_context(result_lines)
     } else {
         result_lines
     };
+    apply_rendered_highlights(
+        &mut lines,
+        HighlightInputs {
+            old,
+            new,
+            old_line_map: &old_line_map,
+            new_line_map: &new_line_map,
+            language,
+            skip_highlight,
+            collapse,
+        },
+    );
 
     FileDiff {
         path: path.to_owned(),

--- a/crates/jj-diff/src/lib.rs
+++ b/crates/jj-diff/src/lib.rs
@@ -1,11 +1,13 @@
 use similar::{Algorithm, TextDiff, TextDiffConfig};
 
+mod change_groups;
 mod compute;
 mod conflicts;
 mod context;
 mod highlights;
 mod line_diff;
 pub mod placeholders;
+mod render_highlights;
 pub mod side_by_side;
 pub mod syntax;
 mod types;
@@ -24,10 +26,8 @@ pub(crate) fn text_diff_config() -> TextDiffConfig {
 #[cfg(test)]
 mod tests;
 
-pub use compute::{
-    change_group_for_anchor, change_groups, compute_file_diff, compute_file_diff_full,
-    highlight_file,
-};
+pub use change_groups::{change_group_for_anchor, change_groups};
+pub use compute::{compute_file_diff, compute_file_diff_full, highlight_file};
 pub use conflicts::{
     annotate_conflict_lines, build_diff_display_items, build_diff_display_lines,
     conflict_display_text,

--- a/crates/jj-diff/src/render_highlights.rs
+++ b/crates/jj-diff/src/render_highlights.rs
@@ -1,0 +1,202 @@
+use std::collections::HashMap;
+
+use crate::syntax::{self, HighlightSpan, SyntaxToken};
+
+use super::highlights::apply_highlights;
+use super::types::{DiffLine, DiffSide, DiffSpan, DiffSpanStyle, LineMap};
+use super::word_diff::word_diff_paired_line;
+
+pub(super) struct HighlightInputs<'a> {
+    pub old: &'a str,
+    pub new: &'a str,
+    pub old_line_map: &'a LineMap,
+    pub new_line_map: &'a LineMap,
+    pub language: &'a str,
+    pub skip_highlight: bool,
+    pub collapse: bool,
+}
+
+pub(super) fn plain_spans(text: &str, style: DiffSpanStyle) -> Vec<DiffSpan> {
+    if text.is_empty() {
+        return vec![];
+    }
+    vec![DiffSpan {
+        text: text.to_owned(),
+        style,
+        token: SyntaxToken::Plain,
+    }]
+}
+
+pub(super) fn apply_rendered_highlights(lines: &mut [DiffLine], inputs: HighlightInputs<'_>) {
+    let old_highlights = SideHighlights::new(
+        inputs.old,
+        inputs.old_line_map,
+        lines,
+        DiffSide::Old,
+        inputs.language,
+        inputs.skip_highlight,
+        inputs.collapse,
+    );
+    let new_highlights = SideHighlights::new(
+        inputs.new,
+        inputs.new_line_map,
+        lines,
+        DiffSide::New,
+        inputs.language,
+        inputs.skip_highlight,
+        inputs.collapse,
+    );
+
+    let mut index = 0usize;
+    while index < lines.len() {
+        if lines[index].style == DiffSpanStyle::Removed
+            && index + 1 < lines.len()
+            && lines[index + 1].style == DiffSpanStyle::Added
+            && let (Some(old_ln), Some(new_ln)) =
+                (lines[index].old_line_no, lines[index + 1].new_line_no)
+        {
+            let old_text = lines[index].text();
+            let new_text = lines[index + 1].text();
+            let (removed_spans, added_spans) = word_diff_paired_line(
+                &old_text,
+                old_highlights.offset(old_ln),
+                old_highlights.spans(),
+                &new_text,
+                new_highlights.offset(new_ln),
+                new_highlights.spans(),
+            );
+            lines[index].spans = removed_spans;
+            lines[index + 1].spans = added_spans;
+            index += 2;
+            continue;
+        }
+
+        if let Some((side, line_no, style)) = highlight_side_for_line(&lines[index]) {
+            let text = lines[index].text();
+            let highlights = match side {
+                DiffSide::Old => &old_highlights,
+                DiffSide::New => &new_highlights,
+            };
+            lines[index].spans =
+                apply_highlights(&text, highlights.offset(line_no), highlights.spans(), style);
+        }
+        index += 1;
+    }
+}
+
+fn highlight_side_for_line(line: &DiffLine) -> Option<(DiffSide, u32, DiffSpanStyle)> {
+    match line.style {
+        DiffSpanStyle::Context => line
+            .new_line_no
+            .map(|line_no| (DiffSide::New, line_no, DiffSpanStyle::Context))
+            .or_else(|| {
+                line.old_line_no
+                    .map(|line_no| (DiffSide::Old, line_no, DiffSpanStyle::Context))
+            }),
+        DiffSpanStyle::Removed => line
+            .old_line_no
+            .map(|line_no| (DiffSide::Old, line_no, DiffSpanStyle::Unchanged)),
+        DiffSpanStyle::Added => line
+            .new_line_no
+            .map(|line_no| (DiffSide::New, line_no, DiffSpanStyle::Unchanged)),
+        DiffSpanStyle::Unchanged | DiffSpanStyle::Separator => None,
+    }
+}
+
+struct SideHighlights {
+    spans: Vec<HighlightSpan>,
+    offsets: HighlightOffsets,
+}
+
+impl SideHighlights {
+    fn new(
+        source: &str,
+        line_map: &LineMap,
+        lines: &[DiffLine],
+        side: DiffSide,
+        language: &str,
+        skip_highlight: bool,
+        collapse: bool,
+    ) -> Self {
+        if skip_highlight {
+            return Self {
+                spans: vec![],
+                offsets: HighlightOffsets::Empty,
+            };
+        }
+        if collapse {
+            let source = VisibleHighlightSource::new(lines, side, line_map);
+            return Self {
+                spans: syntax::highlight(&source.text, language),
+                offsets: HighlightOffsets::Mapped(source.offsets),
+            };
+        }
+        Self {
+            spans: syntax::highlight(source, language),
+            offsets: HighlightOffsets::Mapped(original_offsets(lines, side, line_map)),
+        }
+    }
+
+    fn spans(&self) -> &[HighlightSpan] {
+        &self.spans
+    }
+
+    fn offset(&self, line_no: u32) -> usize {
+        match &self.offsets {
+            HighlightOffsets::Empty => 0,
+            HighlightOffsets::Mapped(offsets) => offsets.get(&line_no).copied().unwrap_or(0),
+        }
+    }
+}
+
+enum HighlightOffsets {
+    Empty,
+    Mapped(HashMap<u32, usize>),
+}
+
+fn original_offsets(lines: &[DiffLine], side: DiffSide, line_map: &LineMap) -> HashMap<u32, usize> {
+    let mut offsets = HashMap::new();
+    for line in lines {
+        let line_no = match side {
+            DiffSide::Old => line.old_line_no,
+            DiffSide::New => line.new_line_no,
+        };
+        let Some(line_no) = line_no else { continue };
+        if offsets.contains_key(&line_no) {
+            continue;
+        }
+        if let Some((offset, _text)) = line_map.get(line_no) {
+            offsets.insert(line_no, *offset);
+        }
+    }
+    offsets
+}
+
+struct VisibleHighlightSource {
+    text: String,
+    offsets: HashMap<u32, usize>,
+}
+
+impl VisibleHighlightSource {
+    fn new(lines: &[DiffLine], side: DiffSide, line_map: &LineMap) -> Self {
+        let mut text = String::new();
+        let mut offsets = HashMap::new();
+        for line in lines {
+            let line_no = match side {
+                DiffSide::Old => line.old_line_no,
+                DiffSide::New => line.new_line_no,
+            };
+            let Some(line_no) = line_no else { continue };
+            if offsets.contains_key(&line_no) {
+                continue;
+            }
+            let Some((_original_offset, line_text)) = line_map.get(line_no) else {
+                continue;
+            };
+            offsets.insert(line_no, text.len());
+            text.push_str(line_text);
+            text.push('\n');
+        }
+        Self { text, offsets }
+    }
+}

--- a/crates/jj-diff/src/tests/performance.rs
+++ b/crates/jj-diff/src/tests/performance.rs
@@ -15,12 +15,11 @@ fn large_highlighted_file_single_line_change_is_fast() {
     let diff = compute_file_diff("big.rs", &old, &new, false);
     let elapsed = start.elapsed();
 
-    // The linear path is ~1s; a small margin over that absorbs CI variance
-    // (Windows runners tip just past a flat 1000ms) while still catching the
-    // O(lines × spans) quadratic blowup this guards against.
+    // The collapsed path should not syntax-highlight thousands of hidden lines;
+    // this still catches the O(lines × spans) quadratic blowup this guards against.
     assert!(
-        elapsed.as_millis() < 1100,
-        "5000-line highlighted diff with 1 change took {}ms (should be ~1s)",
+        elapsed.as_millis() < 1_100,
+        "5000-line highlighted diff with 1 change took {}ms (limit 1100ms)",
         elapsed.as_millis()
     );
 


### PR DESCRIPTION
## Summary
- move macOS-only mono font options into the macOS platform module so Linux clippy does not see them as dead shared constants
- use a Windows-valid filename in the file URL regression test while preserving percent-encoding coverage
- fix the Windows jj-diff performance failure by applying syntax/word highlighting after collapsed context is known, so hidden lines are not highlighted
- split rendered highlighting and change-group helpers out of compute.rs to keep the diff engine modules focused

## Test plan
- cargo test -p jayjay-core repo_file_url_opens_existing_repo_file -- --nocapture
- cargo test -p jj-diff large_highlighted_file_single_line_change_is_fast -- --nocapture
- cargo test -p jj-diff --lib
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --check

Fixes the failures from https://github.com/hewigovens/jayjay/actions/runs/28992037109 and https://github.com/hewigovens/jayjay/actions/runs/28992588315/job/86035484972?pr=107