### PR TITLE
feat: animate pull and push actions

### DIFF
--- a/shell/gpui/assets/icons/arrow-down.svg
+++ b/shell/gpui/assets/icons/arrow-down.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 5v14"/>
+  <path d="m19 12-7 7-7-7"/>
+</svg>

--- a/shell/gpui/assets/icons/arrow-up.svg
+++ b/shell/gpui/assets/icons/arrow-up.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m5 12 7-7 7 7"/>
+  <path d="M12 19V5"/>
+</svg>

--- a/shell/gpui/assets/icons/circle.svg
+++ b/shell/gpui/assets/icons/circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+</svg>

--- a/shell/gpui/src/main.rs
+++ b/shell/gpui/src/main.rs
@@ -12,6 +12,9 @@ use jayjay_gpui::repo::RepoWindow;
 use jayjay_gpui::windows::repo_list::RepoListWindow;
 
 const LUCIDE_FONT: &[u8] = include_bytes!("../assets/fonts/Lucide.ttf");
+const ARROW_DOWN_SVG: &[u8] = include_bytes!("../assets/icons/arrow-down.svg");
+const ARROW_UP_SVG: &[u8] = include_bytes!("../assets/icons/arrow-up.svg");
+const CIRCLE_SVG: &[u8] = include_bytes!("../assets/icons/circle.svg");
 const REFRESH_CW_SVG: &[u8] = include_bytes!("../assets/icons/refresh-cw.svg");
 const LOGO_SVG: &[u8] = include_bytes!("../assets/icons/logo.svg");
 
@@ -20,6 +23,9 @@ struct GpuiAssets;
 impl AssetSource for GpuiAssets {
     fn load(&self, path: &str) -> gpui::Result<Option<Cow<'static, [u8]>>> {
         match path {
+            jayjay_gpui::ui::icons::ARROW_DOWN_SVG => Ok(Some(Cow::Borrowed(ARROW_DOWN_SVG))),
+            jayjay_gpui::ui::icons::ARROW_UP_SVG => Ok(Some(Cow::Borrowed(ARROW_UP_SVG))),
+            jayjay_gpui::ui::icons::CIRCLE_SVG => Ok(Some(Cow::Borrowed(CIRCLE_SVG))),
             jayjay_gpui::ui::icons::REFRESH_CW_SVG => Ok(Some(Cow::Borrowed(REFRESH_CW_SVG))),
             jayjay_gpui::ui::icons::LOGO_SVG => Ok(Some(Cow::Borrowed(LOGO_SVG))),
             _ => Ok(None),

--- a/shell/gpui/src/repo/toolbar/buttons.rs
+++ b/shell/gpui/src/repo/toolbar/buttons.rs
@@ -3,10 +3,11 @@ use std::time::Duration;
 use gpui::{
     Animation, AnimationExt as _, AnyElement, ClickEvent, Context, InteractiveElement, IntoElement,
     MouseButton, MouseDownEvent, ParentElement, SharedString, StatefulInteractiveElement, Styled,
-    Transformation, Window, div, percentage, px, rgb, svg,
+    Transformation, Window, div, percentage, point, px, rgb, svg,
 };
 
 use crate::app::theme::Theme;
+use crate::repo::toolbar::ToolbarActivity;
 use crate::repo::window::RepoWindow;
 use crate::ui::button_group::{self, GroupEdge, group_icon_item, group_item};
 use crate::ui::icons::{self, glyph};
@@ -23,6 +24,36 @@ enum RepoToolAction {
 enum SyncAction {
     FetchOrigin,
     PushDefault,
+}
+
+impl SyncAction {
+    fn icon_path(self) -> &'static str {
+        match self {
+            Self::FetchOrigin => icons::ARROW_DOWN_SVG,
+            Self::PushDefault => icons::ARROW_UP_SVG,
+        }
+    }
+
+    fn id(self) -> &'static str {
+        match self {
+            Self::FetchOrigin => "tb-pull",
+            Self::PushDefault => "tb-push",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::FetchOrigin => "Pull",
+            Self::PushDefault => "Push",
+        }
+    }
+
+    fn direction(self) -> f32 {
+        match self {
+            Self::FetchOrigin => 1.,
+            Self::PushDefault => -1.,
+        }
+    }
 }
 
 pub(super) fn bookmarks_button(
@@ -87,8 +118,7 @@ fn revset_filter_button(
 
 pub(super) fn sync_cluster(
     revset_filter_active: bool,
-    has_wc_changes: bool,
-    is_refreshing: bool,
+    activity: ToolbarActivity,
     t: &Theme,
     cx: &mut Context<RepoWindow>,
 ) -> AnyElement {
@@ -96,21 +126,23 @@ pub(super) fn sync_cluster(
         t,
         vec![
             revset_filter_button(revset_filter_active, GroupEdge::Leading, t, cx),
-            refresh_button(has_wc_changes, is_refreshing, GroupEdge::Inner, t, cx),
-            sync_button(
-                glyph::ARROW_DOWN,
-                "tb-pull",
-                "Pull",
-                SyncAction::FetchOrigin,
+            refresh_button(
+                activity.has_wc_changes,
+                activity.is_refreshing,
                 GroupEdge::Inner,
                 t,
                 cx,
             ),
             sync_button(
-                glyph::ARROW_UP,
-                "tb-push",
-                "Push",
+                SyncAction::FetchOrigin,
+                activity.is_fetching,
+                GroupEdge::Inner,
+                t,
+                cx,
+            ),
+            sync_button(
                 SyncAction::PushDefault,
+                activity.is_pushing,
                 GroupEdge::Trailing,
                 t,
                 cx,
@@ -192,15 +224,15 @@ fn refresh_button(
 }
 
 fn sync_button(
-    glyph_str: &'static str,
-    id: &'static str,
-    label: &'static str,
     action: SyncAction,
+    animating: bool,
     edge: GroupEdge,
     t: &Theme,
     cx: &mut Context<RepoWindow>,
 ) -> AnyElement {
-    group_icon_item(id, glyph_str, label, edge, t)
+    let id = action.id();
+    let label = action.label();
+    group_item(id, label, edge, t)
         .on_click(
             cx.listener(move |view, _ev: &ClickEvent, _w, cx| match action {
                 SyncAction::FetchOrigin => view.git_fetch_origin(cx),
@@ -208,6 +240,64 @@ fn sync_button(
             }),
         )
         .debug_selector(move || format!("toolbar-{label}"))
+        .child(sync_icon(
+            action.icon_path(),
+            id,
+            animating,
+            action.direction(),
+            t,
+        ))
+        .into_any_element()
+}
+
+fn sync_icon(
+    path: &'static str,
+    animation_id: &'static str,
+    animating: bool,
+    direction: f32,
+    t: &Theme,
+) -> AnyElement {
+    let arrow_size = TOOLBAR_ICON_SIZE / 2.;
+    let arrow_inset = (TOOLBAR_ICON_SIZE - arrow_size) / 2.;
+    let circle = svg()
+        .path(icons::CIRCLE_SVG)
+        .w(px(TOOLBAR_ICON_SIZE))
+        .h(px(TOOLBAR_ICON_SIZE))
+        .text_color(rgb(t.fg_dim));
+    let arrow = svg().path(path).size_full().text_color(rgb(t.fg_dim));
+    let arrow = if !animating {
+        arrow.into_any_element()
+    } else {
+        arrow
+            .with_animation(
+                animation_id,
+                Animation::new(Duration::from_millis(700)).repeat(),
+                move |arrow, delta| {
+                    let offset = direction * (-2. + 4. * delta);
+                    let opacity = (delta.min(1. - delta) * 5.).min(1.);
+                    arrow
+                        .opacity(opacity)
+                        .with_transformation(Transformation::translate(point(px(0.), px(offset))))
+                },
+            )
+            .into_any_element()
+    };
+    let arrow = div()
+        .absolute()
+        .top(px(arrow_inset))
+        .left(px(arrow_inset))
+        .w(px(arrow_size))
+        .h(px(arrow_size))
+        .debug_selector(move || format!("sync-arrow-{animation_id}"))
+        .child(arrow);
+    div()
+        .relative()
+        .flex_none()
+        .w(px(TOOLBAR_ICON_SIZE))
+        .h(px(TOOLBAR_ICON_SIZE))
+        .debug_selector(move || format!("sync-icon-{animation_id}"))
+        .child(circle)
+        .child(arrow)
         .into_any_element()
 }
 

--- a/shell/gpui/src/repo/toolbar/mod.rs
+++ b/shell/gpui/src/repo/toolbar/mod.rs
@@ -14,12 +14,18 @@ use crate::ui::primitives::TOOLBAR_BUTTON_HEIGHT;
 
 const TOOLBAR_HEIGHT: f32 = 44.;
 
+pub struct ToolbarActivity {
+    pub has_wc_changes: bool,
+    pub is_refreshing: bool,
+    pub is_fetching: bool,
+    pub is_pushing: bool,
+}
+
 pub fn toolbar(
     repo_path: SharedString,
     bookmark_count: usize,
     revset_filter_visible: bool,
-    has_wc_changes: bool,
-    is_refreshing: bool,
+    activity: ToolbarActivity,
     cx: &mut Context<RepoWindow>,
 ) -> AnyElement {
     let t = theme(cx).clone();
@@ -58,8 +64,7 @@ pub fn toolbar(
         .child(buttons::divider(&t))
         .child(buttons::sync_cluster(
             revset_filter_visible,
-            has_wc_changes,
-            is_refreshing,
+            activity,
             &t,
             cx,
         ))

--- a/shell/gpui/src/repo/window/render/mod.rs
+++ b/shell/gpui/src/repo/window/render/mod.rs
@@ -22,6 +22,7 @@ use crate::app::actions::{
 };
 use crate::app::theme::theme;
 use crate::platform::append_menu_bar;
+use crate::repo::toolbar::ToolbarActivity;
 use crate::ui::app_menu::render_app_menu;
 use crate::ui::context_menu::render_context_menu;
 use crate::windows::command_palette::CommandPalette;
@@ -45,6 +46,8 @@ impl Render for RepoWindow {
             let vm = self.vm.read(cx);
             (vm.loading.wc_changes, vm.loading.refresh_indicator)
         };
+        let is_fetching = self.sync_activity.fetching;
+        let is_pushing = self.sync_activity.pushing;
         let init_error = {
             let vm = self.vm.read(cx);
             if vm.repo.is_none() {
@@ -248,8 +251,12 @@ impl Render for RepoWindow {
                 repo_path,
                 bookmark_count,
                 self.revset_filter_visible(),
-                has_wc_changes,
-                is_refreshing,
+                ToolbarActivity {
+                    has_wc_changes,
+                    is_refreshing,
+                    is_fetching,
+                    is_pushing,
+                },
                 cx,
             ))
             .child(content)

--- a/shell/gpui/src/repo/window/sync.rs
+++ b/shell/gpui/src/repo/window/sync.rs
@@ -7,10 +7,23 @@ use super::RepoWindow;
 
 impl RepoWindow {
     pub fn git_fetch_origin(&mut self, cx: &mut Context<Self>) {
+        if self.sync_activity.fetching {
+            return;
+        }
+        self.sync_activity.fetching = true;
+        cx.notify();
         let task = self.vm.update(cx, |vm, cx| vm.git_fetch_origin(cx));
-        Self::spawn_ok(cx, task, |view, result, cx| {
-            view.show_toast(fetch_status_message(&result), cx);
-        });
+        Self::spawn_update(
+            cx,
+            |_| task,
+            |view, result, cx| {
+                view.sync_activity.fetching = false;
+                if let Ok(result) = result {
+                    view.show_toast(fetch_status_message(&result), cx);
+                }
+                cx.notify();
+            },
+        );
     }
 
     pub fn git_push_default(&mut self, cx: &mut Context<Self>) {
@@ -81,12 +94,25 @@ impl RepoWindow {
     }
 
     pub(super) fn git_push_bookmark(&mut self, bookmark: String, cx: &mut Context<Self>) {
+        if self.sync_activity.pushing {
+            return;
+        }
+        self.sync_activity.pushing = true;
+        cx.notify();
         let task = self
             .vm
             .update(cx, |vm, cx| vm.push_bookmark(bookmark.clone(), cx));
-        Self::spawn_ok(cx, task, move |view, message, cx| {
-            view.show_toast(push_status_message(&bookmark, &message), cx);
-        });
+        Self::spawn_update(
+            cx,
+            |_| task,
+            move |view, result, cx| {
+                view.sync_activity.pushing = false;
+                if let Ok(message) = result {
+                    view.show_toast(push_status_message(&bookmark, &message), cx);
+                }
+                cx.notify();
+            },
+        );
     }
 
     fn spawn_ok<T, E, Fut>(

--- a/shell/gpui/src/repo/window/view.rs
+++ b/shell/gpui/src/repo/window/view.rs
@@ -39,6 +39,7 @@ pub struct RepoWindow {
     pub(crate) diff_edit: DiffEditState,
     pub(crate) scrolls: ScrollHandles,
     pub(crate) feedback: FeedbackState,
+    pub(crate) sync_activity: SyncActivity,
     pub(crate) collapsed_dirs: std::collections::HashSet<String>,
     pub(crate) file_tree_cache: FileTreeCacheSlot,
     pub(crate) app_menu: Option<AppMenuState>,
@@ -55,6 +56,12 @@ pub struct RepoWindow {
     /// True once the watcher's start preconditions are met (repo open + `.jj`), even when the real OS watcher is suppressed under test; lets tests assert the decision.
     pub(crate) fs_watcher_armed: bool,
     pub(crate) review_store: super::review::SharedReviewStore,
+}
+
+#[derive(Default)]
+pub(crate) struct SyncActivity {
+    pub(crate) fetching: bool,
+    pub(crate) pushing: bool,
 }
 
 #[derive(Default)]
@@ -288,6 +295,7 @@ impl RepoWindow {
             diff_edit: DiffEditState::default(),
             scrolls: ScrollHandles::default(),
             feedback: FeedbackState::default(),
+            sync_activity: SyncActivity::default(),
             collapsed_dirs: std::collections::HashSet::new(),
             file_tree_cache: Rc::new(RefCell::new(FileTreeCache::default())),
             app_menu: None,

--- a/shell/gpui/src/ui/icons.rs
+++ b/shell/gpui/src/ui/icons.rs
@@ -7,6 +7,9 @@
 use gpui::{Div, ParentElement, SharedString, Styled, div, px, rgb};
 
 pub const FONT: &str = "lucide";
+pub const ARROW_DOWN_SVG: &str = "icons/arrow-down.svg";
+pub const ARROW_UP_SVG: &str = "icons/arrow-up.svg";
+pub const CIRCLE_SVG: &str = "icons/circle.svg";
 pub const REFRESH_CW_SVG: &str = "icons/refresh-cw.svg";
 pub const LOGO_SVG: &str = "icons/logo.svg";
 

--- a/shell/gpui/tests/repo_revset_filter.rs
+++ b/shell/gpui/tests/repo_revset_filter.rs
@@ -7,6 +7,28 @@ use jj_test::LinearFixture;
 use support::{install_test_globals, settle, settle_visual, suppress_fs_watcher};
 
 #[gpui::test]
+fn toolbar_sync_arrows_are_centered_in_their_circles(cx: &mut TestAppContext) {
+    let fixture = LinearFixture::build();
+    install_test_globals(cx);
+    let (_, cx) = cx.add_window_view(|_, cx| RepoWindow::new(fixture.path.clone(), cx));
+    let cx: &mut VisualTestContext = cx;
+    settle_visual(cx);
+
+    for (action, icon_selector, arrow_selector) in [
+        ("tb-pull", "sync-icon-tb-pull", "sync-arrow-tb-pull"),
+        ("tb-push", "sync-icon-tb-push", "sync-arrow-tb-push"),
+    ] {
+        let icon = cx.debug_bounds(icon_selector).expect("sync icon bounds");
+        let arrow = cx.debug_bounds(arrow_selector).expect("sync arrow bounds");
+        assert_eq!(
+            arrow.center(),
+            icon.center(),
+            "{action} arrow should be centered in its fixed circle"
+        );
+    }
+}
+
+#[gpui::test]
 fn toolbar_revset_filter_applies_custom_input_and_resets(cx: &mut TestAppContext) {
     let fixture = LinearFixture::build();
     install_test_globals(cx);

--- a/shell/mac/Sources/JayJay/Diff/ReviewNoteSheet.swift
+++ b/shell/mac/Sources/JayJay/Diff/ReviewNoteSheet.swift
@@ -33,6 +33,7 @@ struct ReviewNoteSheet: View {
     let onSave: (String) -> Void
 
     @State private var bodyText: String
+    @FocusState private var isBodyFocused: Bool
 
     init(
         editor: ReviewNoteEditorState,
@@ -63,6 +64,7 @@ struct ReviewNoteSheet: View {
                     .frame(minHeight: 130)
                     .scrollContentBackground(.hidden)
                     .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 6))
+                    .focused($isBodyFocused)
                     .accessibilityIdentifier(AID.ReviewNote.body)
                 HStack {
                     Spacer()
@@ -78,6 +80,7 @@ struct ReviewNoteSheet: View {
                 )
             }
         )
+        .onAppear { isBodyFocused = true }
     }
 
     private var contextPreview: some View {

--- a/shell/mac/Sources/JayJay/Repo/ContentView/RepoContentView+Sidebar.swift
+++ b/shell/mac/Sources/JayJay/Repo/ContentView/RepoContentView+Sidebar.swift
@@ -83,6 +83,7 @@ extension RepoContentView {
             Spacer()
             Button("Push") { viewModel.confirmPendingPush() }
                 .controlSize(.small)
+                .disabled(viewModel.isPushingInFlight)
             Button {
                 viewModel.dismissPendingPush()
             } label: {

--- a/shell/mac/Sources/JayJay/Repo/ContentView/RepoContentView+Toolbar.swift
+++ b/shell/mac/Sources/JayJay/Repo/ContentView/RepoContentView+Toolbar.swift
@@ -27,11 +27,11 @@ extension RepoContentView {
             .keyboardShortcut("r")
             .help(viewModel.hasWorkingCopyChanges ? "Files changed — click to refresh (⌘R)" : "Refresh (⌘R)")
             Button { viewModel.gitFetch() } label: {
-                Label("Pull", systemImage: "arrow.down.circle")
+                SyncArrowIndicator(direction: .pull, animating: viewModel.isPullingInFlight)
             }
             .help("Git Pull (fetch + rebase)")
             Button { viewModel.gitPush(bookmark: "") } label: {
-                Label("Push", systemImage: "arrow.up.circle")
+                SyncArrowIndicator(direction: .push, animating: viewModel.isPushingInFlight)
             }
             .help("Git Push")
         }

--- a/shell/mac/Sources/JayJay/Repo/RefreshSpinner.swift
+++ b/shell/mac/Sources/JayJay/Repo/RefreshSpinner.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct RefreshSpinner: View {
     var animating: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private enum Spin {
         case idle
@@ -20,9 +21,9 @@ struct RefreshSpinner: View {
     }
 
     var body: some View {
-        TimelineView(.animation(paused: isResting)) { context in
+        TimelineView(.animation(paused: isResting || reduceMotion)) { context in
             Label("Refresh", systemImage: "arrow.triangle.2.circlepath")
-                .rotationEffect(.degrees(angle(at: context.date)))
+                .rotationEffect(.degrees(reduceMotion ? 0 : angle(at: context.date)))
         }
         .onChange(of: animating, initial: true) { _, active in
             if active {

--- a/shell/mac/Sources/JayJay/Repo/SyncArrowIndicator.swift
+++ b/shell/mac/Sources/JayJay/Repo/SyncArrowIndicator.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+struct SyncArrowIndicator: View {
+    enum Direction {
+        case pull
+        case push
+
+        var label: String {
+            switch self {
+                case .pull: "Pull"
+                case .push: "Push"
+            }
+        }
+
+        var arrowSystemImage: String {
+            switch self {
+                case .pull: "arrow.down"
+                case .push: "arrow.up"
+            }
+        }
+
+        var sign: CGFloat {
+            switch self {
+                case .pull: 1
+                case .push: -1
+            }
+        }
+    }
+
+    let direction: Direction
+    let animating: Bool
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var startedAt = Date()
+
+    private let duration = 0.7
+
+    var body: some View {
+        TimelineView(.animation(paused: !motionEnabled)) { context in
+            let progress = motionEnabled ? progress(at: context.date) : 0
+            Label {
+                Text(direction.label)
+            } icon: {
+                ZStack {
+                    Image(systemName: "circle")
+                    Image(systemName: direction.arrowSystemImage)
+                        .scaleEffect(0.55)
+                        .offset(y: motionEnabled ? direction.sign * (-2 + 4 * progress) : 0)
+                        .opacity(motionEnabled ? phaseOpacity(progress) : 1)
+                }
+            }
+        }
+        .onChange(of: motionEnabled, initial: true) { _, enabled in
+            if enabled { startedAt = Date() }
+        }
+    }
+
+    private var motionEnabled: Bool {
+        animating && !reduceMotion
+    }
+
+    private func progress(at date: Date) -> CGFloat {
+        CGFloat(date.timeIntervalSince(startedAt).truncatingRemainder(dividingBy: duration) / duration)
+    }
+
+    private func phaseOpacity(_ progress: CGFloat) -> Double {
+        Double(min(min(progress * 5, (1 - progress) * 5), 1))
+    }
+}

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/PendingPushConfirmation.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/PendingPushConfirmation.swift
@@ -1,0 +1,9 @@
+enum PendingPushConfirmation {
+    static func remainingBookmark(
+        afterConfirming bookmark: String?,
+        startPush: (String) -> Bool
+    ) -> String? {
+        guard let bookmark else { return nil }
+        return startPush(bookmark) ? nil : bookmark
+    }
+}

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+BookmarkActions.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+BookmarkActions.swift
@@ -26,9 +26,10 @@ extension RepoViewModel {
     }
 
     func confirmPendingPush() {
-        guard let name = pendingPushBookmark else { return }
-        pendingPushBookmark = nil
-        gitPush(bookmark: name)
+        pendingPushBookmark = PendingPushConfirmation.remainingBookmark(
+            afterConfirming: pendingPushBookmark,
+            startPush: { gitPushIfIdle(bookmark: $0) }
+        )
     }
 
     func dismissPendingPush() {

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+GitActions.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+GitActions.swift
@@ -4,29 +4,26 @@ import JayJayCore
 
 extension RepoViewModel {
     func gitFetch() {
-        lastInternalMutationAt = Date()
-        runRepoTask { repo in
+        performPull { repo in
             try repo.gitFetch(remote: "origin")
-        } onSuccess: { viewModel, result in
-            viewModel.successActionSignal += 1
-            viewModel.handleFetchResult(result)
-            viewModel.refresh(selecting: "@")
         }
     }
 
     func gitPullBookmark(name: String) {
-        lastInternalMutationAt = Date()
-        runRepoTask { repo in
+        performPull { repo in
             try repo.gitPullBookmark(bookmark: name)
-        } onSuccess: { viewModel, result in
-            viewModel.successActionSignal += 1
-            viewModel.handleFetchResult(result)
-            viewModel.refresh(selecting: "@")
         }
     }
 
     func gitPush(bookmark: String = "") {
-        performMessaging { try $0.gitPush(bookmark: bookmark) }
+        _ = gitPushIfIdle(bookmark: bookmark)
+    }
+
+    @discardableResult
+    func gitPushIfIdle(bookmark: String) -> Bool {
+        performPush { repo in
+            try repo.gitPush(bookmark: bookmark)
+        }
     }
 
     func forgetStaleBookmarks() {
@@ -62,5 +59,36 @@ extension RepoViewModel {
             msg += "\nConflicting (may be merged): \(names) — consider abandoning"
         }
         info = msg
+    }
+
+    private func performPull(_ operation: @escaping RepoOperation<FetchResult>) {
+        guard !isPullingInFlight else { return }
+        isPullingInFlight = true
+        lastInternalMutationAt = Date()
+        runRepoTask(operation) { viewModel, result in
+            viewModel.isPullingInFlight = false
+            viewModel.successActionSignal += 1
+            viewModel.handleFetchResult(result)
+            viewModel.refresh(selecting: "@")
+        } onFailure: { viewModel, error in
+            viewModel.isPullingInFlight = false
+            viewModel.present(error: error)
+        }
+    }
+
+    private func performPush(_ operation: @escaping RepoOperation<String>) -> Bool {
+        guard !isPushingInFlight else { return false }
+        isPushingInFlight = true
+        lastInternalMutationAt = Date()
+        runRepoTask(operation) { viewModel, message in
+            viewModel.isPushingInFlight = false
+            viewModel.successActionSignal += 1
+            viewModel.info = message
+            viewModel.refresh(selecting: "@")
+        } onFailure: { viewModel, error in
+            viewModel.isPushingInFlight = false
+            viewModel.present(error: error)
+        }
+        return true
     }
 }

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
@@ -57,6 +57,8 @@ final class RepoViewModel: ChangeActions, DAGActions, BookmarkActions {
     var lastInternalMutationAt: Date?
     /// True while a refresh task is running — gates FS-triggered re-entry.
     var isRefreshingInFlight: Bool = false
+    var isPullingInFlight = false
+    var isPushingInFlight = false
     var includeSubmoduleStatuses: Bool
     var prInfo: PrInfo?
     var prFetchTask: Task<Void, Never>?

--- a/shell/mac/Tests/JayJayTests/PendingPushConfirmationTests.swift
+++ b/shell/mac/Tests/JayJayTests/PendingPushConfirmationTests.swift
@@ -1,0 +1,22 @@
+@testable import JayJay
+import XCTest
+
+final class PendingPushConfirmationTests: XCTestCase {
+    func testRejectedPushPreservesPendingBookmark() {
+        let remaining = PendingPushConfirmation.remainingBookmark(
+            afterConfirming: "main",
+            startPush: { _ in false }
+        )
+
+        XCTAssertEqual(remaining, "main")
+    }
+
+    func testAcceptedPushClearsPendingBookmark() {
+        let remaining = PendingPushConfirmation.remainingBookmark(
+            afterConfirming: "main",
+            startPush: { _ in true }
+        )
+
+        XCTAssertNil(remaining)
+    }
+}

--- a/shell/mac/Tests/JayJayUITests/Scenes/ReviewNotesScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/ReviewNotesScene.swift
@@ -25,6 +25,12 @@ final class ReviewNotesScene: SceneBase {
 
         let body = app.textViews[AID.ReviewNote.body]
         XCTAssertTrue(body.waitForExistence(timeout: 5), "Review note editor did not appear")
+        paste("Check this added line\nreview the loop below")
+        XCTAssertEqual(
+            body.value as? String,
+            "Check this added line\nreview the loop below",
+            "Review note editor was not focused when it opened"
+        )
 
         NSPasteboard.general.clearContents()
         let contextCode = app.textViews[AID.ReviewNote.contextCode]
@@ -41,10 +47,6 @@ final class ReviewNotesScene: SceneBase {
             ].joined(separator: "\n"),
             "Review note header did not select the full context"
         )
-
-        body.click()
-        paste("Check this added line\nreview the loop below")
-
         let addNote = app.buttons["Add Note"]
         XCTAssertTrue(addNote.waitForExistence(timeout: 3), "\"Add Note\" button missing")
         addNote.click()


### PR DESCRIPTION
## Summary

- animate Pull and Push while their operations are in flight in both SwiftUI and GPUI
- keep the outer circle fixed while only the centered inner arrow moves in the transfer direction
- prevent duplicate triggers and respect Reduced Motion in the SwiftUI shell
- preserve the tracked-bookmark follow-up when another push is already in flight
- register the new GPUI SVGs with the packaged asset loader
- focus the review-note editor immediately when opened from the diff gutter

## Validation

- `just build`
- `just lint`
- `just test-app` — 135 tests passed
- `just test-gpui` — full suite passed
- `cargo test -p jayjay-gpui --test repo_revset_filter` — 3 tests passed
- `just shell::ui-test JayJayUITests/ReviewNotesScene/testAddAndResolveReviewNoteFromGutterMarker` — passed