### PR TITLE
More pane size persistence

### DIFF
--- a/scripts/ui-test-fixtures.sh
+++ b/scripts/ui-test-fixtures.sh
@@ -24,7 +24,7 @@ setup_defaults() {
   defaults write "$bundle_id" jayjay.recentRepos -array "$fixtures/formats"
   defaults delete "$bundle_id" jayjay.lastOpenedRepo 2>/dev/null || true
   defaults delete "$bundle_id" commandPalette.frameOrigin 2>/dev/null || true
-  for key in jayjay.windowFrame.repo-window jayjay.windowFrame.repo-list-window jayjay.fileColumnWidth jayjay.evologSnapshotsWidth jayjay.evologFilenamesWidth; do
+  for key in jayjay.windowFrame.repo-window jayjay.windowFrame.repo-list-window jayjay.secondaryPaneWidth; do
     defaults delete "$bundle_id" "$key" 2>/dev/null || true
   done
 }

--- a/scripts/ui-test-fixtures.sh
+++ b/scripts/ui-test-fixtures.sh
@@ -24,7 +24,7 @@ setup_defaults() {
   defaults write "$bundle_id" jayjay.recentRepos -array "$fixtures/formats"
   defaults delete "$bundle_id" jayjay.lastOpenedRepo 2>/dev/null || true
   defaults delete "$bundle_id" commandPalette.frameOrigin 2>/dev/null || true
-  for key in jayjay.windowFrame.repo-window jayjay.windowFrame.repo-list-window jayjay.fileColumnWidth; do
+  for key in jayjay.windowFrame.repo-window jayjay.windowFrame.repo-list-window jayjay.fileColumnWidth jayjay.evologSnapshotsWidth jayjay.evologFilenamesWidth; do
     defaults delete "$bundle_id" "$key" 2>/dev/null || true
   done
 }
@@ -99,6 +99,18 @@ fixture_bookmark_diff() {
   (
     cd "$fixtures/bookmark-diff"
     jj bookmark create bookmark-diff -r @
+  )
+}
+
+# Amend the working-copy commit twice so older evolog entries expose distinct, non-empty file lists against head.
+fixture_evolog() {
+  copy_fixture simple evolog
+  (
+    cd "$fixtures/evolog"
+    echo "wip 1 v2" > wip1.txt
+    jj describe -m "wip v2"
+    echo "wip 1 v3" > wip1.txt
+    jj describe -m "wip v3"
   )
 }
 
@@ -347,6 +359,7 @@ fixture_mutating_scenes
 fixture_external_tools
 fixture_sync_cancel
 fixture_bookmark_diff
+fixture_evolog
 fixture_formats
 fixture_review_notes
 fixture_evolog_hide_snapshots

--- a/shell/mac/Sources/JayJay/App/Config/AppSettings.swift
+++ b/shell/mac/Sources/JayJay/App/Config/AppSettings.swift
@@ -18,9 +18,7 @@ final class AppSettings {
         static let enableGitSubmoduleSupport = "jayjay.showGitSubmoduleChanges"
         static let treeFileList = "jayjay.treeFileList"
         static let sidebarWidth = "jayjay.sidebarWidth"
-        static let fileColumnWidth = "jayjay.fileColumnWidth"
-        static let evologSnapshotsWidth = "jayjay.evologSnapshotsWidth"
-        static let evologFilenamesWidth = "jayjay.evologFilenamesWidth"
+        static let secondaryPaneWidth = "jayjay.secondaryPaneWidth"
         static let recentRepos = "jayjay.recentRepos"
         static let lastOpenedRepo = "jayjay.lastOpenedRepo"
         static let hasCompletedOnboarding = "jayjay.hasCompletedOnboarding"
@@ -93,16 +91,8 @@ final class AppSettings {
         didSet { defaults.set(sidebarWidth, forKey: StorageKeys.sidebarWidth) }
     }
 
-    var fileColumnWidth: Double {
-        didSet { defaults.set(fileColumnWidth, forKey: StorageKeys.fileColumnWidth) }
-    }
-
-    var evologSnapshotsWidth: Double {
-        didSet { defaults.set(evologSnapshotsWidth, forKey: StorageKeys.evologSnapshotsWidth) }
-    }
-
-    var evologFilenamesWidth: Double {
-        didSet { defaults.set(evologFilenamesWidth, forKey: StorageKeys.evologFilenamesWidth) }
+    var secondaryPaneWidth: Double {
+        didSet { defaults.set(secondaryPaneWidth, forKey: StorageKeys.secondaryPaneWidth) }
     }
 
     // MARK: - Repos
@@ -191,14 +181,9 @@ final class AppSettings {
         skipAbandonConfirmation = defaults.bool(forKey: StorageKeys.skipAbandonConfirmation)
         confirmDragRebase = defaults.object(forKey: StorageKeys.confirmDragRebase) as? Bool ?? true
         sidebarWidth = min(max(defaults.object(forKey: StorageKeys.sidebarWidth) as? Double ?? 360, PaneLayout.sidebar.lowerBound), PaneLayout.sidebar.upperBound)
-        fileColumnWidth = min(max(defaults.object(forKey: StorageKeys.fileColumnWidth) as? Double ?? 260, PaneLayout.fileColumn.lowerBound), PaneLayout.fileColumn.upperBound)
-        evologSnapshotsWidth = min(
-            max(defaults.object(forKey: StorageKeys.evologSnapshotsWidth) as? Double ?? Double(PaneLayout.evologSnapshotsDefault), PaneLayout.evologSnapshots.lowerBound),
-            PaneLayout.evologSnapshots.upperBound
-        )
-        evologFilenamesWidth = min(
-            max(defaults.object(forKey: StorageKeys.evologFilenamesWidth) as? Double ?? Double(PaneLayout.evologFilenamesDefault), PaneLayout.evologFilenames.lowerBound),
-            PaneLayout.evologFilenames.upperBound
+        secondaryPaneWidth = min(
+            max(defaults.object(forKey: StorageKeys.secondaryPaneWidth) as? Double ?? Double(PaneLayout.secondaryPaneWidthDefault), PaneLayout.secondaryPaneWidth.lowerBound),
+            PaneLayout.secondaryPaneWidth.upperBound
         )
         var seenRecentRepos = Set<String>()
         recentRepos = (defaults.stringArray(forKey: StorageKeys.recentRepos) ?? [])

--- a/shell/mac/Sources/JayJay/App/Config/AppSettings.swift
+++ b/shell/mac/Sources/JayJay/App/Config/AppSettings.swift
@@ -19,6 +19,8 @@ final class AppSettings {
         static let treeFileList = "jayjay.treeFileList"
         static let sidebarWidth = "jayjay.sidebarWidth"
         static let fileColumnWidth = "jayjay.fileColumnWidth"
+        static let evologSnapshotsWidth = "jayjay.evologSnapshotsWidth"
+        static let evologFilenamesWidth = "jayjay.evologFilenamesWidth"
         static let recentRepos = "jayjay.recentRepos"
         static let lastOpenedRepo = "jayjay.lastOpenedRepo"
         static let hasCompletedOnboarding = "jayjay.hasCompletedOnboarding"
@@ -93,6 +95,14 @@ final class AppSettings {
 
     var fileColumnWidth: Double {
         didSet { defaults.set(fileColumnWidth, forKey: StorageKeys.fileColumnWidth) }
+    }
+
+    var evologSnapshotsWidth: Double {
+        didSet { defaults.set(evologSnapshotsWidth, forKey: StorageKeys.evologSnapshotsWidth) }
+    }
+
+    var evologFilenamesWidth: Double {
+        didSet { defaults.set(evologFilenamesWidth, forKey: StorageKeys.evologFilenamesWidth) }
     }
 
     // MARK: - Repos
@@ -182,6 +192,14 @@ final class AppSettings {
         confirmDragRebase = defaults.object(forKey: StorageKeys.confirmDragRebase) as? Bool ?? true
         sidebarWidth = min(max(defaults.object(forKey: StorageKeys.sidebarWidth) as? Double ?? 360, PaneLayout.sidebar.lowerBound), PaneLayout.sidebar.upperBound)
         fileColumnWidth = min(max(defaults.object(forKey: StorageKeys.fileColumnWidth) as? Double ?? 260, PaneLayout.fileColumn.lowerBound), PaneLayout.fileColumn.upperBound)
+        evologSnapshotsWidth = min(
+            max(defaults.object(forKey: StorageKeys.evologSnapshotsWidth) as? Double ?? Double(PaneLayout.evologSnapshotsDefault), PaneLayout.evologSnapshots.lowerBound),
+            PaneLayout.evologSnapshots.upperBound
+        )
+        evologFilenamesWidth = min(
+            max(defaults.object(forKey: StorageKeys.evologFilenamesWidth) as? Double ?? Double(PaneLayout.evologFilenamesDefault), PaneLayout.evologFilenames.lowerBound),
+            PaneLayout.evologFilenames.upperBound
+        )
         var seenRecentRepos = Set<String>()
         recentRepos = (defaults.stringArray(forKey: StorageKeys.recentRepos) ?? [])
             .filter { !$0.isEmpty }

--- a/shell/mac/Sources/JayJay/Detail/ChangeDetailView.swift
+++ b/shell/mac/Sources/JayJay/Detail/ChangeDetailView.swift
@@ -48,7 +48,7 @@ struct ChangeDetailView: View {
     @State var showNotedFilesOnly = false
     @State var diffStats: DiffStats?
     @State var paneMode: DetailPaneMode = .files
-    @State private var fileColumnWidth: CGFloat = 260
+    @State private var fileColumnWidth: CGFloat = PaneLayout.secondaryPaneWidthDefault
     @State var paneBeforeDiffEdit: ActivePane?
     @State var conflictedPaths: Set<String> = []
     @State var trackedGitLfsPaths: Set<String> = []
@@ -130,7 +130,7 @@ struct ChangeDetailView: View {
                 )
             } else {
                 GeometryReader { geo in
-                    let range = PaneLayout.fileColumnRange(detailWidth: geo.size.width)
+                    let range = PaneLayout.secondaryPaneWidthRange(detailWidth: geo.size.width)
                     let width = Binding(get: { min(fileColumnWidth, range.upperBound) }, set: { fileColumnWidth = $0 })
                     HStack(spacing: 0) {
                         fileColumn
@@ -140,7 +140,7 @@ struct ChangeDetailView: View {
                         SidebarDivider(
                             position: width,
                             range: range,
-                            onEnded: { appSettings.fileColumnWidth = $0 }
+                            onEnded: { appSettings.secondaryPaneWidth = $0 }
                         )
                         .accessibilityElement()
                         .accessibilityIdentifier(AID.FileList.columnDivider)
@@ -151,7 +151,7 @@ struct ChangeDetailView: View {
             }
         }
         .onAppear {
-            fileColumnWidth = appSettings.fileColumnWidth
+            fileColumnWidth = appSettings.secondaryPaneWidth
             resetState()
         }
         // Diff edit must own j/k: the DAG's earlier-installed key monitor would otherwise consume them whenever the DAG was the active pane.

--- a/shell/mac/Sources/JayJay/Detail/Evolog/EvologView.swift
+++ b/shell/mac/Sources/JayJay/Detail/Evolog/EvologView.swift
@@ -6,8 +6,8 @@ struct EvologView: View {
     @State private var viewModel: EvologViewModel
     @Environment(\.colorScheme) private var colorScheme
     @Environment(AppSettings.self) private var appSettings
-    @State private var snapshotsWidth = PaneLayout.evologSnapshotsDefault
-    @State private var filenamesWidth = PaneLayout.evologFilenamesDefault
+    @State private var snapshotsWidth = PaneLayout.secondaryPaneWidthDefault
+    @State private var filenamesWidth = PaneLayout.secondaryPaneWidthDefault
     let onDismiss: () -> Void
 
     init(
@@ -46,7 +46,7 @@ struct EvologView: View {
                         SidebarDivider(
                             position: width,
                             range: range,
-                            onEnded: { appSettings.evologSnapshotsWidth = $0 }
+                            onEnded: { appSettings.secondaryPaneWidth = $0 }
                         )
                         .accessibilityElement()
                         .accessibilityIdentifier(AID.Evolog.entryListDivider)
@@ -57,8 +57,8 @@ struct EvologView: View {
             }
         }
         .onAppear {
-            snapshotsWidth = appSettings.evologSnapshotsWidth
-            filenamesWidth = appSettings.evologFilenamesWidth
+            snapshotsWidth = appSettings.secondaryPaneWidth
+            filenamesWidth = appSettings.secondaryPaneWidth
         }
     }
 
@@ -293,7 +293,7 @@ struct EvologView: View {
                 SidebarDivider(
                     position: width,
                     range: range,
-                    onEnded: { appSettings.evologFilenamesWidth = $0 }
+                    onEnded: { appSettings.secondaryPaneWidth = $0 }
                 )
                 .accessibilityElement()
                 .accessibilityIdentifier(AID.Evolog.fileListDivider)

--- a/shell/mac/Sources/JayJay/Detail/Evolog/EvologView.swift
+++ b/shell/mac/Sources/JayJay/Detail/Evolog/EvologView.swift
@@ -5,6 +5,9 @@ import SwiftUI
 struct EvologView: View {
     @State private var viewModel: EvologViewModel
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(AppSettings.self) private var appSettings
+    @State private var snapshotsWidth = PaneLayout.evologSnapshotsDefault
+    @State private var filenamesWidth = PaneLayout.evologFilenamesDefault
     let onDismiss: () -> Void
 
     init(
@@ -32,13 +35,30 @@ struct EvologView: View {
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
-                HSplitView {
-                    entryList
-                        .frame(minWidth: 240, idealWidth: 280, maxWidth: 360)
-                    diffPane
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                GeometryReader { geo in
+                    let range = PaneLayout.evologSnapshotsRange(contentWidth: geo.size.width)
+                    let width = Binding(get: { min(snapshotsWidth, range.upperBound) }, set: { snapshotsWidth = $0 })
+                    HStack(spacing: 0) {
+                        entryList
+                            .frame(width: width.wrappedValue)
+                            .accessibilityElement(children: .contain)
+                            .accessibilityIdentifier(AID.Evolog.entryList)
+                        SidebarDivider(
+                            position: width,
+                            range: range,
+                            onEnded: { appSettings.evologSnapshotsWidth = $0 }
+                        )
+                        .accessibilityElement()
+                        .accessibilityIdentifier(AID.Evolog.entryListDivider)
+                        diffPane
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    }
                 }
             }
+        }
+        .onAppear {
+            snapshotsWidth = appSettings.evologSnapshotsWidth
+            filenamesWidth = appSettings.evologFilenamesWidth
         }
     }
 
@@ -262,40 +282,53 @@ struct EvologView: View {
     }
 
     private func interdiffContent(detail: ChangeDetail) -> some View {
-        HSplitView {
-            fileList(detail: detail)
-                .frame(minWidth: 180, idealWidth: 220, maxWidth: 320)
-            if viewModel.fileLoading {
-                ProgressView().controlSize(.small)
+        GeometryReader { geo in
+            let range = PaneLayout.evologFilenamesRange(detailWidth: geo.size.width)
+            let width = Binding(get: { min(filenamesWidth, range.upperBound) }, set: { filenamesWidth = $0 })
+            HStack(spacing: 0) {
+                fileList(detail: detail)
+                    .frame(width: width.wrappedValue)
+                    .accessibilityElement(children: .contain)
+                    .accessibilityIdentifier(AID.Evolog.fileList)
+                SidebarDivider(
+                    position: width,
+                    range: range,
+                    onEnded: { appSettings.evologFilenamesWidth = $0 }
+                )
+                .accessibilityElement()
+                .accessibilityIdentifier(AID.Evolog.fileListDivider)
+                if viewModel.fileLoading {
+                    ProgressView().controlSize(.small)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let error = viewModel.fileError {
+                    loadError(error) { viewModel.loadFile(path: viewModel.selectedPath) }
+                } else if let hunk = viewModel.selectedHunk,
+                          let from = viewModel.selectedFromCommitId,
+                          let to = viewModel.selectedToCommitId
+                {
+                    DiffSection(
+                        hunk: hunk,
+                        rev: to,
+                        repo: viewModel.repo,
+                        actions: nil,
+                        isWorkingCopy: false,
+                        diffStore: viewModel.diffStore,
+                        reviewStore: nil,
+                        noteEditor: .constant(nil),
+                        compareFromRev: from
+                    )
+                    .id("\(from)|\(hunk.path)")
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if let error = viewModel.fileError {
-                loadError(error) { viewModel.loadFile(path: viewModel.selectedPath) }
-            } else if let hunk = viewModel.selectedHunk,
-                      let from = viewModel.selectedFromCommitId,
-                      let to = viewModel.selectedToCommitId
-            {
-                DiffSection(
-                    hunk: hunk,
-                    rev: to,
-                    repo: viewModel.repo,
-                    actions: nil,
-                    isWorkingCopy: false,
-                    diffStore: viewModel.diffStore,
-                    reviewStore: nil,
-                    noteEditor: .constant(nil),
-                    compareFromRev: from
-                )
-                .id("\(from)|\(hunk.path)")
-                .padding(.horizontal, 14)
-                .padding(.vertical, 10)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                ContentUnavailableView(
-                    "Select a File",
-                    systemImage: "doc",
-                    description: Text("Pick a file from the list to see its diff.")
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    ContentUnavailableView(
+                        "Select a File",
+                        systemImage: "doc",
+                        description: Text("Pick a file from the list to see its diff.")
+                    )
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
             }
         }
     }
@@ -330,6 +363,7 @@ struct EvologView: View {
                     .truncationMode(.middle)
             }
             .tag(hunk.path)
+            .accessibilityIdentifier(AID.Evolog.file(hunk.path))
         }
         .listStyle(.plain)
         .onChange(of: viewModel.selectedPath) { _, newPath in

--- a/shell/mac/Sources/JayJay/Detail/Evolog/EvologView.swift
+++ b/shell/mac/Sources/JayJay/Detail/Evolog/EvologView.swift
@@ -290,10 +290,13 @@ struct EvologView: View {
                     .frame(width: width.wrappedValue)
                     .accessibilityElement(children: .contain)
                     .accessibilityIdentifier(AID.Evolog.fileList)
+                // Sizes from the shared secondaryPaneWidth default but doesn't write resizes back to it: this
+                // third pane is the odd one out in a snapshot/filenames/preview split, not the two-pane layout
+                // the shared preference is tuned for.
                 SidebarDivider(
                     position: width,
                     range: range,
-                    onEnded: { appSettings.secondaryPaneWidth = $0 }
+                    onEnded: { _ in }
                 )
                 .accessibilityElement()
                 .accessibilityIdentifier(AID.Evolog.fileListDivider)

--- a/shell/mac/Sources/JayJay/Shared/AccessibilityIdentifiers.swift
+++ b/shell/mac/Sources/JayJay/Shared/AccessibilityIdentifiers.swift
@@ -46,6 +46,32 @@ enum AID {
         }
     }
 
+    enum Evolog {
+        static let entryList = "evolog.entryList"
+        static let entryListDivider = "evolog.entryListDivider"
+        static let fileList = "evolog.fileList"
+        static let fileListDivider = "evolog.fileListDivider"
+        static let hideSnapshots = "evolog.hideSnapshots"
+        static let comparisonBanner = "evolog.comparisonBanner"
+        static let reverseComparison = "evolog.reverseComparison"
+
+        static func entry(_ index: Int) -> String {
+            "evolog.entry.\(index)"
+        }
+
+        static func file(_ path: String) -> String {
+            "evolog.file.\(path)"
+        }
+
+        static func version(_ index: Int) -> String {
+            "evolog.version.\(index)"
+        }
+
+        static func snapshotRun(start: Int, count: Int) -> String {
+            "evolog.snapshotRun.\(start).\(count)"
+        }
+    }
+
     enum Diff {
         static let section = "diff.section"
         static let gutter = "diff.gutter"
@@ -77,20 +103,6 @@ enum AID {
     enum Compare {
         static let banner = "compare.banner"
         static let reverseDirection = "compare.reverseDirection"
-    }
-
-    enum Evolog {
-        static let hideSnapshots = "evolog.hideSnapshots"
-        static let comparisonBanner = "evolog.comparisonBanner"
-        static let reverseComparison = "evolog.reverseComparison"
-
-        static func version(_ index: Int) -> String {
-            "evolog.version.\(index)"
-        }
-
-        static func snapshotRun(start: Int, count: Int) -> String {
-            "evolog.snapshotRun.\(start).\(count)"
-        }
     }
 
     enum CommitBox {

--- a/shell/mac/Sources/JayJay/Shared/PaneLayout.swift
+++ b/shell/mac/Sources/JayJay/Shared/PaneLayout.swift
@@ -16,4 +16,21 @@ enum PaneLayout {
         let room = detailWidth - dividerWidth - previewMin
         return fileColumn.lowerBound ... min(fileColumn.upperBound, max(fileColumn.lowerBound, room))
     }
+
+    static let evologSnapshots: ClosedRange<CGFloat> = 240 ... 360
+    static let evologFilenames: ClosedRange<CGFloat> = 180 ... 320
+    static let evologSnapshotsDefault: CGFloat = 280
+    static let evologFilenamesDefault: CGFloat = 220
+    /// Evolog nests snapshots+filenames+preview inside the detail pane's own width, which already excludes the sidebar; the app-wide `previewMin` would leave near-zero drag room, so this three-way split gets a smaller reservation.
+    static let evologPreviewMin: CGFloat = 260
+
+    static func evologSnapshotsRange(contentWidth: CGFloat) -> ClosedRange<CGFloat> {
+        let room = contentWidth - 2 * dividerWidth - evologFilenames.lowerBound - evologPreviewMin
+        return evologSnapshots.lowerBound ... min(evologSnapshots.upperBound, max(evologSnapshots.lowerBound, room))
+    }
+
+    static func evologFilenamesRange(detailWidth: CGFloat) -> ClosedRange<CGFloat> {
+        let room = detailWidth - dividerWidth - evologPreviewMin
+        return evologFilenames.lowerBound ... min(evologFilenames.upperBound, max(evologFilenames.lowerBound, room))
+    }
 }

--- a/shell/mac/Sources/JayJay/Shared/PaneLayout.swift
+++ b/shell/mac/Sources/JayJay/Shared/PaneLayout.swift
@@ -3,34 +3,32 @@ import CoreGraphics
 /// The sidebar keeps room for a minimum file column and preview, the file column for a minimum preview; GPUI applies the same rule.
 enum PaneLayout {
     static let sidebar: ClosedRange<CGFloat> = 240 ... 600
-    static let fileColumn: ClosedRange<CGFloat> = 220 ... 480
+    /// Shared width range and default for any side pane sized like the change-detail file column: the file column itself, and the evolog snapshot/filename panes, which persist the same preference.
+    static let secondaryPaneWidth: ClosedRange<CGFloat> = 220 ... 480
+    static let secondaryPaneWidthDefault: CGFloat = 260
     static let previewMin: CGFloat = 420
     static let dividerWidth: CGFloat = 1
 
     static func sidebarRange(windowWidth: CGFloat) -> ClosedRange<CGFloat> {
-        let room = windowWidth - 2 * dividerWidth - fileColumn.lowerBound - previewMin
+        let room = windowWidth - 2 * dividerWidth - secondaryPaneWidth.lowerBound - previewMin
         return sidebar.lowerBound ... min(sidebar.upperBound, max(sidebar.lowerBound, room))
     }
 
-    static func fileColumnRange(detailWidth: CGFloat) -> ClosedRange<CGFloat> {
+    static func secondaryPaneWidthRange(detailWidth: CGFloat) -> ClosedRange<CGFloat> {
         let room = detailWidth - dividerWidth - previewMin
-        return fileColumn.lowerBound ... min(fileColumn.upperBound, max(fileColumn.lowerBound, room))
+        return secondaryPaneWidth.lowerBound ... min(secondaryPaneWidth.upperBound, max(secondaryPaneWidth.lowerBound, room))
     }
 
-    static let evologSnapshots: ClosedRange<CGFloat> = 240 ... 360
-    static let evologFilenames: ClosedRange<CGFloat> = 180 ... 320
-    static let evologSnapshotsDefault: CGFloat = 280
-    static let evologFilenamesDefault: CGFloat = 220
     /// Evolog nests snapshots+filenames+preview inside the detail pane's own width, which already excludes the sidebar; the app-wide `previewMin` would leave near-zero drag room, so this three-way split gets a smaller reservation.
     static let evologPreviewMin: CGFloat = 260
 
     static func evologSnapshotsRange(contentWidth: CGFloat) -> ClosedRange<CGFloat> {
-        let room = contentWidth - 2 * dividerWidth - evologFilenames.lowerBound - evologPreviewMin
-        return evologSnapshots.lowerBound ... min(evologSnapshots.upperBound, max(evologSnapshots.lowerBound, room))
+        let room = contentWidth - 2 * dividerWidth - secondaryPaneWidth.lowerBound - evologPreviewMin
+        return secondaryPaneWidth.lowerBound ... min(secondaryPaneWidth.upperBound, max(secondaryPaneWidth.lowerBound, room))
     }
 
     static func evologFilenamesRange(detailWidth: CGFloat) -> ClosedRange<CGFloat> {
         let room = detailWidth - dividerWidth - evologPreviewMin
-        return evologFilenames.lowerBound ... min(evologFilenames.upperBound, max(evologFilenames.lowerBound, room))
+        return secondaryPaneWidth.lowerBound ... min(secondaryPaneWidth.upperBound, max(secondaryPaneWidth.lowerBound, room))
     }
 }

--- a/shell/mac/Tests/JayJayUITests/Scenes/EvologPaneWidthScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/EvologPaneWidthScene.swift
@@ -50,19 +50,19 @@ final class EvologPaneWidthScene: SceneBase {
         XCTAssertEqual(entryList.frame.width, entryListResized, accuracy: 2, "Switching versions altered the entry list width")
         XCTAssertEqual(fileList.frame.width, fileListResized, accuracy: 2, "Switching versions altered the file list width")
 
-        // Both dividers persist through the same shared pane-width preference, so the last drag (the file
-        // list's) is what both panes restore to on relaunch.
+        // The entry list divider persists to the shared pane-width preference; the file list is the third
+        // pane in this split and only sizes from that preference, so it doesn't write its own drags back.
         app.terminate()
         app.launch()
         rightClickCenter(dagRows(of: app).element(boundBy: 0))
         clickCenter(app.menuItems["Show evolution…"], message: "Show evolution menu item did not appear after relaunch")
         let relaunchedEntryList = app.descendants(matching: .any)[AID.Evolog.entryList]
         XCTAssertTrue(relaunchedEntryList.waitForExistence(timeout: 10), "Evolog entry list missing after relaunch")
-        XCTAssertEqual(relaunchedEntryList.frame.width, fileListResized, accuracy: 2, "Entry list width did not restore the shared pane-width preference")
+        XCTAssertEqual(relaunchedEntryList.frame.width, entryListResized, accuracy: 2, "Entry list width did not restore the shared pane-width preference")
         clickCenter(app.descendants(matching: .any)[AID.Evolog.entry(initialSnapshotIndex)].firstMatch)
         let relaunchedFileList = app.descendants(matching: .any)[AID.Evolog.fileList]
         XCTAssertTrue(relaunchedFileList.waitForExistence(timeout: 10), "Evolog file list missing after relaunch")
-        XCTAssertEqual(relaunchedFileList.frame.width, fileListResized, accuracy: 2, "File list width did not restore the shared pane-width preference")
+        XCTAssertEqual(relaunchedFileList.frame.width, entryListResized, accuracy: 2, "File list width did not fall back to the shared pane-width preference")
     }
 
     private func drag(_ divider: XCUIElement, by dx: CGFloat) {

--- a/shell/mac/Tests/JayJayUITests/Scenes/EvologPaneWidthScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/EvologPaneWidthScene.swift
@@ -50,17 +50,19 @@ final class EvologPaneWidthScene: SceneBase {
         XCTAssertEqual(entryList.frame.width, entryListResized, accuracy: 2, "Switching versions altered the entry list width")
         XCTAssertEqual(fileList.frame.width, fileListResized, accuracy: 2, "Switching versions altered the file list width")
 
+        // Both dividers persist through the same shared pane-width preference, so the last drag (the file
+        // list's) is what both panes restore to on relaunch.
         app.terminate()
         app.launch()
         rightClickCenter(dagRows(of: app).element(boundBy: 0))
         clickCenter(app.menuItems["Show evolution…"], message: "Show evolution menu item did not appear after relaunch")
         let relaunchedEntryList = app.descendants(matching: .any)[AID.Evolog.entryList]
         XCTAssertTrue(relaunchedEntryList.waitForExistence(timeout: 10), "Evolog entry list missing after relaunch")
-        XCTAssertEqual(relaunchedEntryList.frame.width, entryListResized, accuracy: 2, "Entry list width did not persist")
+        XCTAssertEqual(relaunchedEntryList.frame.width, fileListResized, accuracy: 2, "Entry list width did not restore the shared pane-width preference")
         clickCenter(app.descendants(matching: .any)[AID.Evolog.entry(initialSnapshotIndex)].firstMatch)
         let relaunchedFileList = app.descendants(matching: .any)[AID.Evolog.fileList]
         XCTAssertTrue(relaunchedFileList.waitForExistence(timeout: 10), "Evolog file list missing after relaunch")
-        XCTAssertEqual(relaunchedFileList.frame.width, fileListResized, accuracy: 2, "File list width did not persist")
+        XCTAssertEqual(relaunchedFileList.frame.width, fileListResized, accuracy: 2, "File list width did not restore the shared pane-width preference")
     }
 
     private func drag(_ divider: XCUIElement, by dx: CGFloat) {

--- a/shell/mac/Tests/JayJayUITests/Scenes/EvologPaneWidthScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/EvologPaneWidthScene.swift
@@ -1,0 +1,81 @@
+import XCTest
+
+final class EvologPaneWidthScene: SceneBase {
+    private let initialSnapshotIndex = 2
+    private let replacementSnapshotIndex = 4
+    private let replacementSnapshotPath = "wip2.txt"
+    private let resizeOffset: CGFloat = -30
+
+    override class var fixtureName: String {
+        "evolog"
+    }
+
+    override class var startsWithDefaultLayout: Bool {
+        false
+    }
+
+    func testEvologPaneWidthsSurviveSnapshotSwitchAndRelaunch() throws {
+        let app = try XCTUnwrap(app)
+        let rows = dagRows(of: app)
+        XCTAssertTrue(rows.firstMatch.waitForExistence(timeout: 10), "DAG never populated")
+
+        rightClickCenter(rows.element(boundBy: 0))
+        let showEvolution = app.menuItems["Show evolution…"]
+        clickCenter(showEvolution, message: "Show evolution menu item did not appear")
+
+        let entryList = app.descendants(matching: .any)[AID.Evolog.entryList]
+        XCTAssertTrue(entryList.waitForExistence(timeout: 10), "Evolog entry list missing")
+        let entryListDivider = app.descendants(matching: .any)[AID.Evolog.entryListDivider]
+        let entryListInitial = entryList.frame.width
+        let entryListTarget = entryListInitial + resizeOffset
+        drag(entryListDivider, by: resizeOffset)
+        XCTAssertTrue(waitForWidth(entryList, toEqual: entryListTarget), "Narrowing the entry list divider did not resize it")
+        let entryListResized = entryList.frame.width
+
+        clickCenter(app.descendants(matching: .any)[AID.Evolog.entry(initialSnapshotIndex)].firstMatch)
+        let fileList = app.descendants(matching: .any)[AID.Evolog.fileList]
+        XCTAssertTrue(fileList.waitForExistence(timeout: 10), "Evolog file list missing after selecting a version")
+        XCTAssertEqual(entryList.frame.width, entryListResized, accuracy: 2, "Selecting a version altered the entry list width")
+
+        let fileListDivider = app.descendants(matching: .any)[AID.Evolog.fileListDivider]
+        let fileListInitial = fileList.frame.width
+        let fileListTarget = fileListInitial + resizeOffset
+        drag(fileListDivider, by: resizeOffset)
+        XCTAssertTrue(waitForWidth(fileList, toEqual: fileListTarget), "Narrowing the file list divider did not resize it")
+        let fileListResized = fileList.frame.width
+
+        clickCenter(app.descendants(matching: .any)[AID.Evolog.entry(replacementSnapshotIndex)].firstMatch)
+        let replacementFile = app.descendants(matching: .any)[AID.Evolog.file(replacementSnapshotPath)]
+        XCTAssertTrue(replacementFile.waitForExistence(timeout: 10), "Replacement snapshot never loaded its distinct file")
+        XCTAssertEqual(entryList.frame.width, entryListResized, accuracy: 2, "Switching versions altered the entry list width")
+        XCTAssertEqual(fileList.frame.width, fileListResized, accuracy: 2, "Switching versions altered the file list width")
+
+        app.terminate()
+        app.launch()
+        rightClickCenter(dagRows(of: app).element(boundBy: 0))
+        clickCenter(app.menuItems["Show evolution…"], message: "Show evolution menu item did not appear after relaunch")
+        let relaunchedEntryList = app.descendants(matching: .any)[AID.Evolog.entryList]
+        XCTAssertTrue(relaunchedEntryList.waitForExistence(timeout: 10), "Evolog entry list missing after relaunch")
+        XCTAssertEqual(relaunchedEntryList.frame.width, entryListResized, accuracy: 2, "Entry list width did not persist")
+        clickCenter(app.descendants(matching: .any)[AID.Evolog.entry(initialSnapshotIndex)].firstMatch)
+        let relaunchedFileList = app.descendants(matching: .any)[AID.Evolog.fileList]
+        XCTAssertTrue(relaunchedFileList.waitForExistence(timeout: 10), "Evolog file list missing after relaunch")
+        XCTAssertEqual(relaunchedFileList.frame.width, fileListResized, accuracy: 2, "File list width did not persist")
+    }
+
+    private func drag(_ divider: XCUIElement, by dx: CGFloat) {
+        XCTAssertTrue(divider.waitForExistence(timeout: 5), "Divider missing")
+        let grip = divider.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        grip.press(forDuration: 0.2, thenDragTo: grip.withOffset(CGVector(dx: dx, dy: 0)))
+    }
+
+    private func waitForWidth(_ element: XCUIElement, toEqual expected: CGFloat, accuracy: CGFloat = 4) -> Bool {
+        let widthSettled = NSPredicate { _, _ in
+            abs(element.frame.width - expected) <= accuracy
+        }
+        return XCTWaiter().wait(
+            for: [XCTNSPredicateExpectation(predicate: widthSettled, object: nil)],
+            timeout: 5
+        ) == .completed
+    }
+}

--- a/shell/mac/Tests/JayJayUITests/Support/SceneBase.swift
+++ b/shell/mac/Tests/JayJayUITests/Support/SceneBase.swift
@@ -64,8 +64,7 @@ class SceneBase: XCTestCase {
         app.launchArguments += Self.additionalLaunchArguments
         if Self.startsWithDefaultLayout {
             for key in [
-                "jayjay.windowFrame.repo-window", "jayjay.windowFrame.repo-list-window", "jayjay.fileColumnWidth",
-                "jayjay.evologSnapshotsWidth", "jayjay.evologFilenamesWidth"
+                "jayjay.windowFrame.repo-window", "jayjay.windowFrame.repo-list-window", "jayjay.secondaryPaneWidth"
             ] {
                 app.launchArguments += ["-\(key)", ""]
             }

--- a/shell/mac/Tests/JayJayUITests/Support/SceneBase.swift
+++ b/shell/mac/Tests/JayJayUITests/Support/SceneBase.swift
@@ -63,7 +63,10 @@ class SceneBase: XCTestCase {
         }
         app.launchArguments += Self.additionalLaunchArguments
         if Self.startsWithDefaultLayout {
-            for key in ["jayjay.windowFrame.repo-window", "jayjay.windowFrame.repo-list-window", "jayjay.fileColumnWidth"] {
+            for key in [
+                "jayjay.windowFrame.repo-window", "jayjay.windowFrame.repo-list-window", "jayjay.fileColumnWidth",
+                "jayjay.evologSnapshotsWidth", "jayjay.evologFilenamesWidth"
+            ] {
                 app.launchArguments += ["-\(key)", ""]
             }
         }


### PR DESCRIPTION
I noticed evolog pane width adjustments were not preserved. This branch persists evolog snapshot-list pane width, sharing width with the normal file list. The same width is also used for any third pane (eg files in a snapshot).