### PR TITLE
fix: split over-long Swift functions and isolate review stores per UI scene

### DIFF
--- a/shell/mac/Sources/JayJay/Detail/FileList/FileColumn+Actions.swift
+++ b/shell/mac/Sources/JayJay/Detail/FileList/FileColumn+Actions.swift
@@ -15,21 +15,7 @@ extension ChangeDetailView {
         let reviewLabel = reviewActionLabel(for: contextPaths)
 
         if !isBatch {
-            Button("Open in \(appSettings.externalEditor.title)") {
-                appSettings.openInEditor(filePath: path, repoPath: repoPath)
-            }
-            Button("Show in Finder") { showInFinder(path) }
-                .accessibilityIdentifier(AID.FileList.showInFinder)
-            Button("Copy Path") {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(path, forType: .string)
-            }
-            if !includesSubmodulePlaceholder {
-                Divider()
-                Button("Annotate (Blame)") { loadAnnotate(rev: detailRevision, path: path) }
-                Button("File History") { loadFileHistory(path: path) }
-                Divider()
-            }
+            singleFileActions(path: path, isSubmodulePlaceholder: includesSubmodulePlaceholder)
         }
 
         if !includesSubmodulePlaceholder {
@@ -51,19 +37,7 @@ extension ChangeDetailView {
                     actions?.moveToWorkingCopy(rev: detailRevision, paths: contextPaths)
                 }
             }
-            if detail.info.parents.count > 1 {
-                Menu(restoreActionLabel(for: contextPaths)) {
-                    ForEach(Array(detail.info.parents.enumerated()), id: \.offset) { index, parentId in
-                        Button("Parent \(index + 1): \(String(parentId.prefix(8)))") {
-                            actions?.restoreFiles(rev: parentId, paths: contextPaths)
-                        }
-                    }
-                }
-            } else {
-                Button(restoreActionLabel(for: contextPaths)) {
-                    actions?.restoreFiles(rev: detailRevision, paths: contextPaths)
-                }
-            }
+            restoreActions(paths: contextPaths)
             if detail.info.isWorkingCopy {
                 Button(deleteActionLabel(for: contextPaths), role: .destructive) {
                     actions?.deleteFiles(paths: contextPaths)
@@ -72,6 +46,42 @@ extension ChangeDetailView {
             Divider()
             Button(ignoreActionLabel(for: contextPaths)) {
                 actions?.ignoreAndUntrack(paths: contextPaths)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func singleFileActions(path: String, isSubmodulePlaceholder: Bool) -> some View {
+        Button("Open in \(appSettings.externalEditor.title)") {
+            appSettings.openInEditor(filePath: path, repoPath: repoPath)
+        }
+        Button("Show in Finder") { showInFinder(path) }
+            .accessibilityIdentifier(AID.FileList.showInFinder)
+        Button("Copy Path") {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(path, forType: .string)
+        }
+        if !isSubmodulePlaceholder {
+            Divider()
+            Button("Annotate (Blame)") { loadAnnotate(rev: detailRevision, path: path) }
+            Button("File History") { loadFileHistory(path: path) }
+            Divider()
+        }
+    }
+
+    @ViewBuilder
+    private func restoreActions(paths: [String]) -> some View {
+        if detail.info.parents.count > 1 {
+            Menu(restoreActionLabel(for: paths)) {
+                ForEach(Array(detail.info.parents.enumerated()), id: \.offset) { index, parentId in
+                    Button("Parent \(index + 1): \(String(parentId.prefix(8)))") {
+                        actions?.restoreFiles(rev: parentId, paths: paths)
+                    }
+                }
+            }
+        } else {
+            Button(restoreActionLabel(for: paths)) {
+                actions?.restoreFiles(rev: detailRevision, paths: paths)
             }
         }
     }

--- a/shell/mac/Sources/JayJay/Diff/DiffSection+Loading.swift
+++ b/shell/mac/Sources/JayJay/Diff/DiffSection+Loading.swift
@@ -64,31 +64,14 @@ extension DiffSection {
             ignoreWhitespace: settings.ignoreWhitespace,
             projectionMode: projectionModeKey
         )
-        guard !hunk.isSubmodulePlaceholder else {
+        if let content = placeholderContent {
             resetContextExpansion()
             loadedDiff = DiffSectionLoadedDiff(
                 path: hunk.path,
                 fileDiff: nil,
                 displayLines: nil,
                 displayGroups: nil,
-                content: DiffLoadedContent(
-                    oldContent: hunk.oldContent,
-                    newContent: hunk.newContent
-                ),
-                identity: nil
-            )
-            isComputing = false
-            return
-        }
-
-        guard !hunk.isContentFreeRename else {
-            resetContextExpansion()
-            loadedDiff = DiffSectionLoadedDiff(
-                path: hunk.path,
-                fileDiff: nil,
-                displayLines: nil,
-                displayGroups: nil,
-                content: DiffLoadedContent(),
+                content: content,
                 identity: nil
             )
             isComputing = false
@@ -103,18 +86,7 @@ extension DiffSection {
             ignoreWhitespace: settings.ignoreWhitespace,
             projectionMode: requestedProjectionMode
         ) {
-            let prepared = await Self.prepareLoadedDiff(
-                cached,
-                path: path,
-                identity: identity,
-                hunk: hunk,
-                ignoreWhitespace: settings.ignoreWhitespace
-            )
-            guard !Task.isCancelled, hunk.path == path else {
-                isComputing = false
-                return
-            }
-            apply(prepared)
+            await applyLoaded(cached, path: path, identity: identity)
             isComputing = false
             return
         }
@@ -136,20 +108,35 @@ extension DiffSection {
             ignoreWhitespace: settings.ignoreWhitespace,
             projectionMode: requestedProjectionMode
         ) {
-            let prepared = await Self.prepareLoadedDiff(
-                cached,
-                path: path,
-                identity: identity,
-                hunk: hunk,
-                ignoreWhitespace: settings.ignoreWhitespace
-            )
-            guard !Task.isCancelled, hunk.path == path else {
-                isComputing = false
-                return
-            }
-            apply(prepared)
+            await applyLoaded(cached, path: path, identity: identity)
         }
         isComputing = false
+    }
+
+    private var placeholderContent: DiffLoadedContent? {
+        if hunk.isSubmodulePlaceholder {
+            return DiffLoadedContent(oldContent: hunk.oldContent, newContent: hunk.newContent)
+        }
+        if hunk.isContentFreeRename {
+            return DiffLoadedContent()
+        }
+        return nil
+    }
+
+    private func applyLoaded(
+        _ cached: DiffStore.CachedDiff,
+        path: String,
+        identity: DiffContextExpansionIdentity
+    ) async {
+        let prepared = await Self.prepareLoadedDiff(
+            cached,
+            path: path,
+            identity: identity,
+            hunk: hunk,
+            ignoreWhitespace: settings.ignoreWhitespace
+        )
+        guard !Task.isCancelled, hunk.path == path else { return }
+        apply(prepared)
     }
 
     private func clearLoadedContent() {

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGView+ContextMenu.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGView+ContextMenu.swift
@@ -49,6 +49,14 @@ extension DAGView {
         }
 
         Divider()
+        moreActionsMenu(entry: entry, rev: rev)
+        if !entry.change.isImmutable {
+            Divider()
+            abandonButton(entry: entry, rev: rev)
+        }
+    }
+
+    private func moreActionsMenu(entry: GraphEntry, rev: String) -> some View {
         Menu {
             Button { actions?.duplicate(rev: rev) } label: {
                 Label("Duplicate", systemImage: "doc.on.doc")
@@ -64,20 +72,14 @@ extension DAGView {
         } label: {
             Label("More Actions", systemImage: "ellipsis.circle")
         }
+    }
 
-        if !entry.change.isImmutable {
-            Divider()
+    private func abandonButton(entry: GraphEntry, rev: String) -> some View {
+        Button(role: .destructive) { onAbandon?(rev) } label: {
             if entry.change.isDivergent {
-                Button(role: .destructive) { onAbandon?(rev) } label: {
-                    Label(
-                        "Abandon (resolve divergence)",
-                        systemImage: "arrow.triangle.merge"
-                    )
-                }
+                Label("Abandon (resolve divergence)", systemImage: "arrow.triangle.merge")
             } else {
-                Button(role: .destructive) { onAbandon?(rev) } label: {
-                    Label("Abandon", systemImage: "trash")
-                }
+                Label("Abandon", systemImage: "trash")
             }
         }
     }

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+Rebase.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+Rebase.swift
@@ -33,36 +33,11 @@ extension RepoViewModel {
         let includeSubmoduleStatuses = includeSubmoduleStatuses
 
         runRepoTask { [requestedRevset = revset, includeSubmoduleStatuses] repo in
-            let undoOperationId = try repo.opLog().first(where: { $0.isCurrent })?.id.id
-            try repo.rebase(rev: request.sourceRev, dest: request.destRev)
-            try repo.refreshWorkingCopy()
-
-            let graphEntries = try repo.logGraph(revset: requestedRevset)
-            let log = graphEntries.map(\.change)
-            let bookmarks = try repo.listBookmarks()
-            let workspaces = try? repo.workspaceList()
-            let selectedChange = try Self.loadSelectedDetail(
+            try Self.rebaseAndReload(
                 repo: repo,
-                log: log,
-                preferredRev: request.sourceChangeId,
+                request: request,
+                revset: requestedRevset,
                 includeSubmoduleStatuses: includeSubmoduleStatuses
-            )
-            let workingCopy = log.first(where: { $0.isWorkingCopy })
-            let hadConflicts = graphEntries.contains(where: {
-                $0.change.changeId.id == request.sourceChangeId && $0.change.hasConflict
-            })
-
-            return RepoRebaseRefreshResult(
-                graphEntries: graphEntries,
-                bookmarks: bookmarks,
-                workspaces: workspaces,
-                selectedChange: selectedChange,
-                workingCopyChangeId: workingCopy?.changeId.id ?? "",
-                workingCopyIsDivergent: workingCopy?.isDivergent ?? false,
-                workingCopyDescription: workingCopy?.description ?? "",
-                hadConflicts: hadConflicts,
-                undoOperationId: undoOperationId,
-                statusBar: StatusBarSnapshot.load(from: repo)
             )
         } onSuccess: { viewModel, result in
             viewModel.successActionSignal += 1
@@ -97,6 +72,45 @@ extension RepoViewModel {
             viewModel.isRefreshingInFlight = false
             onFailure(viewModel, error.friendlyDescription)
         }
+    }
+
+    private static func rebaseAndReload(
+        repo: JayJayRepo,
+        request: DAGRebaseRequest,
+        revset: String,
+        includeSubmoduleStatuses: Bool
+    ) throws -> RepoRebaseRefreshResult {
+        let undoOperationId = try repo.opLog().first(where: { $0.isCurrent })?.id.id
+        try repo.rebase(rev: request.sourceRev, dest: request.destRev)
+        try repo.refreshWorkingCopy()
+
+        let graphEntries = try repo.logGraph(revset: revset)
+        let log = graphEntries.map(\.change)
+        let bookmarks = try repo.listBookmarks()
+        let workspaces = try? repo.workspaceList()
+        let selectedChange = try loadSelectedDetail(
+            repo: repo,
+            log: log,
+            preferredRev: request.sourceChangeId,
+            includeSubmoduleStatuses: includeSubmoduleStatuses
+        )
+        let workingCopy = log.first(where: { $0.isWorkingCopy })
+        let hadConflicts = graphEntries.contains(where: {
+            $0.change.changeId.id == request.sourceChangeId && $0.change.hasConflict
+        })
+
+        return RepoRebaseRefreshResult(
+            graphEntries: graphEntries,
+            bookmarks: bookmarks,
+            workspaces: workspaces,
+            selectedChange: selectedChange,
+            workingCopyChangeId: workingCopy?.changeId.id ?? "",
+            workingCopyIsDivergent: workingCopy?.isDivergent ?? false,
+            workingCopyDescription: workingCopy?.description ?? "",
+            hadConflicts: hadConflicts,
+            undoOperationId: undoOperationId,
+            statusBar: StatusBarSnapshot.load(from: repo)
+        )
     }
 
     private static func rebaseMessage(for request: DAGRebaseRequest, hadConflicts: Bool) -> String {

--- a/shell/mac/Sources/JayJay/Shared/CommitAvatar.swift
+++ b/shell/mac/Sources/JayJay/Shared/CommitAvatar.swift
@@ -34,7 +34,7 @@ struct CommitAvatar: View {
         if let image {
             Image(nsImage: image)
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .scaledToFill()
                 .frame(width: size, height: size)
                 .clipShape(Circle())
         } else {

--- a/shell/mac/Tests/JayJayUITests/Scenes/SettingsClearReviewScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/SettingsClearReviewScene.swift
@@ -6,24 +6,23 @@ final class SettingsClearReviewScene: SceneBase {
         XCTAssertTrue(dagRows(of: app).element(boundBy: 0).waitForExistence(timeout: 10), "DAG never populated")
         let review = app.buttons[AID.FileList.review("wip1.txt")]
         XCTAssertTrue(review.waitForExistence(timeout: 5), "File review control missing")
+        XCTAssertEqual(review.label, "Unreviewed")
         review.click()
         XCTAssertTrue(review.wait(for: \.label, toEqual: "Reviewed", timeout: 5), "file did not become reviewed")
 
         app.typeKey(",", modifierFlags: .command)
-        let settingsWindow = app.windows.matching(NSPredicate(format: "title CONTAINS 'Settings'")).firstMatch
-        XCTAssertTrue(settingsWindow.waitForExistence(timeout: 5), "Settings window did not open")
-        let diffTab = settingsWindow.descendants(matching: .any)
+        let diffTab = app.descendants(matching: .any)
             .matching(NSPredicate(format: "label == 'Diff'"))
             .firstMatch
         XCTAssertTrue(diffTab.waitForExistence(timeout: 5), "Diff settings tab missing")
         diffTab.click()
-        let clear = settingsWindow.buttons[AID.Settings.clearReviewData]
+        let clear = app.buttons[AID.Settings.clearReviewData]
         XCTAssertTrue(clear.waitForExistence(timeout: 5), "Clear button missing")
         clear.click()
-        let confirm = app.buttons["Clear"].firstMatch
+        // app-wide "Clear" also matches the Touch Bar item, which XCUITest cannot click.
+        let confirm = app.sheets.buttons["Clear"].firstMatch
         XCTAssertTrue(confirm.waitForExistence(timeout: 5), "Confirmation missing")
         confirm.click()
-        settingsWindow.typeKey(.escape, modifierFlags: [])
 
         XCTAssertTrue(review.wait(for: \.label, toEqual: "Unreviewed", timeout: 10), "open window kept stale review state")
     }

--- a/shell/mac/Tests/JayJayUITests/Support/SceneBase.swift
+++ b/shell/mac/Tests/JayJayUITests/Support/SceneBase.swift
@@ -45,7 +45,8 @@ class SceneBase: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false
         let root = Self.fixtureRoot
-        let reviewStorePath = root.appendingPathComponent("\(Self.fixtureName)-review-store.json").path
+        // Scenes on the same fixture can run in parallel runner clones, so each class gets its own store instead of sharing one per fixture.
+        let reviewStorePath = root.appendingPathComponent("\(Self.fixtureName)-\(Self.self)-review-store.json").path
         try? FileManager.default.removeItem(atPath: reviewStorePath)
 
         let app = XCUIApplication()


### PR DESCRIPTION
Fixes the two red jobs on main.

**Lint Swift** — CI runs `swiftlint --strict`, so the four pre-existing `function_body_length` warnings became errors once the rule landed. Split by responsibility instead of exempting:
- `RepoViewModel.rebase` → `rebaseAndReload` static loader
- `DAGView.rowContextMenu` → `moreActionsMenu`, `abandonButton`
- `ChangeDetailView.fileContextMenu` → `singleFileActions`, `restoreActions`
- `DiffSection.computeDiffAsync` → `placeholderContent`, `applyLoaded` (the two placeholder branches and the two prepare/apply blocks were duplicates)
- `CommitAvatar`: `aspectRatio(contentMode: .fill)` → `scaledToFill()` for the newer `legacy_swiftui_aspect_ratio` rule

**swift-ui** — `SettingsClearReviewScene` failed with "file did not become reviewed". The CI recording shows wip1.txt already reviewed at launch, so the click toggled it off. Scenes on the same fixture shared one `<fixture>-review-store.json`, and `ReviewSplitScene` marks that file with Space. Each scene class now gets its own store file; the scene also asserts the unreviewed precondition first so a leak fails at the right step.