### PR TITLE
docs: explain repository list and pins

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -7,7 +7,7 @@
   <title>JayJay User Guide</title>
   <meta name="description"
     content="The complete JayJay user guide: DAG navigation, side-by-side diffs, rich file previews, review notes, diff edit and split, stacked pull requests, conflict resolution, evolog, command palette, bookmarks, workspaces, and keyboard shortcuts.">
-  <meta name="keywords" content="jayjay guide, jj gui guide, jujutsu gui, stacked pull requests, diff edit, rich preview, html default app, notebook diff, sarif diff, review notes, evolog, conflict resolution">
+  <meta name="keywords" content="jayjay guide, jj gui guide, jujutsu gui, repository list, pinned repositories, stacked pull requests, diff edit, rich preview, html default app, notebook diff, sarif diff, review notes, evolog, conflict resolution">
   <meta name="author" content="hewigovens">
   <meta name="theme-color" content="#fbfcfe" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#080b14" media="(prefers-color-scheme: dark)">
@@ -97,6 +97,9 @@
       <ul>
         <li>Open a repository with <code>Cmd+O</code>, the app menu, the Dock recent-repositories menu, or the CLI launcher: <code>jayjay /path/to/repo</code>.</li>
         <li>Open the current terminal directory with <code>jayjay .</code> after installing the bundled CLI launcher.</li>
+        <li>The Repository List separates persistent <strong>Pinned</strong> repositories from shell-local <strong>Recent Repositories</strong>. Use the pin button to keep a repository in the list; clearing Recent does not remove pins. Pins are shared between the SwiftUI and GPUI shells.</li>
+        <li>Click the repository title in an open window to switch repositories. The menu activates an already-open repository without duplicating its window, opens a closed pinned repository in a new window, or returns to the full Repository List.</li>
+        <li>Closing the last repository window returns to the Repository List automatically.</li>
         <li>If you open a folder that is not a jj repository, JayJay shows an onboarding view with a <code>jj git init</code> path.</li>
         <li>JayJay watches the repository and working tree, then refreshes when jj operations or file edits change the repo.</li>
       </ul>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -20,6 +20,7 @@ Anonymous build and OS statistics are enabled by default and can be disabled in 
 
 ## Features
 
+- Repository list: persistent pinned repositories shared between SwiftUI and GPUI, shell-local recent history, and a repository title menu that activates open windows or opens closed pins without duplication
 - DAG graph: lane-based fork/merge rendering, bookmark/conflict/divergent markers, revset filtering
 - Diffs: unified and side-by-side, tree-sitter syntax highlighting, word-level changes, interdiff (compare any two revisions), rich previews for Markdown, SVG, notebooks, CSV/TSV tables, SARIF reports, and binary property lists
 - Diff edit: extract files, hunks, or individual lines into a new change; review files and split with one click

--- a/shell/mac/Resources/JayJayHelpBook/Contents/Resources/English.lproj/topics/open.html
+++ b/shell/mac/Resources/JayJayHelpBook/Contents/Resources/English.lproj/topics/open.html
@@ -2,8 +2,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta name="description" content="Open a Jujutsu repository in JayJay." />
-  <meta name="keywords" content="jayjay, open repository, jj repo, cli, jayjay launcher" />
+  <meta name="description" content="Open, pin, and switch between Jujutsu repositories in JayJay." />
+  <meta name="keywords" content="jayjay, open repository, repository list, pinned repository, recent repository, switch repository, jj repo, cli, jayjay launcher" />
   <title>Open a repository</title>
   <link rel="stylesheet" type="text/css" href="../sty/help.css" />
 </head>
@@ -34,7 +34,10 @@
     <p>Choose <strong>File &gt; Open Repository...</strong> or press <code>Cmd+O</code>, then select a folder that already contains a jj repository.</p>
     <ul>
       <li>After installing the bundled CLI, run <code>jayjay /path/to/repo</code> or <code>jayjay .</code> from a terminal.</li>
-      <li>Recent repositories appear in the welcome window and the Dock menu.</li>
+      <li>The Repository List separates persistent <strong>Pinned</strong> repositories from <strong>Recent Repositories</strong>. Use the pin button to keep a repository in the list; clearing Recent does not remove pins.</li>
+      <li>Click the repository title in an open window to activate another open repository, open a closed pinned repository in a new window, or return to the full Repository List.</li>
+      <li>Closing the last repository window returns to the Repository List automatically.</li>
+      <li>Recent repositories also appear in the Dock menu. Pinned repositories are shared with JayJay's GPUI shell, while each shell keeps its own recent history.</li>
       <li>If the folder is not a jj repository, JayJay offers a <code>jj git init</code> path.</li>
     </ul>
     <div class="shot">


### PR DESCRIPTION
## Summary

- explain the difference between persistent Pinned repositories and shell-local Recent history
- document repository-title switching, existing-window activation, and closed-pin behavior
- keep the web guide, `llms.txt`, and bundled macOS Help Book aligned

## Why

The repository list and title switcher shipped without corresponding user-guide semantics. Users need to know that pins represent persistent projects, clearing Recent preserves pins, pins are shared across SwiftUI and GPUI, and open repository windows are reused instead of duplicated.

## Validation

- `just shell::help`
- `just run` (macOS app build and launch succeeded)
- opened **Help → JayJay Help → Open a repository** in the running debug app and verified the updated content in Tips
- `xmllint --html --noout shell/mac/Resources/JayJayHelpBook/Contents/Resources/English.lproj/topics/open.html`