### PR TITLE
fix: cancel a fetch or push whose jj already exited

### DIFF
--- a/crates/jayjay-core/src/repo/command_process.rs
+++ b/crates/jayjay-core/src/repo/command_process.rs
@@ -64,14 +64,16 @@ impl SyncToken {
             .running
             .iter_mut()
             .filter_map(|(pid, process)| {
-                let mine = process.sync.as_ref().is_some_and(|sync| sync.is(self));
-                // Checked and signaled under the registry lock, so a process that exits on its own cannot be reaped in between and reported as canceled.
-                let live = matches!(process.child.try_wait(), Ok(None));
-                (mine && live).then(|| {
+                if !process.sync.as_ref().is_some_and(|sync| sync.is(self)) {
+                    return None;
+                }
+                // Checked and signaled under the registry lock, so a leader that exits on its own cannot be reaped in between and reported as canceled.
+                if matches!(process.child.try_wait(), Ok(None)) {
                     process.signaled = true;
-                    terminate_process_group(*pid, false);
-                    *pid
-                })
+                }
+                // The group is signaled even after the leader exited: a descendant may still hold the pipes and keep the action blocked.
+                terminate_process_group(*pid, false);
+                Some(*pid)
             })
             .collect();
         self.processes.escalate(targets, false);

--- a/crates/jayjay-core/src/repo/command_process/tests.rs
+++ b/crates/jayjay-core/src/repo/command_process/tests.rs
@@ -123,6 +123,35 @@ fn a_live_process_is_canceled_even_after_it_printed_to_stderr() {
     assert!(matches!(error, CoreError::Canceled), "{error}");
 }
 
+#[test]
+fn cancel_frees_an_action_whose_leader_exited_but_left_a_descendant_on_the_pipes() {
+    let processes = RunningJjProcesses::default();
+    let sync = processes.sync_token();
+    let worker_processes = processes.clone();
+    let worker_sync = sync.clone();
+    let worker = thread::spawn(move || {
+        let _enter = worker_sync.enter();
+        let mut command = Command::new("/bin/sh");
+        command.args(["-c", "sleep 30 & exit 0"]);
+        worker_processes.output(&mut command, "leader that exits early")
+    });
+    wait_for_running(&processes, 1);
+    thread::sleep(Duration::from_millis(100));
+
+    let started = Instant::now();
+    sync.cancel();
+
+    let output = worker
+        .join()
+        .expect("command thread")
+        .expect("the leader's own result is kept");
+    assert!(output.status.success());
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "descendant kept the action blocked"
+    );
+}
+
 fn run_true(processes: &RunningJjProcesses) -> CoreResult<std::process::Output> {
     processes.output(&mut Command::new("/usr/bin/true"), "true")
 }


### PR DESCRIPTION
Follow-up to #176 (review thread on `command_process.rs`).

When jj (the process-group leader) exits while a git or credential-helper descendant still holds the output pipes, the action stays blocked, and cancel used to skip the kill because the leader was no longer live. Cancel now signals the process group of every registered process of the action; only a leader that was still live is reported as canceled, so a completed leader keeps its own result.

Covered by `cancel_frees_an_action_whose_leader_exited_but_left_a_descendant_on_the_pipes`.