### PR TITLE
ci: pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -52,7 +52,7 @@ jobs:
           appstreamcli validate --no-net shell/gpui/linux/dev.hewig.JayJay.metainfo.xml
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@33c9ab3ef95cd57c164d9d6eb1f9a46338538d41 # main
         with:
           extra-conf: |
             experimental-features = nix-command flakes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: stable
           components: clippy, rustfmt
 
       - name: Install jj (for component test fixtures)
@@ -61,7 +62,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
 
       - name: Install tools
         run: brew install just xcodegen xcbeautify swiftlint jj

--- a/.github/workflows/gpui-ci.yml
+++ b/.github/workflows/gpui-ci.yml
@@ -32,8 +32,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
         with:
+          toolchain: stable
           components: clippy
 
       - name: Install Linux deps
@@ -80,7 +81,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
 
       - name: Install jj (for component test fixtures)
         shell: pwsh


### PR DESCRIPTION
## Summary

- pin `DeterminateSystems/nix-installer-action` to the commit proposed by #124
- pin all four remaining `dtolnay/rust-toolchain` uses to a full commit SHA
- preserve the stable toolchain selection with an explicit `toolchain: stable` input

## Why

PR #124 identified one mutable third-party action reference, but the workflow audit found four additional `@stable` references. Pinning every external action prevents an upstream branch or tag move from changing the code executed by CI.

`dtolnay/rust-toolchain` documents that durable full-SHA pins should use a commit from its `master` history, so this uses the current `master` commit rather than the disposable `stable` branch commit.

## Validation

- parsed every workflow YAML file
- audited all workflow `uses:` entries and confirmed every external action now uses a full SHA
- confirmed the repository already has weekly Dependabot updates for GitHub Actions
- confirmed there are no local JayJay review notes