### PR TITLE
fix(mac): reuse main window for repository list

### DIFF
--- a/shell/mac/Sources/JayJay/App/JayJayApp.swift
+++ b/shell/mac/Sources/JayJay/App/JayJayApp.swift
@@ -190,6 +190,9 @@ struct JayJayApp: App {
                 .task(id: path) {
                     settings.recordOpenedRepo(path)
                 }
+                .background(WindowConfigurator { window in
+                    window.identifier = NSUserInterfaceItemIdentifier(AppWindows.main)
+                })
                 .background(WindowContentSizer(targetSize: NSSize(width: 1100, height: 700), minimumOnly: true))
         } else {
             WelcomeView(onOpen: { path in

--- a/shell/mac/Sources/JayJay/App/Window/RepoListWindowBridge.swift
+++ b/shell/mac/Sources/JayJay/App/Window/RepoListWindowBridge.swift
@@ -12,9 +12,11 @@ struct RepoListWindowBridge: View {
             .onAppear {
                 windowManager.setWindowActions(
                     openRepo: { openWindow(id: AppWindows.repo, value: $0) },
-                    showRepoList: {
+                    showRepoList: { openNewWindow in
                         repoPath = nil
-                        openWindow(id: AppWindows.main)
+                        if openNewWindow {
+                            openWindow(id: AppWindows.main)
+                        }
                     }
                 )
             }

--- a/shell/mac/Sources/JayJay/App/Window/RepoWindowManager.swift
+++ b/shell/mac/Sources/JayJay/App/Window/RepoWindowManager.swift
@@ -8,7 +8,7 @@ final class RepoWindowManager {
     private(set) var openRepoPaths: [String] = []
     private let settings: AppSettings
     private var openRepoAction: ((String) -> Void)?
-    private var showRepoListAction: (() -> Void)?
+    private var showRepoListAction: ((Bool) -> Void)?
     private var isRepoListRequested = false
 
     init(settings: AppSettings) {
@@ -17,7 +17,7 @@ final class RepoWindowManager {
 
     func setWindowActions(
         openRepo: @escaping (String) -> Void,
-        showRepoList: @escaping () -> Void
+        showRepoList: @escaping (_ openNewWindow: Bool) -> Void
     ) {
         openRepoAction = openRepo
         showRepoListAction = showRepoList
@@ -30,15 +30,23 @@ final class RepoWindowManager {
             $0.identifier?.rawValue == AppWindows.welcome
         }) {
             isRepoListRequested = false
-            window.deminiaturize(nil)
-            window.makeKeyAndOrderFront(nil)
-            NSApp.activate(ignoringOtherApps: true)
+            activate(window)
+            return
+        }
+
+        if let window = NSApp.windows.first(where: {
+            ($0.isVisible || $0.isMiniaturized)
+                && $0.identifier?.rawValue == AppWindows.main
+        }) {
+            isRepoListRequested = false
+            showRepoListAction?(false)
+            activate(window)
             return
         }
 
         guard !isRepoListRequested, let showRepoListAction else { return }
         isRepoListRequested = true
-        showRepoListAction()
+        showRepoListAction(true)
     }
 
     func repoWindowWillClose() {
@@ -94,11 +102,15 @@ final class RepoWindowManager {
         guard let window = NSApp.windows.first(where: {
             $0.representedURL?.standardizedFileURL.path == path
         }) else { return false }
+        activate(window)
+        repoWindowDidAppear()
+        return true
+    }
+
+    private func activate(_ window: NSWindow) {
         window.deminiaturize(nil)
         window.makeKeyAndOrderFront(nil)
-        repoWindowDidAppear()
         NSApp.activate(ignoringOtherApps: true)
-        return true
     }
 
     func openRepo(_ path: String) {

--- a/shell/mac/Tests/JayJayUITests/Scenes/RepoListInitialRepositoryScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/RepoListInitialRepositoryScene.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+final class RepoListInitialRepositoryScene: SceneBase {
+    func testRepositoryListReusesInitialWindow() throws {
+        let app = try XCTUnwrap(app)
+        XCTAssertEqual(app.windows.count, 1, "JayJay did not start with one repository window")
+
+        let repoWindow = app.windows.firstMatch
+        let titleMenu = repoWindow.toolbars.menuButtons["Switch Repository"].firstMatch
+        XCTAssertTrue(titleMenu.waitForExistence(timeout: 5), "Repository title menu missing")
+        titleMenu.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 1.2)).click()
+
+        let repoList = app.menuItems["Repository List..."]
+        XCTAssertTrue(repoList.waitForExistence(timeout: 3), "Repository List menu item missing")
+        repoList.click()
+
+        XCTAssertTrue(
+            app.staticTexts["Recent Repositories"].waitForExistence(timeout: 5),
+            "Repository title menu did not show the repository list"
+        )
+        XCTAssertEqual(app.windows.count, 1, "Opening the repository list duplicated the initial window")
+    }
+}


### PR DESCRIPTION
## Summary

- reuse the initial SwiftUI main repository window when opening Repository List
- open a new main scene only when no repository-list or reusable main window exists
- add a UI regression for the direct-repository launch path

## Root cause

When JayJay launched directly into a repository, that repository occupied the main `WindowGroup`. The first Repository List action set the shared path to `nil` (turning that window into the list) and also called `openWindow(id: AppWindows.main)`, creating a second list window.

## Validation

- `just shell::ui-test JayJayUITests/RepoListInitialRepositoryScene/testRepositoryListReusesInitialWindow`
- `just shell::ui-test JayJayUITests/RepoListWindowScene`
- `just test-app` (133 tests)
- `just lint`