### PR TITLE
fix: keep landed snapshots and let users cancel a fetch or push

### DIFF
--- a/crates/jayjay-core/src/lib.rs
+++ b/crates/jayjay-core/src/lib.rs
@@ -45,12 +45,12 @@ pub(crate) use repo::jj_binary;
 #[cfg(feature = "repository")]
 pub use repo::{
     COMMIT_MESSAGE_PROMPT, DEFAULT_REVSET, DEFAULT_REVSET_DEPTH, Repo, ReviewNoteOutputFormat,
-    ReviewNotesReport, RevsetPreset, add_review_note, build_default_revset, check_gh_environment,
-    check_glab_environment, check_jj_environment, check_origin_environment, detect_ai_provider,
-    find_existing_binary, generate_branch_name_cli, generate_commit_message_cli, home_dir,
-    init_jj_git_repo, is_executable_file, is_valid_bookmark_name, is_valid_workspace_name,
-    login_shell, login_shell_path, resolve_review_note, review_notes_output, revset_presets,
-    workspace_primary_root,
+    ReviewNotesReport, RevsetPreset, SyncToken, add_review_note, build_default_revset,
+    check_gh_environment, check_glab_environment, check_jj_environment, check_origin_environment,
+    detect_ai_provider, find_existing_binary, generate_branch_name_cli,
+    generate_commit_message_cli, home_dir, init_jj_git_repo, is_executable_file,
+    is_valid_bookmark_name, is_valid_workspace_name, login_shell, login_shell_path,
+    resolve_review_note, review_notes_output, revset_presets, workspace_primary_root,
 };
 pub use theme::{DiffThemeColors, change_id_prefix_color, diff_theme_colors};
 #[cfg(feature = "repository")]

--- a/crates/jayjay-core/src/repo/command.rs
+++ b/crates/jayjay-core/src/repo/command.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 use std::process::Output;
 
 use super::Repo;
+use super::command_process::SyncToken;
 use super::environment;
 use crate::types::*;
 
@@ -19,9 +20,13 @@ impl Repo {
         self.running_jj_processes.output(&mut command, &context)
     }
 
+    pub fn sync_token(&self) -> SyncToken {
+        self.running_jj_processes.sync_token()
+    }
+
     /// Quit-only: refuses new jj processes and terminates the running process groups.
     pub fn cancel_running_jj_processes(&self) {
-        self.running_jj_processes.cancel();
+        self.running_jj_processes.close();
     }
 
     pub(crate) fn run_jj_reload(&self, args: &[&str]) -> CoreResult<()> {

--- a/crates/jayjay-core/src/repo/command_process.rs
+++ b/crates/jayjay-core/src/repo/command_process.rs
@@ -6,9 +6,13 @@ mod windows;
 #[cfg(all(test, unix))]
 mod tests;
 
-use std::collections::HashSet;
-use std::process::{Command, Output, Stdio};
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::io::Read;
+use std::process::{Child, ChildStderr, ChildStdout, Command, ExitStatus, Output, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
+use std::thread;
 use std::time::Duration;
 
 #[cfg(unix)]
@@ -18,8 +22,13 @@ use windows::{configure_process_group, terminate_process_group};
 
 use crate::types::*;
 
-/// A stray `jj git fetch` has survived SIGTERM in the field, so quit escalates to SIGKILL after this grace.
+/// A stray `jj git fetch` has survived SIGTERM in the field, so termination escalates to SIGKILL after this grace.
 const TERMINATE_GRACE: Duration = Duration::from_millis(200);
+const REAP_POLL: Duration = Duration::from_millis(10);
+
+thread_local! {
+    static CURRENT_SYNC: RefCell<Option<SyncToken>> = const { RefCell::new(None) };
+}
 
 #[derive(Clone, Default)]
 pub(super) struct RunningJjProcesses {
@@ -29,53 +38,183 @@ pub(super) struct RunningJjProcesses {
 #[derive(Default)]
 struct ProcessState {
     closed: bool,
-    pids: HashSet<u32>,
+    running: HashMap<u32, RunningProcess>,
+}
+
+struct RunningProcess {
+    child: Child,
+    sync: Option<SyncToken>,
+    signaled: bool,
+}
+
+/// Cancellation handle for one fetch or push: the shell creates it before the action starts, and every jj process the action spawns is bound to it.
+#[derive(Clone)]
+pub struct SyncToken {
+    canceled: Arc<AtomicBool>,
+    processes: RunningJjProcesses,
+}
+
+impl SyncToken {
+    /// Returns as soon as the cancel is latched and SIGTERM is sent; the SIGKILL escalation runs in the background.
+    pub fn cancel(&self) {
+        self.canceled.store(true, Ordering::SeqCst);
+        let targets: Vec<u32> = self
+            .processes
+            .state()
+            .running
+            .iter_mut()
+            .filter_map(|(pid, process)| {
+                let mine = process.sync.as_ref().is_some_and(|sync| sync.is(self));
+                // Checked and signaled under the registry lock, so a process that exits on its own cannot be reaped in between and reported as canceled.
+                let live = matches!(process.child.try_wait(), Ok(None));
+                (mine && live).then(|| {
+                    process.signaled = true;
+                    terminate_process_group(*pid, false);
+                    *pid
+                })
+            })
+            .collect();
+        self.processes.escalate(targets, false);
+    }
+
+    pub(crate) fn check(&self) -> CoreResult<()> {
+        if self.is_canceled() {
+            return Err(CoreError::Canceled);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn enter(&self) -> SyncEnter {
+        let previous = CURRENT_SYNC.with(|current| current.replace(Some(self.clone())));
+        SyncEnter { previous }
+    }
+
+    fn is_canceled(&self) -> bool {
+        self.canceled.load(Ordering::SeqCst)
+    }
+
+    fn is(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.canceled, &other.canceled)
+    }
+}
+
+pub(crate) struct SyncEnter {
+    previous: Option<SyncToken>,
+}
+
+impl Drop for SyncEnter {
+    fn drop(&mut self) {
+        let previous = self.previous.take();
+        CURRENT_SYNC.with(|current| *current.borrow_mut() = previous);
+    }
 }
 
 impl RunningJjProcesses {
+    pub(super) fn sync_token(&self) -> SyncToken {
+        SyncToken {
+            canceled: Arc::default(),
+            processes: self.clone(),
+        }
+    }
+
     pub(super) fn output(&self, command: &mut Command, context: &str) -> CoreResult<Output> {
         let internal = |error: std::io::Error| CoreError::Internal {
             message: format!("{context}: {error}"),
         };
+        let sync = CURRENT_SYNC.with(|current| current.borrow().clone());
         configure_process_group(command);
         command
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        // Spawn under the lock so no process can slip in between the closed check and the kill sweep.
-        let child = {
+        // Checked and spawned under the lock so no process can slip in between a cancel or close and its kill sweep.
+        let (pid, stdout, stderr) = {
             let mut state = self.state();
             if state.closed {
                 return Err(CoreError::Internal {
                     message: format!("{context}: canceled because JayJay is quitting"),
                 });
             }
-            let child = command.spawn().map_err(internal)?;
-            state.pids.insert(child.id());
-            child
+            if sync.as_ref().is_some_and(SyncToken::is_canceled) {
+                return Err(CoreError::Canceled);
+            }
+            let mut child = command.spawn().map_err(internal)?;
+            let pid = child.id();
+            let stdout = child.stdout.take();
+            let stderr = child.stderr.take();
+            let process = RunningProcess {
+                child,
+                sync,
+                signaled: false,
+            };
+            state.running.insert(pid, process);
+            (pid, stdout, stderr)
         };
-        let pid = child.id();
-        let output = child.wait_with_output();
-        self.state().pids.remove(&pid);
-        output.map_err(internal)
+        let pipes = read_pipes(stdout, stderr);
+        let (status, signaled) = self.reap(pid).map_err(internal)?;
+        let (stdout, stderr) = pipes.map_err(internal)?;
+        if signaled && !status.success() {
+            return Err(CoreError::Canceled);
+        }
+        Ok(Output {
+            status,
+            stdout,
+            stderr,
+        })
     }
 
-    pub(super) fn cancel(&self) {
-        let pids = {
+    fn reap(&self, pid: u32) -> std::io::Result<(ExitStatus, bool)> {
+        loop {
+            {
+                let mut state = self.state();
+                let Some(process) = state.running.get_mut(&pid) else {
+                    return Err(std::io::Error::other("process left the registry early"));
+                };
+                match process.child.try_wait() {
+                    Ok(Some(status)) => {
+                        let signaled = process.signaled;
+                        state.running.remove(&pid);
+                        return Ok((status, signaled));
+                    }
+                    Ok(None) => {}
+                    Err(error) => {
+                        state.running.remove(&pid);
+                        return Err(error);
+                    }
+                }
+            }
+            thread::sleep(REAP_POLL);
+        }
+    }
+
+    pub(super) fn close(&self) {
+        let targets: Vec<u32> = {
             let mut state = self.state();
             state.closed = true;
-            state.pids.clone()
+            for pid in state.running.keys() {
+                terminate_process_group(*pid, false);
+            }
+            state.running.keys().copied().collect()
         };
+        self.escalate(targets, true);
+    }
+
+    fn escalate(&self, pids: Vec<u32>, wait_for_grace: bool) {
         if pids.is_empty() {
             return;
         }
-        for pid in &pids {
-            terminate_process_group(*pid, false);
-        }
-        std::thread::sleep(TERMINATE_GRACE);
-        let state = self.state();
-        for pid in pids.intersection(&state.pids) {
-            terminate_process_group(*pid, true);
+        let processes = self.clone();
+        let escalate = move || {
+            thread::sleep(TERMINATE_GRACE);
+            let state = processes.state();
+            for pid in pids.iter().filter(|pid| state.running.contains_key(pid)) {
+                terminate_process_group(*pid, true);
+            }
+        };
+        if wait_for_grace {
+            escalate();
+        } else {
+            thread::spawn(escalate);
         }
     }
 
@@ -85,6 +224,26 @@ impl RunningJjProcesses {
 
     #[cfg(test)]
     fn running_count(&self) -> usize {
-        self.state().pids.len()
+        self.state().running.len()
     }
+}
+
+fn read_pipes(
+    stdout: Option<ChildStdout>,
+    stderr: Option<ChildStderr>,
+) -> std::io::Result<(Vec<u8>, Vec<u8>)> {
+    let stderr_reader = thread::spawn(move || read_to_end(stderr));
+    let stdout = read_to_end(stdout)?;
+    let stderr = stderr_reader
+        .join()
+        .map_err(|_| std::io::Error::other("stderr reader panicked"))??;
+    Ok((stdout, stderr))
+}
+
+fn read_to_end(pipe: Option<impl Read>) -> std::io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    if let Some(mut pipe) = pipe {
+        pipe.read_to_end(&mut bytes)?;
+    }
+    Ok(bytes)
 }

--- a/crates/jayjay-core/src/repo/command_process/tests.rs
+++ b/crates/jayjay-core/src/repo/command_process/tests.rs
@@ -2,10 +2,11 @@ use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use super::RunningJjProcesses;
+use super::{RunningJjProcesses, SyncToken};
+use crate::types::*;
 
 #[test]
-fn cancel_terminates_a_process_group_that_ignores_sigterm() {
+fn close_terminates_a_process_group_that_ignores_sigterm() {
     let processes = RunningJjProcesses::default();
     let worker_processes = processes.clone();
     let worker = thread::spawn(move || {
@@ -16,14 +17,10 @@ fn cancel_terminates_a_process_group_that_ignores_sigterm() {
         ]);
         worker_processes.output(&mut command, "stubborn command")
     });
-    let deadline = Instant::now() + Duration::from_secs(2);
-    while processes.running_count() == 0 {
-        assert!(Instant::now() < deadline, "command did not start");
-        thread::sleep(Duration::from_millis(10));
-    }
+    wait_for_running(&processes, 1);
 
     let started = Instant::now();
-    processes.cancel();
+    processes.close();
     let output = worker
         .join()
         .expect("command thread should finish")
@@ -35,12 +32,119 @@ fn cancel_terminates_a_process_group_that_ignores_sigterm() {
 }
 
 #[test]
-fn canceled_registry_rejects_new_processes() {
+fn closed_registry_rejects_new_processes() {
     let processes = RunningJjProcesses::default();
-    processes.cancel();
+    processes.close();
 
-    let error = processes
-        .output(&mut Command::new("/usr/bin/true"), "new command")
-        .expect_err("quitting should reject new processes");
+    let error = run_true(&processes).expect_err("quitting rejects new processes");
     assert!(format!("{error}").contains("quitting"));
+}
+
+#[test]
+fn cancel_targets_only_the_processes_of_its_action() {
+    let processes = RunningJjProcesses::default();
+    let pull = processes.sync_token();
+    let push = processes.sync_token();
+    let pull_worker = spawn_sleeper(&processes, Some(&pull));
+    let push_worker = spawn_sleeper(&processes, Some(&push));
+    let unbound_worker = spawn_sleeper(&processes, None);
+    wait_for_running(&processes, 3);
+
+    pull.cancel();
+
+    let error = pull_worker
+        .join()
+        .expect("pull thread")
+        .expect_err("the pull process should be canceled");
+    assert!(matches!(error, CoreError::Canceled), "{error}");
+    assert_eq!(processes.running_count(), 2);
+    assert!(push.check().is_ok());
+
+    processes.close();
+    push_worker
+        .join()
+        .expect("push thread")
+        .expect("the push process is killed, not canceled");
+    unbound_worker
+        .join()
+        .expect("unbound thread")
+        .expect("a process outside any action is killed, not canceled");
+}
+
+#[test]
+fn a_canceled_action_spawns_nothing_more() {
+    let processes = RunningJjProcesses::default();
+    let sync = processes.sync_token();
+    sync.cancel();
+
+    {
+        let _enter = sync.enter();
+        assert!(matches!(sync.check(), Err(CoreError::Canceled)));
+        let refused = run_true(&processes).expect_err("the action's later processes are refused");
+        assert!(matches!(refused, CoreError::Canceled), "{refused}");
+    }
+    run_true(&processes).expect("processes outside the action are unaffected");
+
+    let next = processes.sync_token();
+    let _enter = next.enter();
+    run_true(&processes).expect("the next action starts clean");
+}
+
+#[test]
+fn a_live_process_is_canceled_even_after_it_printed_to_stderr() {
+    let processes = RunningJjProcesses::default();
+    let sync = processes.sync_token();
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let printed = temp_dir.path().join("printed");
+    let worker_processes = processes.clone();
+    let worker_sync = sync.clone();
+    let worker = thread::spawn(move || {
+        let _enter = worker_sync.enter();
+        let mut command = Command::new("/bin/sh");
+        command.args([
+            "-c",
+            "echo 'remote: banner' >&2; : > \"$0\"; sleep 30",
+            printed.to_str().expect("utf-8 path"),
+        ]);
+        worker_processes.output(&mut command, "chatty command")
+    });
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !temp_dir.path().join("printed").exists() {
+        assert!(Instant::now() < deadline, "process did not print");
+        thread::sleep(Duration::from_millis(5));
+    }
+
+    sync.cancel();
+
+    let error = worker
+        .join()
+        .expect("command thread")
+        .expect_err("a live process reached by the cancel is canceled");
+    assert!(matches!(error, CoreError::Canceled), "{error}");
+}
+
+fn run_true(processes: &RunningJjProcesses) -> CoreResult<std::process::Output> {
+    processes.output(&mut Command::new("/usr/bin/true"), "true")
+}
+
+fn spawn_sleeper(
+    processes: &RunningJjProcesses,
+    sync: Option<&SyncToken>,
+) -> thread::JoinHandle<CoreResult<std::process::Output>> {
+    let processes = processes.clone();
+    let sync = sync.cloned();
+    thread::spawn(move || {
+        let _enter = sync.as_ref().map(SyncToken::enter);
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", "sleep 30"]);
+        processes.output(&mut command, "sleeper")
+    })
+}
+
+fn wait_for_running(processes: &RunningJjProcesses, count: usize) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while processes.running_count() < count {
+        assert!(Instant::now() < deadline, "processes did not start");
+        thread::sleep(Duration::from_millis(10));
+    }
 }

--- a/crates/jayjay-core/src/repo/git/sync.rs
+++ b/crates/jayjay-core/src/repo/git/sync.rs
@@ -1,12 +1,13 @@
 use std::collections::HashSet;
 
-use crate::repo::{DEFAULT_REVSET_DEPTH, Repo};
+use crate::repo::{DEFAULT_REVSET_DEPTH, Repo, SyncToken};
 use crate::types::*;
 
 impl Repo {
     /// Returns a message describing what happened (warnings, errors, or success).
     /// Auto-tracks untracked bookmarks before pushing.
-    pub fn git_push(&self, bookmark: &str) -> CoreResult<String> {
+    pub fn git_push(&self, bookmark: &str, sync: &SyncToken) -> CoreResult<String> {
+        let _enter = sync.enter();
         if bookmark.is_empty() {
             self.run_jj_quiet(&["bookmark", "track", "glob:*"]);
         } else {
@@ -20,6 +21,7 @@ impl Repo {
         let output = self.run_jj_output(&args)?;
         self.ensure_success(&output, "git push failed")?;
         self.reload()?;
+        sync.check()?;
         let result = combine_output(&Self::stdout_text(&output), &Self::stderr_text(&output));
         if result.contains("No bookmarks found") || result.contains("Nothing changed") {
             Ok("Nothing to push — create a bookmark first".to_owned())
@@ -53,23 +55,37 @@ impl Repo {
     }
 
     /// Fetch all remotes, auto-track, rebase, and clean up merged bookmarks.
-    pub fn git_fetch(&self, remote: &str) -> CoreResult<FetchResult> {
-        let tracking_before = self.tracking_bookmark_names();
-        let msg = self.git_fetch_raw(remote, "")?;
-        let _ = self.run_jj_reload(&["bookmark", "track", "glob:*"]);
-        self.rebase_to_trunk();
-        let _ = self.reload();
-        Ok(self.post_fetch_cleanup(msg, &tracking_before))
+    pub fn git_fetch(&self, remote: &str, sync: &SyncToken) -> CoreResult<FetchResult> {
+        self.pull(
+            sync,
+            |repo| repo.git_fetch_raw(remote, ""),
+            &["bookmark", "track", "glob:*"],
+        )
     }
 
     /// Fetch a specific bookmark, auto-track it, rebase, and clean up.
-    pub fn git_pull_bookmark(&self, bookmark: &str) -> CoreResult<FetchResult> {
+    pub fn git_pull_bookmark(&self, bookmark: &str, sync: &SyncToken) -> CoreResult<FetchResult> {
+        self.pull(
+            sync,
+            |repo| repo.git_fetch_raw("", bookmark),
+            &["bookmark", "track", "--remote=origin", "--", bookmark],
+        )
+    }
+
+    fn pull(
+        &self,
+        sync: &SyncToken,
+        fetch: impl FnOnce(&Self) -> CoreResult<String>,
+        track_args: &[&str],
+    ) -> CoreResult<FetchResult> {
+        let _enter = sync.enter();
         let tracking_before = self.tracking_bookmark_names();
-        let msg = self.git_fetch_raw("", bookmark)?;
-        let _ = self.run_jj_reload(&["bookmark", "track", "--remote=origin", "--", bookmark]);
+        let msg = fetch(self)?;
+        let _ = self.run_jj_reload(track_args);
         self.rebase_to_trunk();
         let _ = self.reload();
-        Ok(self.post_fetch_cleanup(msg, &tracking_before))
+        sync.check()?;
+        self.post_fetch_cleanup(msg, &tracking_before, sync)
     }
 
     fn git_fetch_raw(&self, remote: &str, bookmark: &str) -> CoreResult<String> {
@@ -107,7 +123,8 @@ impl Repo {
         &self,
         message: String,
         tracking_before: &HashSet<String>,
-    ) -> FetchResult {
+        sync: &SyncToken,
+    ) -> CoreResult<FetchResult> {
         let graph = self
             .log_graph(&format!(
                 "present(@) | ancestors(immutable_heads().., {DEFAULT_REVSET_DEPTH})"
@@ -138,6 +155,7 @@ impl Repo {
                 continue;
             }
             if c.is_empty {
+                sync.check()?;
                 // 100% safe: empty after rebase = content already in parent
                 self.run_jj_quiet(&["abandon", &c.change_id.id]);
                 abandoned.extend(lost_on_commit);
@@ -147,11 +165,12 @@ impl Repo {
             }
         }
 
-        FetchResult {
+        sync.check()?;
+        Ok(FetchResult {
             message,
             abandoned_bookmarks: abandoned,
             suggest_abandon_bookmarks: suggest_abandon,
-        }
+        })
     }
 }
 

--- a/crates/jayjay-core/src/repo/mod.rs
+++ b/crates/jayjay-core/src/repo/mod.rs
@@ -71,6 +71,7 @@ use jj_lib::transaction::Transaction;
 use jj_lib::workspace::Workspace;
 
 use command_process::RunningJjProcesses;
+pub use command_process::SyncToken;
 use config::{default_settings, working_copy_factories};
 use support::{block_on_result, load_repo_at_head, load_workspace_internal, op_is_ancestor_of};
 

--- a/crates/jayjay-core/src/repo/working_copy.rs
+++ b/crates/jayjay-core/src/repo/working_copy.rs
@@ -1,7 +1,12 @@
+use std::sync::Arc;
+#[cfg(test)]
+use std::sync::Mutex;
+
 use jj_lib::commit::Commit;
 use jj_lib::matchers::{EverythingMatcher, NothingMatcher};
 use jj_lib::repo::{ReadonlyRepo, Repo as _};
 use jj_lib::working_copy::SnapshotOptions;
+use jj_lib::workspace::LockedWorkspace;
 
 use super::Repo;
 use super::support::{block_on_result, load_repo_at_head, load_workspace_internal};
@@ -9,6 +14,11 @@ use super::working_copy_ignore::{WorkingCopyIgnoreMatcher, base_git_ignores};
 use crate::types::*;
 
 const WORKING_COPY_REFRESH_STACK_SIZE: usize = 8 * 1024 * 1024;
+
+#[cfg(test)]
+type LockHook = Box<dyn Fn(&std::path::Path) + Send + Sync>;
+#[cfg(test)]
+static BEFORE_WORKING_COPY_LOCK: Mutex<Option<LockHook>> = Mutex::new(None);
 
 impl Repo {
     pub(crate) fn working_copy_commit(&self, repo: &ReadonlyRepo) -> CoreResult<Commit> {
@@ -67,28 +77,24 @@ impl Repo {
 
     fn refresh_working_copy_inner(&self) -> CoreResult<()> {
         let mut workspace = load_workspace_internal(&self.path, "load workspace for snapshot")?;
-
-        let repo = load_repo_at_head(&workspace, "load repo for snapshot")?;
-
-        let wc_commit_id = repo
-            .view()
-            .get_wc_commit_id(self.workspace_name.as_ref())
-            .ok_or_else(|| CoreError::Internal {
-                message: format!(
-                    "workspace {} has no working-copy commit",
-                    self.workspace_name.as_symbol()
-                ),
-            })?
-            .clone();
-        let wc_commit =
-            repo.store()
-                .get_commit(&wc_commit_id)
-                .map_err(|e| CoreError::Internal {
-                    message: format!("load working-copy commit: {e}"),
-                })?;
-
-        let mut locked_ws =
+        let repo_loader = workspace.repo_loader().clone();
+        #[cfg(test)]
+        if let Some(hook) = BEFORE_WORKING_COPY_LOCK.lock().unwrap().as_ref() {
+            hook(&self.path);
+        }
+        // Lock before loading the head: a snapshot that lands while we wait would otherwise be rewritten from a stale head, forking `@`.
+        let locked_ws =
             block_on_result("lock working copy", workspace.start_working_copy_mutation())?;
+        let repo = block_on_result("load repo for snapshot", repo_loader.load_at_head())?;
+        self.snapshot_locked_working_copy(locked_ws, repo)
+    }
+
+    fn snapshot_locked_working_copy(
+        &self,
+        mut locked_ws: LockedWorkspace<'_>,
+        repo: Arc<ReadonlyRepo>,
+    ) -> CoreResult<()> {
+        let wc_commit = self.working_copy_commit(&repo)?;
 
         let snapshot_options = SnapshotOptions {
             base_ignores: base_git_ignores(&repo, &self.path)?,
@@ -143,5 +149,63 @@ impl Repo {
             .metadata()
             .map(|m| m.len() > LARGE_TREE_STATE_BYTES)
             .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::Duration;
+
+    use jj_test::init_jj_repo;
+
+    use super::super::Repo;
+    use super::super::support::{block_on_result, load_workspace_internal};
+    use super::BEFORE_WORKING_COPY_LOCK;
+
+    #[test]
+    fn refresh_keeps_a_snapshot_that_lands_while_it_waits_for_the_lock() {
+        let temp_dir = init_jj_repo();
+        let repo_path = temp_dir.path().join("repo");
+        let repo = Repo::open(&repo_path).expect("open repo");
+        let mut workspace =
+            load_workspace_internal(&repo_path, "load workspace").expect("load workspace");
+        let repo_loader = workspace.repo_loader().clone();
+        let locked_ws = block_on_result("lock", workspace.start_working_copy_mutation())
+            .expect("hold the working-copy lock");
+        fs::write(repo_path.join("hello.txt"), "edited under the lock\n").expect("edit file");
+        let (reached_lock_tx, reached_lock_rx) = mpsc::channel();
+        let refreshing_path = repo.path().to_owned();
+        *BEFORE_WORKING_COPY_LOCK.lock().unwrap() = Some(Box::new(move |path| {
+            if path == refreshing_path {
+                let _ = reached_lock_tx.send(());
+            }
+        }));
+
+        thread::scope(|scope| {
+            let refresh = scope.spawn(|| repo.refresh_working_copy());
+            reached_lock_rx
+                .recv_timeout(Duration::from_secs(10))
+                .expect("refresh reaches the working-copy lock");
+            let head = block_on_result("load head", repo_loader.load_at_head()).expect("load head");
+            repo.snapshot_locked_working_copy(locked_ws, head)
+                .expect("snapshot under the held lock");
+            refresh
+                .join()
+                .expect("refresh thread")
+                .expect("refresh once the lock is released");
+        });
+
+        *BEFORE_WORKING_COPY_LOCK.lock().unwrap() = None;
+
+        // A refresh that read the head before locking commits a second op head; loading then merges them into an op with two parents.
+        repo.reload().expect("reload");
+        assert_eq!(
+            repo.get_repo().operation().parent_ids().len(),
+            1,
+            "refresh committed against a stale head"
+        );
     }
 }

--- a/crates/jayjay-core/tests/remote_operations.rs
+++ b/crates/jayjay-core/tests/remote_operations.rs
@@ -1,0 +1,59 @@
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use jayjay_core::{CoreError, Repo};
+use jj_test::{init_jj_repo, run_jj_in};
+
+#[test]
+fn canceling_the_sync_token_interrupts_a_fetch() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let git_started = temp_dir.path().join("git-started");
+    let fake_git = temp_dir.path().join("git");
+    fs::write(
+        &fake_git,
+        format!("#!/bin/sh\ntouch '{}'\nsleep 30\n", git_started.display()),
+    )
+    .expect("write fake git");
+    fs::set_permissions(&fake_git, fs::Permissions::from_mode(0o755)).expect("chmod fake git");
+    run_jj_in(
+        &repo_path,
+        &[
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://example.invalid/repo.git",
+        ],
+    );
+    run_jj_in(
+        &repo_path,
+        &[
+            "config",
+            "set",
+            "--repo",
+            "git.executable-path",
+            fake_git.to_str().expect("utf-8 path"),
+        ],
+    );
+    let repo = Repo::open(&repo_path).expect("open repo");
+    let sync = repo.sync_token();
+
+    let outcome = thread::scope(|scope| {
+        let fetch = scope.spawn(|| repo.git_fetch("origin", &sync));
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !git_started.exists() {
+            assert!(Instant::now() < deadline, "fetch never reached git");
+            thread::sleep(Duration::from_millis(20));
+        }
+        sync.cancel();
+        fetch.join().expect("fetch thread")
+    });
+
+    let error = outcome.expect_err("fetch should be canceled");
+    assert!(matches!(error, CoreError::Canceled), "{error}");
+}

--- a/crates/jayjay-primitives/src/error.rs
+++ b/crates/jayjay-primitives/src/error.rs
@@ -16,6 +16,8 @@ pub enum JayJayError {
     FileEditorStale { path: String },
     #[error("{message}")]
     Internal { message: String },
+    #[error("canceled")]
+    Canceled,
 }
 
 impl JayJayError {

--- a/crates/jayjay-uniffi/src/error.rs
+++ b/crates/jayjay-uniffi/src/error.rs
@@ -18,6 +18,8 @@ pub enum JayJayError {
     FileEditorStale { path: String },
     #[error("internal error: {message}")]
     Internal { message: String },
+    #[error("canceled")]
+    Canceled,
 }
 
 impl From<CoreError> for JayJayError {
@@ -31,6 +33,7 @@ impl From<CoreError> for JayJayError {
             CoreError::ConflictEditorStale { path } => Self::ConflictEditorStale { path },
             CoreError::FileEditorStale { path } => Self::FileEditorStale { path },
             CoreError::Internal { message } => Self::Internal { message },
+            CoreError::Canceled => Self::Canceled,
         }
     }
 }

--- a/crates/jayjay-uniffi/src/repo.rs
+++ b/crates/jayjay-uniffi/src/repo.rs
@@ -6,7 +6,7 @@ use jayjay_core::{
     DiffEditDestination, DiffEditFileSelection, DiffHunk, DiffStats, EvologEntry, FetchResult,
     FileDiffStats, FileEditorData, GitSubmoduleStatus, GraphEntry, JjCommand, JjCommandResult,
     OpLogEntry, PrInfo, Repo, ReviewNoteOutputFormat, RevsetPreset, Stack, StackedPrResult,
-    SubmitStackLayer, ToolsConfig, WorkspaceInfo, WorkspacePresence,
+    SubmitStackLayer, SyncToken, ToolsConfig, WorkspaceInfo, WorkspacePresence,
     diff::{self, CollapsedDiff, FileDiff},
 };
 use jayjay_primitives::{NoteAnchor, NoteEntry, NoteSide, ReviewNoteStatus};
@@ -365,6 +365,18 @@ pub struct JayJayRepo {
     inner: Repo,
 }
 
+#[derive(uniffi::Object)]
+pub struct JayJaySyncToken {
+    inner: SyncToken,
+}
+
+#[uniffi::export]
+impl JayJaySyncToken {
+    fn cancel(&self) {
+        self.inner.cancel();
+    }
+}
+
 #[uniffi::export]
 impl JayJayRepo {
     #[uniffi::constructor]
@@ -487,6 +499,12 @@ impl JayJayRepo {
 
     fn workspace_name(&self) -> String {
         self.inner.workspace_name().to_owned()
+    }
+
+    fn sync_token(&self) -> Arc<JayJaySyncToken> {
+        Arc::new(JayJaySyncToken {
+            inner: self.inner.sync_token(),
+        })
     }
 
     fn cancel_running_jj_processes(&self) {
@@ -718,20 +736,32 @@ impl JayJayRepo {
         Ok(self.inner.forget_stale_bookmarks()?)
     }
 
-    fn git_push(&self, bookmark: String) -> Result<String, JayJayError> {
-        Ok(self.inner.git_push(&bookmark)?)
+    fn git_push(
+        &self,
+        bookmark: String,
+        sync: Arc<JayJaySyncToken>,
+    ) -> Result<String, JayJayError> {
+        Ok(self.inner.git_push(&bookmark, &sync.inner)?)
     }
 
     fn remote_web_url(&self) -> Option<String> {
         self.inner.remote_web_url()
     }
 
-    fn git_fetch(&self, remote: String) -> Result<FetchResult, JayJayError> {
-        Ok(self.inner.git_fetch(&remote)?)
+    fn git_fetch(
+        &self,
+        remote: String,
+        sync: Arc<JayJaySyncToken>,
+    ) -> Result<FetchResult, JayJayError> {
+        Ok(self.inner.git_fetch(&remote, &sync.inner)?)
     }
 
-    fn git_pull_bookmark(&self, bookmark: String) -> Result<FetchResult, JayJayError> {
-        Ok(self.inner.git_pull_bookmark(&bookmark)?)
+    fn git_pull_bookmark(
+        &self,
+        bookmark: String,
+        sync: Arc<JayJaySyncToken>,
+    ) -> Result<FetchResult, JayJayError> {
+        Ok(self.inner.git_pull_bookmark(&bookmark, &sync.inner)?)
     }
 
     fn jj_commit(&self, message: String) -> Result<(), JayJayError> {

--- a/scripts/ui-test-fixtures.sh
+++ b/scripts/ui-test-fixtures.sh
@@ -80,6 +80,19 @@ fixture_mutating_scenes() {
   copy_fixture simple file-editor
 }
 
+# Pull stays in flight until canceled: jj's git subprocess is a script that never returns.
+fixture_sync_cancel() {
+  copy_fixture simple sync-cancel
+  local fake_git="$fixtures/sync-cancel-git"
+  printf '#!/bin/sh\nsleep 600\n' > "$fake_git"
+  chmod +x "$fake_git"
+  (
+    cd "$fixtures/sync-cancel"
+    jj git remote add origin https://example.invalid/repo.git
+    jj config set --repo git.executable-path "$fake_git"
+  )
+}
+
 fixture_bookmark_diff() {
   copy_fixture simple bookmark-diff
   (
@@ -318,6 +331,7 @@ mkdir -p "$fixtures"
 fixture_simple
 fixture_mutating_scenes
 fixture_external_tools
+fixture_sync_cancel
 fixture_bookmark_diff
 fixture_formats
 fixture_review_notes

--- a/shell/gpui/src/cli/dispatch.rs
+++ b/shell/gpui/src/cli/dispatch.rs
@@ -82,6 +82,7 @@ fn describe_error(error: &CoreError) -> String {
         CoreError::Review { message }
         | CoreError::Diff { message }
         | CoreError::Internal { message } => message.clone(),
+        CoreError::Canceled => "Canceled".to_owned(),
     }
 }
 

--- a/shell/gpui/src/repo/view_model/mutations.rs
+++ b/shell/gpui/src/repo/view_model/mutations.rs
@@ -216,7 +216,7 @@ impl RepoViewModel {
     ) -> gpui::Task<CoreResult<String>> {
         self.repo_result_task_without_indicator(
             cx,
-            move |repo| repo.git_push(&name),
+            move |repo| repo.git_push(&name, &repo.sync_token()),
             |vm, _message, cx| vm.refresh(false, cx),
         )
     }
@@ -227,7 +227,7 @@ impl RepoViewModel {
     ) -> gpui::Task<CoreResult<FetchResult>> {
         self.repo_result_task_without_indicator(
             cx,
-            move |repo| repo.git_fetch("origin"),
+            move |repo| repo.git_fetch("origin", &repo.sync_token()),
             |vm, _result, cx| vm.refresh(false, cx),
         )
     }

--- a/shell/mac/Sources/JayJay/Repo/ContentView/RepoContentView+CommandPalette.swift
+++ b/shell/mac/Sources/JayJay/Repo/ContentView/RepoContentView+CommandPalette.swift
@@ -75,6 +75,7 @@ extension RepoContentView {
         items.append(CommandPaletteItem(title: "Git Push", icon: "arrow.up.circle", category: "Git") {
             viewModel.gitPush(bookmark: "")
         })
+        items.append(contentsOf: cancelSyncPaletteItems)
 
         items.append(CommandPaletteItem(
             title: "Bookmark Manager",
@@ -270,5 +271,20 @@ extension RepoContentView {
                 viewModel.refresh()
             }
         )
+    }
+
+    private var cancelSyncPaletteItems: [CommandPaletteItem] {
+        var items: [CommandPaletteItem] = []
+        if viewModel.isPullingInFlight {
+            items.append(CommandPaletteItem(title: "Cancel Pull", icon: "xmark.circle", category: "Git") {
+                viewModel.cancelPull()
+            })
+        }
+        if viewModel.isPushingInFlight {
+            items.append(CommandPaletteItem(title: "Cancel Push", icon: "xmark.circle", category: "Git") {
+                viewModel.cancelPush()
+            })
+        }
+        return items
     }
 }

--- a/shell/mac/Sources/JayJay/Repo/ContentView/RepoContentView+Toolbar.swift
+++ b/shell/mac/Sources/JayJay/Repo/ContentView/RepoContentView+Toolbar.swift
@@ -26,14 +26,18 @@ extension RepoContentView {
             }
             .keyboardShortcut("r")
             .help(viewModel.hasWorkingCopyChanges ? "Files changed — click to refresh (⌘R)" : "Refresh (⌘R)")
-            Button { viewModel.gitFetch() } label: {
-                SyncArrowIndicator(direction: .pull, animating: viewModel.isPullingInFlight)
-            }
-            .help("Git Pull (fetch + rebase)")
-            Button { viewModel.gitPush(bookmark: "") } label: {
-                SyncArrowIndicator(direction: .push, animating: viewModel.isPushingInFlight)
-            }
-            .help("Git Push")
+            syncButton(
+                .pull,
+                inFlight: viewModel.isPullingInFlight,
+                start: { viewModel.gitFetch() },
+                cancel: { viewModel.cancelPull() }
+            )
+            syncButton(
+                .push,
+                inFlight: viewModel.isPushingInFlight,
+                start: { viewModel.gitPush(bookmark: "") },
+                cancel: { viewModel.cancelPush() }
+            )
         }
 
         repositoryTitle
@@ -54,6 +58,25 @@ extension RepoContentView {
             }
             .help("Settings")
         }
+    }
+
+    private func syncButton(
+        _ direction: SyncArrowIndicator.Direction,
+        inFlight: Bool,
+        start: @escaping () -> Void,
+        cancel: @escaping () -> Void
+    ) -> some View {
+        Button {
+            if inFlight {
+                cancel()
+            } else {
+                start()
+            }
+        } label: {
+            SyncArrowIndicator(direction: direction, animating: inFlight)
+        }
+        .help(inFlight ? "Cancel \(direction.label)" : direction.help)
+        .accessibilityIdentifier(direction.accessibilityIdentifier)
     }
 
     private var repositoryTitle: some ToolbarContent {
@@ -110,5 +133,21 @@ struct SidebarDivider: View {
                         onEnded(position)
                     }
             )
+    }
+}
+
+private extension SyncArrowIndicator.Direction {
+    var help: String {
+        switch self {
+            case .pull: "Git Pull (fetch + rebase)"
+            case .push: "Git Push"
+        }
+    }
+
+    var accessibilityIdentifier: String {
+        switch self {
+            case .pull: AID.Toolbar.pull
+            case .push: AID.Toolbar.push
+        }
     }
 }

--- a/shell/mac/Sources/JayJay/Repo/SyncArrowIndicator.swift
+++ b/shell/mac/Sources/JayJay/Repo/SyncArrowIndicator.swift
@@ -39,7 +39,7 @@ struct SyncArrowIndicator: View {
         TimelineView(.animation(paused: !motionEnabled)) { context in
             let progress = motionEnabled ? progress(at: context.date) : 0
             Label {
-                Text(direction.label)
+                Text(animating ? "Cancel \(direction.label)" : direction.label)
             } icon: {
                 ZStack {
                     Image(systemName: "circle")
@@ -51,7 +51,9 @@ struct SyncArrowIndicator: View {
             }
         }
         .onChange(of: motionEnabled, initial: true) { _, enabled in
-            if enabled { startedAt = Date() }
+            if enabled {
+                startedAt = Date()
+            }
         }
     }
 

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+GitActions.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+GitActions.swift
@@ -4,14 +4,14 @@ import JayJayCore
 
 extension RepoViewModel {
     func gitFetch() {
-        performPull { repo in
-            try repo.gitFetch(remote: "origin")
+        performPull { repo, sync in
+            try repo.gitFetch(remote: "origin", sync: sync)
         }
     }
 
     func gitPullBookmark(name: String) {
-        performPull { repo in
-            try repo.gitPullBookmark(bookmark: name)
+        performPull { repo, sync in
+            try repo.gitPullBookmark(bookmark: name, sync: sync)
         }
     }
 
@@ -21,14 +21,34 @@ extension RepoViewModel {
 
     @discardableResult
     func gitPushIfIdle(bookmark: String) -> Bool {
-        performResult(
+        let sync = repo.syncToken()
+        let started = performResult(
             gatedBy: RepoActionGate(
                 state: \.isPushingInFlight,
                 busyMessage: "Push already in progress"
             ),
-            onSuccess: { viewModel, message in viewModel.info = message },
-            { try $0.gitPush(bookmark: bookmark) }
+            onSuccess: { viewModel, message in
+                viewModel.pushSync = nil
+                viewModel.info = message
+            },
+            onFailure: { viewModel, error in
+                viewModel.pushSync = nil
+                viewModel.presentSyncFailure(error, canceledMessage: "Push canceled")
+            },
+            { try $0.gitPush(bookmark: bookmark, sync: sync) }
         )
+        if started {
+            pushSync = sync
+        }
+        return started
+    }
+
+    func cancelPull() {
+        pullSync?.cancel()
+    }
+
+    func cancelPush() {
+        pushSync?.cancel()
     }
 
     func forgetStaleBookmarks() {
@@ -64,14 +84,36 @@ extension RepoViewModel {
         info = msg
     }
 
-    private func performPull(_ operation: @escaping RepoOperation<FetchResult>) {
-        performResult(
+    private func performPull(_ operation: @escaping @Sendable (JayJayRepo, JayJaySyncToken) throws -> FetchResult) {
+        let sync = repo.syncToken()
+        let started = performResult(
             gatedBy: RepoActionGate(
                 state: \.isPullingInFlight,
                 busyMessage: "Pull already in progress"
             ),
-            onSuccess: { viewModel, result in viewModel.handleFetchResult(result) },
-            operation
+            onSuccess: { viewModel, result in
+                viewModel.pullSync = nil
+                viewModel.handleFetchResult(result)
+            },
+            onFailure: { viewModel, error in
+                viewModel.pullSync = nil
+                viewModel.presentSyncFailure(error, canceledMessage: "Pull canceled")
+            },
+            { repo in try operation(repo, sync) }
         )
+        if started {
+            pullSync = sync
+        }
+    }
+
+    @MainActor
+    private func presentSyncFailure(_ error: any Error, canceledMessage: String) {
+        if let jjError = error as? JayJayError, case .Canceled = jjError {
+            info = canceledMessage
+            // The remote phase may have landed before the cancel took effect.
+            refresh()
+        } else {
+            present(error: error)
+        }
     }
 }

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
@@ -71,6 +71,8 @@ final class RepoViewModel: ChangeActions, DAGActions, BookmarkActions {
     var isRefreshingInFlight: Bool = false
     var isPullingInFlight = false
     var isPushingInFlight = false
+    var pullSync: JayJaySyncToken?
+    var pushSync: JayJaySyncToken?
     var isAddingWorkspace = false
     var includeSubmoduleStatuses: Bool
     var prInfo: PrInfo?

--- a/shell/mac/Sources/JayJay/Shared/AccessibilityIdentifiers.swift
+++ b/shell/mac/Sources/JayJay/Shared/AccessibilityIdentifiers.swift
@@ -9,6 +9,11 @@ enum AID {
         }
     }
 
+    enum Toolbar {
+        static let pull = "toolbar.pull"
+        static let push = "toolbar.push"
+    }
+
     enum Picker {
         static let refresh = "picker.refresh"
 

--- a/shell/mac/Sources/JayJay/Shared/ErrorMessages.swift
+++ b/shell/mac/Sources/JayJay/Shared/ErrorMessages.swift
@@ -21,6 +21,8 @@ extension Error {
                     return "\(path): file changed since the editor opened — refresh and retry"
                 case let .Internal(message):
                     return unwrapCommandError(message)
+                case .Canceled:
+                    return "Canceled"
             }
         }
         return localizedDescription

--- a/shell/mac/Tests/JayJayTests/RepoViewModelSyncCancelTests.swift
+++ b/shell/mac/Tests/JayJayTests/RepoViewModelSyncCancelTests.swift
@@ -1,0 +1,52 @@
+@testable import JayJay
+import JayJayCore
+import XCTest
+
+@MainActor
+final class RepoViewModelSyncCancelTests: RepoViewModelTestCase {
+    func testCancelingAPullReportsCancellationAndReleasesTheGate() async throws {
+        let viewModel = try XCTUnwrap(viewModel)
+        let scratch = URL(fileURLWithPath: viewModel.repoPath).deletingLastPathComponent()
+        let gitStarted = scratch.appendingPathComponent("git-started-\(UUID().uuidString)")
+        let fakeGit = scratch.appendingPathComponent("fake-git-\(UUID().uuidString)")
+        try "#!/bin/sh\ntouch '\(gitStarted.path)'\nsleep 30\n".write(to: fakeGit, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeGit.path)
+        defer {
+            try? FileManager.default.removeItem(at: fakeGit)
+            try? FileManager.default.removeItem(at: gitStarted)
+        }
+        try runJj(["git", "remote", "add", "origin", "https://example.invalid/repo.git"], in: viewModel.repoPath)
+        try runJj(["config", "set", "--repo", "git.executable-path", fakeGit.path], in: viewModel.repoPath)
+
+        viewModel.gitFetch()
+        XCTAssertTrue(viewModel.isPullingInFlight)
+        try await waitUntil("fetch reaches git") { FileManager.default.fileExists(atPath: gitStarted.path) }
+
+        viewModel.cancelPull()
+
+        try await waitUntil("pull gate releases") { !viewModel.isPullingInFlight }
+        XCTAssertEqual(viewModel.info, "Pull canceled")
+        XCTAssertNil(viewModel.error)
+        XCTAssertNotNil(viewModel.refreshTask, "a canceled pull still refreshes: its remote phase may have landed")
+    }
+
+    private func runJj(_ arguments: [String], in repoPath: String) throws {
+        let process = Process()
+        process.executableURL = try URL(fileURLWithPath: XCTUnwrap(findBinary(name: "jj")))
+        process.arguments = ["-R", repoPath] + arguments
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0, "jj \(arguments.joined(separator: " ")) failed")
+    }
+
+    private func waitUntil(_ what: String, _ condition: @MainActor () -> Bool) async throws {
+        let deadline = Date().addingTimeInterval(10)
+        while !condition() {
+            if Date() >= deadline {
+                XCTFail("timed out waiting until \(what)")
+                throw CancellationError()
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+}

--- a/shell/mac/Tests/JayJayUITests/Scenes/PullCancelScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/PullCancelScene.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+/// The `sync-cancel` fixture routes `git` to a script that never returns, so Pull stays in flight until canceled.
+final class PullCancelScene: SceneBase {
+    override class var fixtureName: String {
+        "sync-cancel"
+    }
+
+    func testCancelPullFromToolbar() throws {
+        let app = try XCTUnwrap(app)
+        let pull = app.buttons[AID.Toolbar.pull]
+        XCTAssertTrue(pull.waitForExistence(timeout: 10), "Pull toolbar button missing")
+
+        pull.click()
+        XCTAssertTrue(
+            pull.wait(for: \.label, toEqual: "Cancel Pull", timeout: 10),
+            "Pull did not switch to Cancel while in flight"
+        )
+
+        pull.click()
+        XCTAssertTrue(app.staticTexts["Pull canceled"].waitForExistence(timeout: 10), "Cancel toast missing")
+        XCTAssertTrue(pull.wait(for: \.label, toEqual: "Pull", timeout: 10), "Pull button did not return to idle")
+    }
+}


### PR DESCRIPTION
Stacked on #175.

The working-copy refresh read the repo head before taking the working-copy lock, so a snapshot that landed while it waited (another jj process or a sibling workspace) was rewritten from the stale head and forked `@` into a divergent change. Take the lock first, then load the head.

A fetch or push that hung on the network, a credential prompt, or a stuck git had no way out but quitting. The toolbar buttons and the command palette now cancel the operation in flight: the process registry terminates the `jj git` process group, the call ends with `CoreError::Canceled`, and the SwiftUI shell reports "Pull canceled" instead of an error.