### PR TITLE
fix(mac): close the sole auto-opened repository window cleanly

### DIFF
--- a/shell/mac/Sources/JayJay/App/Window/RepoWindowManager.swift
+++ b/shell/mac/Sources/JayJay/App/Window/RepoWindowManager.swift
@@ -34,8 +34,9 @@ final class RepoWindowManager {
             return
         }
 
+        // On-screen or miniaturized only: a mid-close window is neither, and reactivating it would countermand the close and strand the window; a miniaturized one must still deminiaturize on Dock reopen.
         if let window = NSApp.windows.first(where: {
-            $0.identifier?.rawValue == AppWindows.main
+            $0.identifier?.rawValue == AppWindows.main && ($0.isVisible || $0.isMiniaturized)
         }) {
             isRepoListRequested = false
             showRepoListAction?(false)

--- a/shell/mac/Tests/JayJayUITests/Scenes/RepoListInitialRepositoryScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/RepoListInitialRepositoryScene.swift
@@ -10,6 +10,37 @@ final class RepoListInitialRepositoryScene: SceneBase {
         _ = try openPinnedRepository(in: app)
     }
 
+    func testClosingSoleInitialRepositoryWindowShowsRepoList() throws {
+        let app = try XCTUnwrap(app)
+        XCTAssertEqual(app.windows.count, 1, "JayJay did not start with one repository window")
+
+        let initialWindow = app.windows["simple"]
+        XCTAssertTrue(initialWindow.waitForExistence(timeout: 5), "Initial repository window missing")
+        initialWindow.buttons[XCUIIdentifierCloseWindow].click()
+
+        XCTAssertTrue(
+            app.staticTexts["Recent Repositories"].waitForExistence(timeout: 5),
+            "Closing the sole initial repository window did not show the repository list"
+        )
+        XCTAssertTrue(
+            app.windows["simple"].waitForNonExistence(timeout: 5),
+            "The closed repository window was reactivated as the list instead of a fresh list window replacing it"
+        )
+
+        let simpleRow = app.buttons
+            .matching(NSPredicate(format: "label BEGINSWITH %@", "simple,"))
+            .firstMatch
+        XCTAssertTrue(simpleRow.waitForExistence(timeout: 5), "Recent repository row missing from the list")
+        simpleRow.click()
+
+        let reopened = app.windows["simple"]
+        XCTAssertTrue(reopened.waitForExistence(timeout: 10), "Reopening from the list did not open a repository window")
+        XCTAssertTrue(
+            reopened.toolbars.menuButtons["Switch Repository"].waitForExistence(timeout: 10),
+            "Reopened window is not a functional repository window"
+        )
+    }
+
     func testRepositoryListWorksAfterMainWindowCloses() throws {
         let app = try XCTUnwrap(app)
         let (mainWindow, pinnedWindow) = try openPinnedRepository(in: app)


### PR DESCRIPTION
A Dock or login relaunch renders the last repository inside the single-instance main window. When that was the only window, closing it triggered the show-repository-list path, whose main-window reuse branch matched the very window that was mid-close and reactivated it, countermanding the close and stranding the window in an unclosable state. The workaround was opening a second repository first.

showRepoList now only reuses a main-tagged window that is still visible; the deferred close bookkeeping guarantees the mid-close window is no longer visible by then, so the transition falls through to opening a fresh repository-list window instead. Title-menu and Dock reopen reuse paths are unaffected because their window is visible.

Adds a regression test closing the sole initial repository window in RepoListInitialRepositoryScene.

Note: the new XCUITest could not be executed in this session (screen-locked host blocks UI-automation mode); verify locally with `just shell::ui-test JayJayUITests/RepoListInitialRepositoryScene` plus the manual flow: quit, relaunch from the Dock, close the sole repository window.
