### PR TITLE
fix: terminate jj subprocesses when JayJay quits

### DIFF
--- a/crates/jayjay-core/src/jj_command.rs
+++ b/crates/jayjay-core/src/jj_command.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::{CoreError, CoreResult, jj_binary, repo::subprocess_command};
+use crate::{CoreError, CoreResult, Repo, jj_binary, repo::subprocess_command};
 
 /// Palette runs capture stdout/stderr, so an interactive editor would hang
 /// forever. `["false"]` makes editor-requiring commands (`describe`/`commit`/
@@ -45,14 +45,7 @@ impl JjCommand {
     }
 
     pub fn run_in_path(&self, path: &Path) -> CoreResult<JjCommandResult> {
-        let args = self.parse_args().ok_or_else(|| CoreError::Internal {
-            message: "Unclosed quote in jj command.".to_owned(),
-        })?;
-        if args.is_empty() {
-            return Err(CoreError::Internal {
-                message: "No jj command to run.".to_owned(),
-            });
-        }
+        let args = self.validated_args()?;
 
         let output = subprocess_command(&jj_binary())
             .args(NON_INTERACTIVE_ARGS)
@@ -63,19 +56,42 @@ impl JjCommand {
                 message: format!("run jj: {e}"),
             })?;
 
-        let stdout = trim_output(&output.stdout);
-        let stderr = trim_output(&output.stderr);
-        let combined = match (stdout.is_empty(), stderr.is_empty()) {
-            (true, true) => "(no output)".to_owned(),
-            (false, true) => stdout.clone(),
-            (true, false) => stderr.clone(),
-            (false, false) => format!("{stdout}\n{stderr}"),
-        };
+        Ok(command_result(output))
+    }
 
-        Ok(JjCommandResult {
-            output: combined,
-            exit_code: output.status.code().unwrap_or(-1),
-        })
+    pub fn run_in_repo(&self, repo: &Repo) -> CoreResult<JjCommandResult> {
+        let args = self.validated_args()?;
+        let mut command_args = NON_INTERACTIVE_ARGS.to_vec();
+        command_args.extend(args.iter().map(String::as_str));
+        Ok(command_result(repo.run_jj_output(&command_args)?))
+    }
+
+    fn validated_args(&self) -> CoreResult<Vec<String>> {
+        let args = self.parse_args().ok_or_else(|| CoreError::Internal {
+            message: "Unclosed quote in jj command.".to_owned(),
+        })?;
+        if args.is_empty() {
+            return Err(CoreError::Internal {
+                message: "No jj command to run.".to_owned(),
+            });
+        }
+        Ok(args)
+    }
+}
+
+fn command_result(output: std::process::Output) -> JjCommandResult {
+    let stdout = trim_output(&output.stdout);
+    let stderr = trim_output(&output.stderr);
+    let combined = match (stdout.is_empty(), stderr.is_empty()) {
+        (true, true) => "(no output)".to_owned(),
+        (false, true) => stdout.clone(),
+        (true, false) => stderr.clone(),
+        (false, false) => format!("{stdout}\n{stderr}"),
+    };
+
+    JjCommandResult {
+        output: combined,
+        exit_code: output.status.code().unwrap_or(-1),
     }
 }
 

--- a/crates/jayjay-core/src/repo/command.rs
+++ b/crates/jayjay-core/src/repo/command.rs
@@ -13,11 +13,15 @@ impl Repo {
 
     pub(crate) fn run_jj_output(&self, args: &[&str]) -> CoreResult<Output> {
         let binary = environment::jj_binary();
-        self.command_output(
-            &binary,
-            args,
-            &format!("run jj {}", args.first().unwrap_or(&"")),
-        )
+        let context = format!("run jj {}", args.first().unwrap_or(&""));
+        let mut command = environment::command(&binary);
+        command.current_dir(&self.path).args(args);
+        self.running_jj_processes.output(&mut command, &context)
+    }
+
+    /// Quit-only: refuses new jj processes and terminates the running process groups.
+    pub fn cancel_running_jj_processes(&self) {
+        self.running_jj_processes.cancel();
     }
 
     pub(crate) fn run_jj_reload(&self, args: &[&str]) -> CoreResult<()> {

--- a/crates/jayjay-core/src/repo/command_process.rs
+++ b/crates/jayjay-core/src/repo/command_process.rs
@@ -1,0 +1,90 @@
+#[cfg(unix)]
+mod unix;
+#[cfg(windows)]
+mod windows;
+
+#[cfg(all(test, unix))]
+mod tests;
+
+use std::collections::HashSet;
+use std::process::{Command, Output, Stdio};
+use std::sync::{Arc, Mutex, MutexGuard};
+use std::time::Duration;
+
+#[cfg(unix)]
+use unix::{configure_process_group, terminate_process_group};
+#[cfg(windows)]
+use windows::{configure_process_group, terminate_process_group};
+
+use crate::types::*;
+
+/// A stray `jj git fetch` has survived SIGTERM in the field, so quit escalates to SIGKILL after this grace.
+const TERMINATE_GRACE: Duration = Duration::from_millis(200);
+
+#[derive(Clone, Default)]
+pub(super) struct RunningJjProcesses {
+    state: Arc<Mutex<ProcessState>>,
+}
+
+#[derive(Default)]
+struct ProcessState {
+    closed: bool,
+    pids: HashSet<u32>,
+}
+
+impl RunningJjProcesses {
+    pub(super) fn output(&self, command: &mut Command, context: &str) -> CoreResult<Output> {
+        let internal = |error: std::io::Error| CoreError::Internal {
+            message: format!("{context}: {error}"),
+        };
+        configure_process_group(command);
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+        // Spawn under the lock so no process can slip in between the closed check and the kill sweep.
+        let child = {
+            let mut state = self.state();
+            if state.closed {
+                return Err(CoreError::Internal {
+                    message: format!("{context}: canceled because JayJay is quitting"),
+                });
+            }
+            let child = command.spawn().map_err(internal)?;
+            state.pids.insert(child.id());
+            child
+        };
+        let pid = child.id();
+        let output = child.wait_with_output();
+        self.state().pids.remove(&pid);
+        output.map_err(internal)
+    }
+
+    pub(super) fn cancel(&self) {
+        let pids = {
+            let mut state = self.state();
+            state.closed = true;
+            state.pids.clone()
+        };
+        if pids.is_empty() {
+            return;
+        }
+        for pid in &pids {
+            terminate_process_group(*pid, false);
+        }
+        std::thread::sleep(TERMINATE_GRACE);
+        let state = self.state();
+        for pid in pids.intersection(&state.pids) {
+            terminate_process_group(*pid, true);
+        }
+    }
+
+    fn state(&self) -> MutexGuard<'_, ProcessState> {
+        self.state.lock().unwrap_or_else(|error| error.into_inner())
+    }
+
+    #[cfg(test)]
+    fn running_count(&self) -> usize {
+        self.state().pids.len()
+    }
+}

--- a/crates/jayjay-core/src/repo/command_process/tests.rs
+++ b/crates/jayjay-core/src/repo/command_process/tests.rs
@@ -1,0 +1,46 @@
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::RunningJjProcesses;
+
+#[test]
+fn cancel_terminates_a_process_group_that_ignores_sigterm() {
+    let processes = RunningJjProcesses::default();
+    let worker_processes = processes.clone();
+    let worker = thread::spawn(move || {
+        let mut command = Command::new("/bin/sh");
+        command.args([
+            "-c",
+            "trap '' TERM; /bin/sh -c 'trap \"\" TERM; while :; do sleep 1; done' & wait",
+        ]);
+        worker_processes.output(&mut command, "stubborn command")
+    });
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while processes.running_count() == 0 {
+        assert!(Instant::now() < deadline, "command did not start");
+        thread::sleep(Duration::from_millis(10));
+    }
+
+    let started = Instant::now();
+    processes.cancel();
+    let output = worker
+        .join()
+        .expect("command thread should finish")
+        .expect("wait for killed command");
+
+    assert!(!output.status.success());
+    assert!(started.elapsed() < Duration::from_secs(2));
+    assert_eq!(processes.running_count(), 0);
+}
+
+#[test]
+fn canceled_registry_rejects_new_processes() {
+    let processes = RunningJjProcesses::default();
+    processes.cancel();
+
+    let error = processes
+        .output(&mut Command::new("/usr/bin/true"), "new command")
+        .expect_err("quitting should reject new processes");
+    assert!(format!("{error}").contains("quitting"));
+}

--- a/crates/jayjay-core/src/repo/command_process/unix.rs
+++ b/crates/jayjay-core/src/repo/command_process/unix.rs
@@ -1,0 +1,17 @@
+use std::os::unix::process::CommandExt as _;
+use std::process::Command;
+
+pub(super) fn configure_process_group(command: &mut Command) {
+    command.process_group(0);
+}
+
+pub(super) fn terminate_process_group(pid: u32, force: bool) {
+    let Ok(pid) = i32::try_from(pid) else {
+        return;
+    };
+    let signal = if force { libc::SIGKILL } else { libc::SIGTERM };
+    // SAFETY: a negative PID targets the dedicated process group created for this child.
+    unsafe {
+        libc::kill(-pid, signal);
+    }
+}

--- a/crates/jayjay-core/src/repo/command_process/windows.rs
+++ b/crates/jayjay-core/src/repo/command_process/windows.rs
@@ -1,0 +1,16 @@
+use std::process::{Command, Stdio};
+
+pub(super) fn configure_process_group(_command: &mut Command) {}
+
+pub(super) fn terminate_process_group(pid: u32, force: bool) {
+    let mut command = Command::new("taskkill");
+    command.args(["/PID", &pid.to_string(), "/T"]);
+    if force {
+        command.arg("/F");
+    }
+    let _ = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}

--- a/crates/jayjay-core/src/repo/mod.rs
+++ b/crates/jayjay-core/src/repo/mod.rs
@@ -1,6 +1,7 @@
 mod annotate;
 mod bookmarks;
 mod command;
+mod command_process;
 mod commit_ai;
 mod config;
 mod conflicts;
@@ -69,6 +70,7 @@ use jj_lib::repo_path::RepoPathUiConverter;
 use jj_lib::transaction::Transaction;
 use jj_lib::workspace::Workspace;
 
+use command_process::RunningJjProcesses;
 use config::{default_settings, working_copy_factories};
 use support::{block_on_result, load_repo_at_head, load_workspace_internal, op_is_ancestor_of};
 
@@ -79,6 +81,7 @@ pub struct Repo {
     repo_path: PathBuf,
     workspace_name: jj_lib::ref_name::WorkspaceNameBuf,
     repo: RwLock<Arc<ReadonlyRepo>>,
+    running_jj_processes: RunningJjProcesses,
 }
 
 impl Repo {
@@ -103,6 +106,7 @@ impl Repo {
             repo_path,
             workspace_name: workspace.workspace_name().to_owned(),
             repo: RwLock::new(repo),
+            running_jj_processes: RunningJjProcesses::default(),
         })
     }
 

--- a/crates/jayjay-uniffi/src/repo.rs
+++ b/crates/jayjay-uniffi/src/repo.rs
@@ -305,14 +305,6 @@ fn parse_jj_command_args(command: String) -> Option<Vec<String>> {
     JjCommand::new(command).parse_args()
 }
 
-#[uniffi::export]
-fn run_jj_command_in_repo_path(
-    repo_path: String,
-    command: String,
-) -> Result<JjCommandResult, JayJayError> {
-    Ok(JjCommand::new(command).run_in_path(&PathBuf::from(repo_path))?)
-}
-
 /// Walks the same fallback paths jj does; macOS `.app` bundles get stripped PATH from launchd, so this avoids relying on shell PATH.
 #[uniffi::export]
 fn find_binary(name: String) -> Option<String> {
@@ -383,6 +375,10 @@ impl JayJayRepo {
 
     fn path(&self) -> String {
         self.inner.path().display().to_string()
+    }
+
+    fn run_jj_command(&self, command: String) -> Result<JjCommandResult, JayJayError> {
+        Ok(JjCommand::new(command).run_in_repo(&self.inner)?)
     }
 
     fn refresh_working_copy(&self) -> Result<(), JayJayError> {
@@ -491,6 +487,10 @@ impl JayJayRepo {
 
     fn workspace_name(&self) -> String {
         self.inner.workspace_name().to_owned()
+    }
+
+    fn cancel_running_jj_processes(&self) {
+        self.inner.cancel_running_jj_processes();
     }
 
     fn workspace_forget(

--- a/shell/gpui/src/repo/view_model/mod.rs
+++ b/shell/gpui/src/repo/view_model/mod.rs
@@ -351,6 +351,13 @@ impl RepoViewModel {
     }
 
     pub fn boot(&mut self, cx: &mut Context<Self>) {
+        cx.on_app_quit(|vm, _| {
+            if let Some(repo) = &vm.repo {
+                repo.cancel_running_jj_processes();
+            }
+            async {}
+        })
+        .detach();
         // Snapshot small repos on open so the WC is current; huge checkouts defer (snapshot is slow).
         if self
             .repo

--- a/shell/gpui/src/windows/command_palette/exec.rs
+++ b/shell/gpui/src/windows/command_palette/exec.rs
@@ -1,6 +1,7 @@
-use std::path::PathBuf;
+use std::sync::Arc;
 
 use gpui::Context;
+use jayjay_core::Repo;
 
 use super::state::{CommandOutput, CommandPalette};
 
@@ -25,11 +26,14 @@ impl CommandPalette {
         cx.notify();
         let cwd = self.repo_path.to_string();
         let repo_window = self.repo_window.clone();
+        let repo = repo_window
+            .as_ref()
+            .and_then(|window| window.read(cx).view_model().read(cx).repo.clone());
         let command_for_history = body.clone();
         cx.spawn(async move |this, cx| {
             let result = cx
                 .background_executor()
-                .spawn(async move { execute(body, &cwd, display) })
+                .spawn(async move { execute(body, repo, &cwd, display) })
                 .await;
             let success = result.is_success();
             let _ = this.update(cx, |this, cx| {
@@ -48,8 +52,13 @@ impl CommandPalette {
     }
 }
 
-fn execute(body: String, cwd: &str, display: String) -> CommandOutput {
-    match jayjay_core::JjCommand::new(body).run_in_path(&PathBuf::from(cwd)) {
+fn execute(body: String, repo: Option<Arc<Repo>>, cwd: &str, display: String) -> CommandOutput {
+    let command = jayjay_core::JjCommand::new(body);
+    let result = match &repo {
+        Some(repo) => command.run_in_repo(repo),
+        None => command.run_in_path(std::path::Path::new(cwd)),
+    };
+    match result {
         Ok(result) => CommandOutput::Done {
             display,
             output: result.output,

--- a/shell/mac/Sources/JayJay/App/AppDelegate.swift
+++ b/shell/mac/Sources/JayJay/App/AppDelegate.swift
@@ -6,6 +6,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var openHandler: ((String) -> Void)?
     var showRepoSelector: (() -> Void)?
     var recentReposProvider: (() -> [String])?
+    var prepareForTermination: (() -> Void)?
     var terminateAfterLastWindowClosed = false
     var externalToolInvocation: ExternalToolInvocation?
     private var dockMenuActions: [DockMenuAction] = []
@@ -89,6 +90,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        prepareForTermination?()
         // In a tool session jj interprets our exit status; any exit that is not an explicit save must report the cancel code.
         if let controller = externalToolWindowController {
             Darwin.exit(controller.cancelExitCode)

--- a/shell/mac/Sources/JayJay/App/JayJayApp.swift
+++ b/shell/mac/Sources/JayJay/App/JayJayApp.swift
@@ -39,6 +39,7 @@ struct JayJayApp: App {
         appDelegate.openHandler = { manager.openRepo($0) }
         appDelegate.showRepoSelector = { manager.showRepoList() }
         appDelegate.recentReposProvider = { initialSettings.recentRepos }
+        appDelegate.prepareForTermination = { manager.prepareForTermination() }
     }
 
     var body: some Scene {

--- a/shell/mac/Sources/JayJay/App/Window/RepoWindowManager.swift
+++ b/shell/mac/Sources/JayJay/App/Window/RepoWindowManager.swift
@@ -129,6 +129,11 @@ final class RepoWindowManager {
         }
     }
 
+    func prepareForTermination() {
+        compactRegistrations()
+        registeredRepos.values.compactMap(\.viewModel).forEach { $0.prepareForTermination() }
+    }
+
     func repoWindowDidAppear() {
         hideRepoList()
         refreshOpenRepoPaths()

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel+AsyncSupport.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel+AsyncSupport.swift
@@ -160,9 +160,8 @@ extension RepoViewModel {
 
     @MainActor
     func runJjCommand(_ command: String) async throws -> JjCommandResult {
-        let path = repoPath
-        return try await awaitRepoTask { _ in
-            try runJjCommandInRepoPath(repoPath: path, command: command)
+        try await awaitRepoTask { repo in
+            try repo.runJjCommand(command: command)
         }
     }
 }

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
@@ -125,6 +125,12 @@ final class RepoViewModel: ChangeActions, DAGActions, BookmarkActions {
     }
 
     @MainActor
+    func prepareForTermination() {
+        beginShutdown()
+        repo.cancelRunningJjProcesses()
+    }
+
+    @MainActor
     func prepareForRemoval() async {
         beginShutdown()
         while let task = repoTasks.values.first {

--- a/shell/mac/Tests/JayJayTests/RepoWindowManagerTests.swift
+++ b/shell/mac/Tests/JayJayTests/RepoWindowManagerTests.swift
@@ -201,6 +201,21 @@ final class RepoWindowManagerTests: XCTestCase {
         XCTAssertTrue(completed.isSet)
     }
 
+    func testAppTerminationQuiescesEveryRegisteredRepository() throws {
+        let manager = try makeManager()
+        let first = try makeRepository(named: "app-shutdown-first")
+        let second = try makeRepository(named: "app-shutdown-second")
+        let firstViewModel = try makeViewModel(at: first.0, repo: first.1)
+        let secondViewModel = try makeViewModel(at: second.0, repo: second.1)
+        XCTAssertTrue(manager.register(firstViewModel))
+        XCTAssertTrue(manager.register(secondViewModel))
+
+        manager.prepareForTermination()
+
+        XCTAssertTrue(firstViewModel.isShuttingDown)
+        XCTAssertTrue(secondViewModel.isShuttingDown)
+    }
+
     func testCloseRepoWindowNormalizesRepresentedPathAliases() throws {
         let manager = try makeManager()
         let root = try makeTemporaryDirectory(named: "window-alias")


### PR DESCRIPTION
A `jj git fetch` left behind by a quit app kept holding jj's file locks, so every later jj command hung until the stray process was killed by hand; SIGTERM alone did not stop it.

Each repo handle now tracks its jj children in their own process groups. App quit refuses new ones, signals the running groups with SIGTERM, and escalates to SIGKILL after a short grace. Command palette runs go through the repo handle so they are covered too.