### PR TITLE
feat(mac): add a beta update channel

### DIFF
--- a/UserGuide.md
+++ b/UserGuide.md
@@ -129,6 +129,7 @@ Turn a linear stack of changes into one PR (GitHub) or MR (GitLab) per change, e
 ## Tools and Settings
 
 - Configure appearance, diff behavior, editor, terminal, jj settings, and app metadata in Settings.
+- The update channel dropdown in Settings → About switches between Stable and Beta; the Beta channel receives pre-release builds through the regular update check.
 - Anonymous build and OS statistics are enabled by default and can be disabled in Settings. JayJay sends no repository, file, or command data, and rotating identifiers cannot link an installation across months.
 - JayJay checks for jj availability and detects supported AI providers.
 - Pick a font family and adjust zoom with `Cmd++`, `Cmd+-`, and `Cmd+0`.

--- a/agents/release.md
+++ b/agents/release.md
@@ -14,6 +14,12 @@ Releases are not complete after `just release`. The full release flow is:
 8. Push `main` only after `just shell::publish` succeeds, so `docs/appcast.xml` never points at a missing or draft-only asset.
 9. Commit and push the Homebrew tap change in `../tap`.
 
+## Beta Releases
+
+Beta versions use the `<X.Y.Z>-beta.<N>` scheme with a monotonic build number; the stable release that follows must use a higher build number (the appcast script enforces this). The suffix exists only in release artifacts — the tag, zip, notes file, appcast item title, and channel tag. The installed app carries the base `X.Y.Z` in `MARKETING_VERSION` and the Cargo version, so beta builds report plain versions to telemetry and need no worker or D1 changes; identify a beta cohort by its build number.
+
+`just set-version 0.3.16-beta.1 50` writes the split automatically, `just release` tags the appcast item with `<sparkle:channel>beta</sparkle:channel>` (invisible to clients that have not selected the Beta update channel in Settings > About), and `just shell::publish` marks the GitHub release as a pre-release and skips the Homebrew cask. Betas still require `releases/<version>.html` notes and the full notarization flow. Promote by cutting the plain stable version with the next build number; do not edit a published beta's appcast entry in place.
+
 The Cloudflare worker is independent of Sparkle: `docs/appcast.xml` remains the direct update source, while enabled anonymous statistics use `/ping`. `/appcast.xml` remains only for compatibility with older releases, whose payloads the worker must continue to accept. If a release changes `infra/worker`, the worker name, the telemetry payload, or any `workers.dev` endpoint, apply pending D1 migrations before deploying the worker, then verify both routes:
 
 ```bash

--- a/agents/storage.md
+++ b/agents/storage.md
@@ -17,9 +17,9 @@ Rust stores resolve platform-native directories through `directories::ProjectDir
 | --- | --- | --- | --- |
 | Pinned repositories | `jayjay-core`; SwiftUI via UniFFI; GPUI directly | `repositories.json` in the shared config directory | An ordered `repositories` array of canonical absolute UTF-8 repository paths. New pins are inserted first; empty paths and exact duplicates are removed on load. |
 | Review marks and notes | `jayjay-review`; SwiftUI via UniFFI; GPUI and CLI directly | `review_store.json` in the shared config directory | File/hunk review marks keyed by `change_id|path`, content identities, and local review notes including path, side, line, anchor context, body, timestamps, and resolution state. |
-| SwiftUI settings and history | SwiftUI-only `AppSettings` | `UserDefaults` for bundle `dev.hewig.jayjay` | Appearance and font, diff options, layout, confirmations, onboarding, editor/terminal choices, sponsorship state, up to 12 recent repositories, and the last opened repository. |
+| SwiftUI settings and history | SwiftUI-only `AppSettings` | `UserDefaults` for bundle `dev.hewig.jayjay` | Appearance and font, diff options, layout, confirmations, onboarding, editor/terminal choices, update channel, sponsorship state, up to 12 recent repositories, and the last opened repository. |
 | SwiftUI auxiliary state | SwiftUI components | The same `UserDefaults` domain | Command-palette position. A legacy `jayjay.reviewedFiles` blob is imported once into the shared review store and then removed. |
-| GPUI settings and history | GPUI-only Rust `AppConfig` | `config.toml` in the platform config directory | Appearance and font, diff options, layout, tools, feature confirmations, onboarding, window bounds/maximized state, and up to 12 recent repositories. |
+| GPUI settings and history | GPUI-only Rust `AppConfig` | `config.toml` in the platform config directory | Appearance and font, diff options, layout, tools, feature confirmations, onboarding, update channel, window bounds/maximized state, and up to 12 recent repositories. |
 
 Recent repositories are history, not projects. Each shell owns its own recent list. Pins are persistent projects and are intentionally shared by both shells.
 

--- a/crates/jayjay-primitives/src/lib.rs
+++ b/crates/jayjay-primitives/src/lib.rs
@@ -9,6 +9,7 @@ mod ops;
 mod review;
 mod stacked_pr;
 mod time;
+mod update_channel;
 
 pub use bookmark::*;
 pub use change::*;
@@ -21,3 +22,4 @@ pub use ops::*;
 pub use review::*;
 pub use stacked_pr::*;
 pub use time::*;
+pub use update_channel::*;

--- a/crates/jayjay-primitives/src/update_channel.rs
+++ b/crates/jayjay-primitives/src/update_channel.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum UpdateChannel {
+    #[default]
+    Stable,
+    Beta,
+}
+
+impl UpdateChannel {
+    pub fn identifier(self) -> &'static str {
+        match self {
+            Self::Stable => "stable",
+            Self::Beta => "beta",
+        }
+    }
+
+    /// Unknown values fall back to Stable so nothing opts into betas by accident.
+    pub fn parse(value: &str) -> Self {
+        if value == "beta" { Self::Beta } else { Self::Stable }
+    }
+}

--- a/crates/jayjay-uniffi/src/types/mod.rs
+++ b/crates/jayjay-uniffi/src/types/mod.rs
@@ -2,6 +2,7 @@ mod changes;
 mod diff;
 mod repo;
 mod review;
+mod settings;
 mod stacked_pr;
 mod theme;
 
@@ -9,5 +10,6 @@ pub use changes::*;
 pub use diff::*;
 pub use repo::*;
 pub use review::*;
+pub use settings::*;
 pub use stacked_pr::*;
 pub use theme::*;

--- a/crates/jayjay-uniffi/src/types/settings.rs
+++ b/crates/jayjay-uniffi/src/types/settings.rs
@@ -1,0 +1,17 @@
+use jayjay_core::UpdateChannel;
+
+#[uniffi::remote(Enum)]
+pub enum UpdateChannel {
+    Stable,
+    Beta,
+}
+
+#[uniffi::export]
+fn parse_update_channel(value: String) -> UpdateChannel {
+    UpdateChannel::parse(&value)
+}
+
+#[uniffi::export]
+fn update_channel_identifier(channel: UpdateChannel) -> String {
+    channel.identifier().to_owned()
+}

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -329,6 +329,7 @@
       <h2>Tools &amp; Settings <a href="#settings">#</a></h2>
       <ul>
         <li>Configure appearance, diff behavior, editor, terminal, jj settings, and app metadata in Settings. JayJay checks for jj availability and detects supported AI providers.</li>
+        <li>The update channel dropdown in Settings &rarr; About switches between Stable and Beta; the Beta channel receives pre-release builds through the regular update check.</li>
         <li>Anonymous build and OS statistics are enabled by default and can be disabled in Settings. No repository, file, or command data is sent, and rotating identifiers cannot link an installation across months.</li>
         <li>Pick a font family and adjust zoom with <code>Cmd++</code>, <code>Cmd+-</code>, and <code>Cmd+0</code>.</li>
         <li>Open files in external editors such as VS Code, VSCodium, Cursor, Zed, Xcode, or Vim. Cursor launches with <code>--classic</code> so it opens in editor mode rather than its agent window.</li>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -4,7 +4,7 @@
 
 JayJay is a desktop client for [Jujutsu (jj)](https://github.com/jj-vcs/jj), the version control system that reimagines the git model with mutable history, changes instead of commits, and bookmarks instead of branches. It runs on macOS 26 or later, is free and source-available, and wraps `jj-lib` directly rather than scraping the CLI. A GPUI shell built on Zed's framework is in alpha, shares the same Rust core, and currently targets feature parity on Linux; its macOS build is for development.
 
-Anonymous build and OS statistics are enabled by default and can be disabled in Settings. JayJay sends no repository, file, or command data; rotating identifiers cannot link an installation across months.
+Beta updates are opt-in via the Beta update channel in Settings. Anonymous build and OS statistics are enabled by default and can be disabled in Settings. JayJay sends no repository, file, or command data; rotating identifiers cannot link an installation across months.
 
 ## Key links
 

--- a/scripts/build-help-book.sh
+++ b/scripts/build-help-book.sh
@@ -14,6 +14,7 @@ help_book_css="$root/docs/help-book.css"
 help_js="$root/docs/help.js"
 feature_index="$project/Resources/HelpFeatures.json"
 app_version="$(awk -F'"' '/^version :=/ { print $2; exit }' "$root/shell/justfile")"
+app_version="${app_version%%-beta.*}"
 app_build="$(awk -F'"' '/^build_number :=/ { print $2; exit }' "$root/shell/justfile")"
 
 if ! command -v sips >/dev/null 2>&1; then

--- a/scripts/update-appcast.py
+++ b/scripts/update-appcast.py
@@ -10,7 +10,7 @@ import re
 from datetime import datetime, timezone
 
 if len(sys.argv) < 6:
-    print("Usage: update-appcast.py <version> <build_number> <app_name> <zip_path> <appcast_path> [signature]")
+    print("Usage: update-appcast.py <version> <build_number> <app_name> <zip_path> <appcast_path> [signature] [channel]")
     sys.exit(1)
 
 version = sys.argv[1]
@@ -19,6 +19,7 @@ app_name = sys.argv[3]
 zip_path = sys.argv[4]
 appcast_path = sys.argv[5]
 signature = sys.argv[6] if len(sys.argv) > 6 else "PENDING"
+channel = sys.argv[7] if len(sys.argv) > 7 else "stable"
 
 # macOS deployment target — gate Sparkle so clients on older macOS aren't offered
 # an update they can't launch. Keep in sync with shell/mac/project.yml.
@@ -60,10 +61,13 @@ description_block = f"""            <description><![CDATA[
             ]]></description>
 """
 
+channel_line = "            <sparkle:channel>beta</sparkle:channel>\n" if channel == "beta" else ""
+short_version = version.split("-")[0]
+
 new_item = f"""        <item>
             <title>Version {version}</title>
-            <sparkle:version>{build_number}</sparkle:version>
-            <sparkle:shortVersionString>{version}</sparkle:shortVersionString>
+{channel_line}            <sparkle:version>{build_number}</sparkle:version>
+            <sparkle:shortVersionString>{short_version}</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>{MINIMUM_SYSTEM_VERSION}</sparkle:minimumSystemVersion>
             <pubDate>{pub_date}</pubDate>
 {description_block}            <enclosure url="https://github.com/hewigovens/jayjay/releases/download/v{version}/{app_name}-{version}.zip"
@@ -83,6 +87,15 @@ if os.path.exists(appcast_path) and os.path.getsize(appcast_path) > 0:
         re.MULTILINE | re.DOTALL,
     )
     content = pattern.sub("", content)
+
+    # Sparkle only offers strictly greater sparkle:version values; a reused build number would strand earlier installs (beta testers most of all) with no upgrade path.
+    existing_builds = [int(b) for b in re.findall(r"<sparkle:version>(\d+)</sparkle:version>", content)]
+    if existing_builds and int(build_number) <= max(existing_builds):
+        print(
+            f"ERROR: build {build_number} must exceed every published sparkle:version (highest is {max(existing_builds)})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     # Prepend the new entry right after the channel header without consuming the next item's indentation.
     if "</language>" in content:

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -7,25 +7,32 @@ justfile="$root/shell/justfile"
 workspace_cargo="$root/Cargo.toml"
 projyml="$root/shell/mac/project.yml"
 
-# file | line prefix | version|build | label
+# base fields carry X.Y.Z without any -beta.N suffix: installed builds and their pings never see it.
+# file | line prefix | version|base|build | label
 fields=(
   "$justfile|^version := |version|justfile version"
   "$justfile|^build_number := |build|justfile build_number"
-  "$workspace_cargo|^version = |version|Cargo workspace version"
-  "$projyml|MARKETING_VERSION: |version|project.yml marketing"
+  "$workspace_cargo|^version = |base|Cargo workspace version"
+  "$projyml|MARKETING_VERSION: |base|project.yml marketing"
   "$projyml|CURRENT_PROJECT_VERSION: |build|project.yml build"
 )
 
 # Read/replace the version-or-build number on the matching line, leaving any quotes intact.
-read_field() { grep -m1 "$2" "$1" | grep -oE '[0-9][0-9.]*' | head -1; }
-write_field() { sed -i '' -E "s|($2[^0-9]*)[0-9][0-9.]*|\\1$3|" "$1"; }
-want() { [ "$1" = build ] && printf %s "$build" || printf %s "$version"; }
+read_field() { grep -m1 "$2" "$1" | grep -oE '[0-9][0-9.]*(-beta\.[0-9]+)?' | head -1; }
+write_field() { sed -i '' -E "s|($2[^0-9]*)[0-9][0-9.]*(-beta\.[0-9]+)?|\\1$3|" "$1"; }
+want() {
+  case "$1" in
+    build) printf %s "$build" ;;
+    base) printf %s "${version%%-beta.*}" ;;
+    *) printf %s "$version" ;;
+  esac
+}
 
 cmd="${1:-}" version="${2:-}" build="${3:-}"
 
 case "$cmd" in
   set)
-    [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ && "$build" =~ ^[0-9]+$ ]] || { echo "usage: version.sh set <X.Y.Z> <build>" >&2; exit 2; }
+    [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$ && "$build" =~ ^[0-9]+$ ]] || { echo "usage: version.sh set <X.Y.Z[-beta.N]> <build>" >&2; exit 2; }
     for f in "${fields[@]}"; do
       IFS='|' read -r file prefix which _ <<<"$f"
       write_field "$file" "$prefix" "$(want "$which")"

--- a/shell/gpui/src/app/config/mod.rs
+++ b/shell/gpui/src/app/config/mod.rs
@@ -14,6 +14,7 @@ pub mod window;
 
 use std::path::{Path, PathBuf};
 
+use jayjay_core::UpdateChannel;
 use serde::{Deserialize, Serialize};
 
 pub use appearance::AppearanceMode;
@@ -38,6 +39,7 @@ pub struct AppConfig {
     pub(crate) features: FeaturesConfig,
     pub onboarding: OnboardingConfig,
     pub telemetry: TelemetryConfig,
+    pub update_channel: UpdateChannel,
     pub window: WindowState,
     pub recent_repos: Vec<String>,
 }
@@ -54,6 +56,7 @@ impl Default for AppConfig {
             features: FeaturesConfig::default(),
             onboarding: OnboardingConfig::default(),
             telemetry: TelemetryConfig::default(),
+            update_channel: UpdateChannel::Stable,
             window: WindowState::default(),
             recent_repos: Vec::new(),
         }

--- a/shell/mac/Resources/JayJayHelpBook/Contents/Resources/English.lproj/topics/settings.html
+++ b/shell/mac/Resources/JayJayHelpBook/Contents/Resources/English.lproj/topics/settings.html
@@ -36,6 +36,7 @@
       <li>Adjust zoom with <code>Cmd++</code>, <code>Cmd+-</code>, and <code>Cmd+0</code>.</li>
       <li>Choose external editors such as VS Code, VSCodium, Cursor, Zed, Xcode, or Vim.</li>
       <li>Choose Terminal.app, iTerm2, or Ghostty for repository terminal actions.</li>
+      <li>The update channel dropdown in the About tab switches between Stable and Beta; the Beta channel receives pre-release builds through the regular update check.</li>
       <li>Anonymous build and OS statistics are enabled by default and can be disabled here. JayJay sends no repository, file, or command data, and rotating identifiers cannot link an installation across months.</li>
       <li>Choose <strong>Help &gt; Send Feedback</strong> to email us.</li>
     </ul>

--- a/shell/mac/Sources/JayJay/App/Config/AppSettings.swift
+++ b/shell/mac/Sources/JayJay/App/Config/AppSettings.swift
@@ -5,6 +5,7 @@ import JayJayCore
 final class AppSettings {
     /// UserDefaults key for the anonymous build and OS statistics preference.
     static let sendsAnonymousStatsKey = "jayjay.sendsAnonymousStats"
+    static let updateChannelKey = "jayjay.updateChannel"
 
     private enum StorageKeys {
         static let fontFamily = "jayjay.fontFamily"
@@ -151,6 +152,12 @@ final class AppSettings {
         didSet { defaults.set(sendsAnonymousStats, forKey: Self.sendsAnonymousStatsKey) }
     }
 
+    // MARK: - Updates
+
+    var updateChannel: UpdateChannel {
+        didSet { defaults.set(updateChannelIdentifier(channel: updateChannel), forKey: Self.updateChannelKey) }
+    }
+
     // MARK: - Init
 
     private let defaults: UserDefaults
@@ -185,6 +192,7 @@ final class AppSettings {
         sponsorDismissed = defaults.bool(forKey: StorageKeys.sponsorDismissed)
         sponsorNextPromptCount = max(defaults.integer(forKey: StorageKeys.sponsorNextPromptCount), 5)
         sendsAnonymousStats = defaults.object(forKey: Self.sendsAnonymousStatsKey) as? Bool ?? true
+        updateChannel = parseUpdateChannel(value: defaults.string(forKey: Self.updateChannelKey) ?? "")
     }
 
     // MARK: - Repo helpers

--- a/shell/mac/Sources/JayJay/App/JayJayApp.swift
+++ b/shell/mac/Sources/JayJay/App/JayJayApp.swift
@@ -8,7 +8,7 @@ struct JayJayApp: App {
     @State private var settings = AppSettings()
     @State private var repositoryStore = RepositoryStore()
     @State private var windowManager: RepoWindowManager
-    private let updater = SparkleUpdater()
+    private let updater: SparkleUpdater
 
     init() {
         CommandLineInterface.runAndExitIfNeeded(arguments: CommandLine.arguments)
@@ -16,6 +16,7 @@ struct JayJayApp: App {
         NSWindow.allowsAutomaticWindowTabbing = false
 
         let initialSettings = AppSettings()
+        updater = SparkleUpdater(includesBetaUpdates: { initialSettings.updateChannel == .beta })
         AppTelemetry.maybePing(enabled: initialSettings.sendsAnonymousStats)
         let cliPath = LaunchArguments.repoPath(from: CommandLine.arguments)
         _settings = State(initialValue: initialSettings)

--- a/shell/mac/Sources/JayJay/App/SparkleUpdater.swift
+++ b/shell/mac/Sources/JayJay/App/SparkleUpdater.swift
@@ -1,13 +1,31 @@
 import Sparkle
+import JayJayCore
 import SwiftUI
+
+private final class UpdaterChannelDelegate: NSObject, SPUUpdaterDelegate {
+    let includesBetaUpdates: () -> Bool
+
+    init(includesBetaUpdates: @escaping () -> Bool) {
+        self.includesBetaUpdates = includesBetaUpdates
+    }
+
+    func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+        includesBetaUpdates() ? ["beta"] : []
+    }
+}
 
 final class SparkleUpdater: ObservableObject {
     @Published private(set) var canCheckForUpdates = false
 
     private let controller: SPUStandardUpdaterController
+    private let channelDelegate: UpdaterChannelDelegate
+
     private var canCheckForUpdatesObservation: NSKeyValueObservation?
 
-    init() {
+    init(includesBetaUpdates: @escaping () -> Bool = {
+        parseUpdateChannel(value: UserDefaults.standard.string(forKey: AppSettings.updateChannelKey) ?? "") == .beta
+    }) {
+        channelDelegate = UpdaterChannelDelegate(includesBetaUpdates: includesBetaUpdates)
         // Debug builds must not offer production releases as updates to the development app.
         #if DEBUG
         let startsUpdater = false
@@ -16,7 +34,7 @@ final class SparkleUpdater: ObservableObject {
         #endif
         controller = SPUStandardUpdaterController(
             startingUpdater: startsUpdater,
-            updaterDelegate: nil,
+            updaterDelegate: channelDelegate,
             userDriverDelegate: nil
         )
         canCheckForUpdatesObservation = controller.updater.observe(
@@ -29,6 +47,10 @@ final class SparkleUpdater: ObservableObject {
 
     func checkForUpdates() {
         controller.checkForUpdates(nil)
+    }
+
+    func channelSelectionChanged() {
+        controller.updater.resetUpdateCycle()
     }
 
     var autoChecksEnabled: Bool {

--- a/shell/mac/Sources/JayJay/Settings/AboutView.swift
+++ b/shell/mac/Sources/JayJay/Settings/AboutView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import JayJayCore
 import SwiftUI
 
 struct AboutView: View {
@@ -54,10 +55,7 @@ struct AboutView: View {
             if embedded {
                 Spacer()
                 Grid(alignment: .trailing, horizontalSpacing: 16, verticalSpacing: 8) {
-                    aboutToggleRow("Check for updates automatically", isOn: Binding(
-                        get: { updater.autoChecksEnabled },
-                        set: { updater.autoChecksEnabled = $0 }
-                    ))
+                    updateRow
                     aboutToggleRow("Share anonymous build and OS stats", isOn: Binding(
                         get: { settings.sendsAnonymousStats },
                         set: {
@@ -107,6 +105,36 @@ struct AboutView: View {
             sound.play()
         } else {
             NSSound(named: NSSound.Name("Frog"))?.play()
+        }
+    }
+
+    private var updateRow: some View {
+        GridRow {
+            Text("Check for updates automatically")
+                .gridColumnAlignment(.leading)
+            HStack(spacing: 8) {
+                Picker("Update channel", selection: Binding(
+                    get: { settings.updateChannel },
+                    set: {
+                        settings.updateChannel = $0
+                        updater.channelSelectionChanged()
+                    }
+                )) {
+                    Text("Stable").tag(UpdateChannel.stable)
+                    Text("Beta").tag(UpdateChannel.beta)
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .controlSize(.small)
+                .fixedSize()
+                Toggle("Check for updates automatically", isOn: Binding(
+                    get: { updater.autoChecksEnabled },
+                    set: { updater.autoChecksEnabled = $0 }
+                ))
+                .labelsHidden()
+                .toggleStyle(.switch)
+                .controlSize(.small)
+            }
         }
     }
 

--- a/shell/release.just
+++ b/shell/release.just
@@ -2,6 +2,8 @@
 # Workspace variables (version, app_name, derived_data, release_dir, signing_identity, ...)
 # are inherited from the importing justfile.
 
+channel := if version =~ '-beta\.' { "beta" } else { "stable" }
+
 release: ffi-release help sync-icon
   #!/usr/bin/env bash
   set -euo pipefail
@@ -68,7 +70,7 @@ release: ffi-release help sync-icon
     echo "Error: no Sparkle edSignature in sign_update output: $sign_output" >&2
     exit 1
   fi
-  python3 "{{root}}/scripts/update-appcast.py" "{{version}}" "{{build_number}}" "{{app_name}}" "$zip_path" "{{root}}/docs/appcast.xml" "$sig"
+  python3 "{{root}}/scripts/update-appcast.py" "{{version}}" "{{build_number}}" "{{app_name}}" "$zip_path" "{{root}}/docs/appcast.xml" "$sig" "{{channel}}"
 
   echo
   echo "Local artifacts ready. After committing, push the v{{version}} tag first,"
@@ -78,6 +80,7 @@ release: ffi-release help sync-icon
 # Publish the already-built release: create a public GitHub release, upload the zip, verify it,
 # and bump the Homebrew cask.
 # Run AFTER pushing the v<version> git tag — `--verify-tag` will fail otherwise.
+# Beta versions publish as GitHub pre-releases; update-cask itself skips them.
 publish: create-release upload-release verify-public-release update-cask
 
 # Create or refresh the public GitHub release with the SwiftUI release notes.
@@ -91,11 +94,12 @@ create-release:
     exit 1
   fi
 
+  if [ "{{channel}}" = "beta" ]; then prerelease_flag="--prerelease=true"; else prerelease_flag="--prerelease=false"; fi
   if gh release view "v{{version}}" &>/dev/null; then
-    gh release edit "v{{version}}" --notes-file "$swiftui_notes"
+    gh release edit "v{{version}}" --notes-file "$swiftui_notes" "$prerelease_flag"
     echo "Updated release notes for v{{version}}"
   else
-    gh release create "v{{version}}" --verify-tag --title "v{{version}}" --notes-file "$swiftui_notes"
+    gh release create "v{{version}}" --verify-tag --title "v{{version}}" --notes-file "$swiftui_notes" "$prerelease_flag"
   fi
 
 # Upload the release zip to the GitHub release.
@@ -126,6 +130,10 @@ verify-public-release:
 update-cask:
   #!/usr/bin/env bash
   set -euo pipefail
+  if [ "{{channel}}" = "beta" ]; then
+    echo "Beta release: skipping Homebrew cask update."
+    exit 0
+  fi
   zip_path="{{release_dir}}/{{app_name}}-{{version}}.zip"
   if [ ! -f "$zip_path" ]; then
     echo "Expected archive at $zip_path. Run 'just shell::release' first." >&2


### PR DESCRIPTION
Add an update channel dropdown (Stable / Beta) beside the automatic-check toggle in Settings → About, wired to Sparkle's `allowedChannels`, so pre-releases reach only opted-in users through the regular update check.

- Beta releases use the `X.Y.Z-beta.N` scheme **in release artifacts only** (tag, zip, notes, appcast item title, channel tag): `set-version` writes the full identifier to the justfile and the base `X.Y.Z` to `MARKETING_VERSION` and the Cargo version, so installed builds report plain versions and telemetry needs no worker or schema changes — a beta cohort is identified by its build number.
- The appcast item carries `sparkle:channel` (invisible to clients on the Stable channel) and enforces monotonic build numbers so beta testers are never stranded; `publish` marks the GitHub release as a pre-release and skips the Homebrew cask.
- Switching the channel resets Sparkle's update cycle so it takes effect immediately; the channel read goes through the injected `AppSettings` instance.
- Docs updated together per the help-book rule: user guide, web guide, `llms.txt`, and the bundled Help Book.

https://claude.ai/code/session_0123jhoFdxVNtjpAvQG3Myqc