### PR TITLE
test(mac): close the intended repository window

### DIFF
--- a/shell/mac/Tests/JayJayUITests/Scenes/RepoListInitialRepositoryScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/RepoListInitialRepositoryScene.swift
@@ -13,7 +13,19 @@ final class RepoListInitialRepositoryScene: SceneBase {
     func testRepositoryListWorksAfterMainWindowCloses() throws {
         let app = try XCTUnwrap(app)
         let (mainWindow, pinnedWindow) = try openPinnedRepository(in: app)
-        mainWindow.buttons[XCUIIdentifierCloseWindow].click()
+
+        app.menuBars.menuBarItems["Window"].click()
+        let mainWindowMenuItems = app.menuItems.matching(identifier: "simple")
+        XCTAssertTrue(mainWindowMenuItems.firstMatch.waitForExistence(timeout: 3), "Initial repository window menu item missing")
+        let mainWindowMenuItem = try XCTUnwrap(
+            mainWindowMenuItems.allElementsBoundByIndex.first(where: \.isHittable),
+            "Initial repository window menu item was not actionable"
+        )
+        mainWindowMenuItem.click()
+        app.typeKey("w", modifierFlags: .command)
+
+        XCTAssertFalse(mainWindow.waitForExistence(timeout: 3), "Initial repository window did not close")
+        XCTAssertTrue(pinnedWindow.waitForExistence(timeout: 3), "Secondary repository window closed unexpectedly")
         chooseRepositoryList(in: app, from: pinnedWindow)
 
         XCTAssertTrue(


### PR DESCRIPTION
## Summary

- activate the original repository window through AppKit's Window menu before closing it
- assert that the secondary repository window remains open before exercising Repository List
- avoid clicking an obscured background close button that the foreground window can intercept

## Root cause

In [CI run 29670235501](https://github.com/hewigovens/jayjay/actions/runs/29670235501/job/88148138383), both repository windows occupied the same screen frame. XCTest resolved the background window's close button but delivered the click at the foreground window's identical close-button coordinate, closing `simple-formats` instead of `simple`.

## Verification

- focused UI test passed once
- the same UI test passed 3 additional test iterations
- `jj fix`
- `just lint`