### PR TITLE
ci: reduce workflow latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,10 @@ jobs:
       - name: Install jj (for component test fixtures)
         run: brew install jj
 
-      - name: Cache cargo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
@@ -57,7 +52,6 @@ jobs:
 
   swift:
     runs-on: macos-26
-    needs: rust
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -69,15 +63,10 @@ jobs:
       - name: Install tools
         run: brew install just xcodegen xcbeautify swiftlint jj
 
-      - name: Cache cargo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Lint Swift
         run: swiftlint lint --config .swiftlint.yml --strict

--- a/.github/workflows/gpui-ci.yml
+++ b/.github/workflows/gpui-ci.yml
@@ -55,21 +55,13 @@ jobs:
           sudo mv /tmp/jj /usr/local/bin/jj
           jj --version
 
-      - name: Cache cargo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-gpui-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-gpui-${{ runner.os }}-
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
-
-      - name: Build jayjay-gpui
-        run: cargo build -p jayjay-gpui
 
       - name: Test
         run: cargo test --workspace
@@ -97,15 +89,10 @@ jobs:
           Add-Content -Path $env:GITHUB_PATH -Value "$env:USERPROFILE\jj-bin"
           & "$env:USERPROFILE\jj-bin\jj.exe" --version
 
-      - name: Cache cargo
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-gpui-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-gpui-${{ runner.os }}-
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build jayjay-gpui
         run: cargo build -p jayjay-gpui


### PR DESCRIPTION
## Summary

- run macOS Rust and Swift checks concurrently
- replace multi-gigabyte whole-target caches with dependency-only Rust caches
- save reusable caches only from `main`
- remove the redundant Linux GPUI build step

## Measured impact

| Workflow | Recent median before | Final measured | Change |
| --- | ---: | ---: | ---: |
| macOS CI critical path | ~26.9m | 11m50s | ~56% faster |
| GPUI critical path | 25.6m | 14m58s | ~42% faster |
| Swift job | 19.2m | 11m15s | ~41% faster |
| Windows job | 25.6m | 14m54s | ~42% faster |

The warm Swift cache restored in 29s and reduced `Build app` from 9m40s cold to 2m04s. The warm Windows cache restored in 45s, reduced the production build from 7m32s to 1m10s, and eliminated the multi-minute post-job cache upload.

The new caches were 1.19GB for Swift and 1.64GB for Windows. A concurrent legacy Windows cache was 6.40GB. The macOS Rust and Linux seed entries were evicted by that legacy cache, so their final jobs were deliberately cold controls; the critical-path result still improved substantially.

- [cold cache-seeding CI](https://github.com/hewigovens/jayjay/actions/runs/32339501740)
- [cold cache-seeding GPUI CI](https://github.com/hewigovens/jayjay/actions/runs/32339501724)
- [final-policy CI](https://github.com/hewigovens/jayjay/actions/runs/32341367817)
- [final-policy GPUI CI](https://github.com/hewigovens/jayjay/actions/runs/32341367869)

## Validation

- `actionlint` 1.7.12
- YAML parsing
- full-SHA action reference scan
- signed upstream `rust-cache` v2.9.2 tag and commit verification
- cold seed and warm final-policy CI runs all passed