### PR TITLE
feat(gpui): rename bookmarks from the manager

### DIFF
--- a/agents/gpui.md
+++ b/agents/gpui.md
@@ -26,8 +26,9 @@ shell/gpui/src/
 │   │                  mutations (incl. abandon_selected_diff_lines), tasks
 │   └── window/        RepoWindow view: render, actions, sidebar, DAG, detail, review, status bar,
 │                      gutter_menu/note_menu/note_composer (review-note + abandon-lines UI)
-├── ui/            reusable widgets: text_area/, input/, avatar/ (+cache), context_menu,
-│                  button_group, scrollbar (uniform-list + free-form ScrollHandle variants)
+├── ui/            reusable widgets: overlay/ (dimmed layer + card + text prompt), text_area/,
+│                  input/, avatar/ (+cache), context_menu, button_group, scrollbar
+│                  (uniform-list + free-form ScrollHandle variants)
 └── windows/       secondary GPUI windows: settings/, bookmark_manager, operation_log/,
                    command_palette/, evolog, file_history — each opened via a static `open(...)`
 ```

--- a/crates/jayjay-core/src/repo/bookmarks.rs
+++ b/crates/jayjay-core/src/repo/bookmarks.rs
@@ -223,17 +223,29 @@ impl Repo {
     }
 
     pub fn rename_bookmark(&self, old_name: &str, new_name: &str) -> CoreResult<()> {
-        let repo = self.get_repo();
-        let target = repo
-            .view()
-            .get_local_bookmark(RefName::new(old_name))
-            .clone();
-        if target.is_absent() {
-            return Err(CoreError::Internal {
-                message: format!("bookmark '{old_name}' not found"),
-            });
+        if old_name == new_name {
+            return Ok(());
         }
+        // Destination uniqueness is checked inside the transaction so a concurrent create cannot be overwritten.
         self.with_repo_transaction("rename bookmark", false, move |_, repo_mut| {
+            let target = repo_mut
+                .view()
+                .get_local_bookmark(RefName::new(old_name))
+                .clone();
+            if target.is_absent() {
+                return Err(CoreError::Internal {
+                    message: format!("bookmark '{old_name}' not found"),
+                });
+            }
+            if !repo_mut
+                .view()
+                .get_local_bookmark(RefName::new(new_name))
+                .is_absent()
+            {
+                return Err(CoreError::Internal {
+                    message: format!("Bookmark already exists: {new_name}"),
+                });
+            }
             self.set_bookmark_target(repo_mut, new_name, target);
             self.set_bookmark_target(repo_mut, old_name, RefTarget::absent());
             Ok(())

--- a/crates/jayjay-core/tests/bookmarks.rs
+++ b/crates/jayjay-core/tests/bookmarks.rs
@@ -245,6 +245,31 @@ fn remove_bookmark_from_rev_on_a_resolved_bookmark() {
 }
 
 #[test]
+fn rename_bookmark_rejects_a_live_destination() {
+    let fixture = LinearFixture::build();
+    run_jj_in(&fixture.path, &["bookmark", "create", "source", "-r", "@"]);
+    let repo = Repo::open(&fixture.path).expect("open repo");
+
+    let err = repo
+        .rename_bookmark("source", "main")
+        .expect_err("main already exists");
+    assert!(
+        err.to_string().contains("already exists"),
+        "unexpected error: {err}"
+    );
+
+    let names: Vec<_> = repo
+        .list_bookmarks()
+        .expect("list bookmarks")
+        .into_iter()
+        .filter(|bookmark| !bookmark.is_deleted)
+        .map(|bookmark| bookmark.name)
+        .collect();
+    assert!(names.iter().any(|name| name == "source"));
+    assert!(names.iter().any(|name| name == "main"));
+}
+
+#[test]
 fn a_bookmark_known_only_to_the_backing_git_repo_is_local_only() {
     let temp_dir = init_jj_repo();
     let repo_path = temp_dir.path().join("repo");

--- a/shell/gpui/src/repo/window/actions.rs
+++ b/shell/gpui/src/repo/window/actions.rs
@@ -1,4 +1,4 @@
-use gpui::{AppContext, Context, ScrollStrategy, SharedString, point, px};
+use gpui::{Context, ScrollStrategy, SharedString, point, px};
 
 use super::{
     ActivePane, DiffRichPreviewKind, DiffRichPreviewSelection, RepoWindow, TextModalAction,
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::diff::projection;
 use crate::repo::revset;
-use crate::ui::text_area::TextArea;
+use crate::ui::overlay::TextPrompt;
 use crate::windows::bookmark_manager::BookmarkManagerView;
 use crate::windows::operation_log::OperationLogView;
 
@@ -115,34 +115,33 @@ impl RepoWindow {
         action: TextModalAction,
         cx: &mut Context<Self>,
     ) {
-        let input = cx.new(|cx| TextArea::new(description, "Description", true, 190., cx));
-        self.text_modal = Some(TextModalState {
-            title: "Edit Description".into(),
-            subtitle: subtitle.into(),
-            primary_label: "Save".into(),
+        self.text_modal = Some(TextModalState::new(
+            TextPrompt::multiline(
+                "Edit Description",
+                subtitle,
+                description,
+                "Description",
+                "Save",
+                190.,
+                cx,
+            ),
             action,
-            input,
-            focus_pending: true,
-            context: None,
-            checkbox: None,
-            file_list: None,
-        });
+        ));
         cx.notify();
     }
 
     pub(crate) fn open_create_bookmark(&mut self, rev: String, cx: &mut Context<Self>) {
-        let input = cx.new(|cx| TextArea::new("", "Bookmark name", false, 32., cx));
-        self.text_modal = Some(TextModalState {
-            title: "Create Bookmark".into(),
-            subtitle: rev.chars().take(12).collect::<String>().into(),
-            primary_label: "Create".into(),
-            action: TextModalAction::CreateBookmark { rev },
-            input,
-            focus_pending: true,
-            context: None,
-            checkbox: None,
-            file_list: None,
-        });
+        self.text_modal = Some(TextModalState::new(
+            TextPrompt::single_line(
+                "Create Bookmark",
+                rev.chars().take(12).collect::<String>(),
+                "",
+                "Bookmark name",
+                "Create",
+                cx,
+            ),
+            TextModalAction::CreateBookmark { rev },
+        ));
         cx.notify();
     }
 
@@ -164,7 +163,7 @@ impl RepoWindow {
         let Some(modal) = self.text_modal.as_ref() else {
             return;
         };
-        let text = modal.input.read(cx).text();
+        let text = modal.prompt.text(cx);
         match modal.action.clone() {
             TextModalAction::EditDescription { rev } => {
                 self.text_modal = None;

--- a/shell/gpui/src/repo/window/confirmation.rs
+++ b/shell/gpui/src/repo/window/confirmation.rs
@@ -1,10 +1,11 @@
 use gpui::{
     AnyElement, Context, InteractiveElement, IntoElement, ParentElement, SharedString,
-    StatefulInteractiveElement, Styled, div, px, rgb, rgba,
+    StatefulInteractiveElement, Styled, div, px, rgb,
 };
 
 use super::RepoWindow;
 use crate::app::theme::Theme;
+use crate::ui::overlay::{overlay_actions, overlay_card, overlay_layer};
 use crate::ui::primitives::button;
 
 pub(crate) struct Confirmation {
@@ -55,29 +56,9 @@ pub(super) fn confirmation_overlay(
     t: &Theme,
     cx: &mut Context<RepoWindow>,
 ) -> AnyElement {
-    div()
-        .absolute()
-        .top_0()
-        .left_0()
-        .right_0()
-        .bottom_0()
-        .flex()
-        .items_center()
-        .justify_center()
-        .bg(rgba(0x00000033))
-        .occlude()
+    overlay_layer()
         .child(
-            div()
-                .flex()
-                .flex_col()
-                .gap(px(12.))
-                .w(px(400.))
-                .px(px(18.))
-                .py(px(16.))
-                .rounded_lg()
-                .border_1()
-                .border_color(rgb(t.border))
-                .bg(rgb(t.header_bg))
+            overlay_card(t, 400.)
                 .debug_selector(|| "confirmation".to_owned())
                 .child(
                     div()
@@ -93,30 +74,19 @@ pub(super) fn confirmation_overlay(
                         .whitespace_normal()
                         .child(confirmation.message.clone()),
                 )
-                .child(
-                    div()
-                        .flex()
-                        .flex_row()
-                        .justify_end()
-                        .gap(px(8.))
-                        .child(
-                            button("confirmation-cancel", "Cancel", t, false)
-                                .debug_selector(|| "confirmation-cancel".to_owned())
-                                .on_click(
-                                    cx.listener(|view, _, _, cx| view.cancel_confirmation(cx)),
-                                ),
-                        )
-                        .child(
-                            button(
-                                "confirmation-submit",
-                                confirmation.confirm_label.clone(),
-                                t,
-                                true,
-                            )
-                            .debug_selector(|| "confirmation-submit".to_owned())
-                            .on_click(cx.listener(|view, _, _, cx| view.confirm(cx))),
-                        ),
-                ),
+                .child(overlay_actions(
+                    button("confirmation-cancel", "Cancel", t, false)
+                        .debug_selector(|| "confirmation-cancel".to_owned())
+                        .on_click(cx.listener(|view, _, _, cx| view.cancel_confirmation(cx))),
+                    button(
+                        "confirmation-submit",
+                        confirmation.confirm_label.clone(),
+                        t,
+                        true,
+                    )
+                    .debug_selector(|| "confirmation-submit".to_owned())
+                    .on_click(cx.listener(|view, _, _, cx| view.confirm(cx))),
+                )),
         )
         .into_any_element()
 }

--- a/shell/gpui/src/repo/window/conflict_editor/view.rs
+++ b/shell/gpui/src/repo/window/conflict_editor/view.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    AnyElement, Context, InteractiveElement, IntoElement, MouseButton, MouseDownEvent,
-    ParentElement, SharedString, StatefulInteractiveElement, Styled, div, px, rgb, rgba,
+    AnyElement, Context, InteractiveElement, IntoElement, ParentElement, SharedString,
+    StatefulInteractiveElement, Styled, div, px, rgb,
 };
 use jayjay_core::MergeHunkSource;
 use jayjay_core::external_tools::conflict_marker_count;
@@ -9,6 +9,7 @@ use crate::app::fonts;
 use crate::app::theme::Theme;
 use crate::ui::icons::{glyph, icon};
 use crate::ui::merge_editor::{merge_base_toggle, merge_source_panel, merge_source_row};
+use crate::ui::overlay::overlay_layer;
 use crate::ui::primitives::button;
 
 use super::RepoWindow;
@@ -129,21 +130,7 @@ pub(in crate::repo::window) fn conflict_editor_overlay(
         )
         .child(conflict_result_section(view, data, &result_text, t, cx));
 
-    div()
-        .absolute()
-        .top_0()
-        .left_0()
-        .right_0()
-        .bottom_0()
-        .flex()
-        .items_center()
-        .justify_center()
-        .p(px(16.))
-        .bg(rgba(0x00000033))
-        .occlude()
-        .on_mouse_down(MouseButton::Left, |_: &MouseDownEvent, _, _| {})
-        .child(panel)
-        .into_any_element()
+    overlay_layer().p(px(16.)).child(panel).into_any_element()
 }
 
 fn sources_section(

--- a/shell/gpui/src/repo/window/file_actions.rs
+++ b/shell/gpui/src/repo/window/file_actions.rs
@@ -2,12 +2,12 @@
 
 use std::sync::Arc;
 
-use gpui::{App, AppContext, Context, Pixels, Point, SharedString};
+use gpui::{App, Context, Pixels, Point, SharedString};
 
 use super::{RepoWindow, TextModalAction, TextModalCheckbox, TextModalState};
 use crate::repo::revset;
 use crate::ui::context_menu::ContextMenuItem;
-use crate::ui::text_area::TextArea;
+use crate::ui::overlay::TextPrompt;
 
 /// A selected revision and its file paths, shared by direct file actions and their confirmation UI.
 pub struct SelectedFilesRequest {
@@ -48,14 +48,16 @@ impl RepoWindow {
         let noun = if count == 1 { "file" } else { "files" };
         let mut sorted_paths = request.paths.clone();
         sorted_paths.sort();
-        let input = cx.new(|cx| TextArea::new("", "Description for split change", false, 32., cx));
         self.text_modal = Some(TextModalState {
-            title: format!("Split {count} {noun} to new change").into(),
-            subtitle: SharedString::default(),
-            primary_label: "Split".into(),
+            prompt: TextPrompt::single_line(
+                format!("Split {count} {noun} to new change"),
+                SharedString::default(),
+                "",
+                "Description for split change",
+                "Split",
+                cx,
+            ),
             action: TextModalAction::SplitFiles(request),
-            input,
-            focus_pending: true,
             context: None,
             checkbox: Some(TextModalCheckbox {
                 label: "Parallel split".into(),

--- a/shell/gpui/src/repo/window/file_editor/view.rs
+++ b/shell/gpui/src/repo/window/file_editor/view.rs
@@ -1,10 +1,11 @@
 use gpui::{
-    AnyElement, Context, InteractiveElement, IntoElement, MouseButton, MouseDownEvent,
-    ParentElement, StatefulInteractiveElement, Styled, div, px, rgb, rgba,
+    AnyElement, Context, InteractiveElement, IntoElement, ParentElement,
+    StatefulInteractiveElement, Styled, div, px, rgb,
 };
 
 use crate::app::fonts;
 use crate::app::theme::Theme;
+use crate::ui::overlay::overlay_layer;
 use crate::ui::primitives::button;
 
 use super::super::RepoWindow;
@@ -119,19 +120,5 @@ pub(in crate::repo::window) fn file_editor_overlay(
                 .children(state.editor.clone()),
         );
 
-    div()
-        .absolute()
-        .top_0()
-        .left_0()
-        .right_0()
-        .bottom_0()
-        .flex()
-        .items_center()
-        .justify_center()
-        .p(px(16.))
-        .bg(rgba(0x00000033))
-        .occlude()
-        .on_mouse_down(MouseButton::Left, |_: &MouseDownEvent, _, _| {})
-        .child(panel)
-        .into_any_element()
+    overlay_layer().p(px(16.)).child(panel).into_any_element()
 }

--- a/shell/gpui/src/repo/window/note_composer.rs
+++ b/shell/gpui/src/repo/window/note_composer.rs
@@ -6,6 +6,7 @@ use jayjay_review::{NoteAnchor, NoteEntry, NoteSide};
 
 use super::note_menu::{AddNoteRequest, display_line_index_for};
 use super::{RepoWindow, TextModalAction, TextModalContext, TextModalState};
+use crate::ui::overlay::TextPrompt;
 use crate::ui::text_area::TextArea;
 
 #[derive(Clone)]
@@ -149,7 +150,6 @@ impl RepoWindow {
         cx: &mut Context<Self>,
     ) {
         let subtitle = target.path.clone();
-        let input = cx.new(|cx| TextArea::new(body, "Note", true, 130., cx));
         let context_text = context
             .iter()
             .map(|line| line.text.as_str())
@@ -160,12 +160,8 @@ impl RepoWindow {
             TextArea::selectable_code_block(context_text, context.len(), emphasized_line, cx)
         });
         self.text_modal = Some(TextModalState {
-            title: title.into(),
-            subtitle: subtitle.into(),
-            primary_label: primary_label.into(),
+            prompt: TextPrompt::multiline(title, subtitle, body, "Note", primary_label, 130., cx),
             action: TextModalAction::ReviewNote(target),
-            input,
-            focus_pending: true,
             context: Some(TextModalContext {
                 lines: context,
                 input: context_input,

--- a/shell/gpui/src/repo/window/rebase_confirmation.rs
+++ b/shell/gpui/src/repo/window/rebase_confirmation.rs
@@ -1,6 +1,6 @@
 use gpui::{
     AnyElement, Context, InteractiveElement, IntoElement, ParentElement,
-    StatefulInteractiveElement, Styled, div, px, rgb, rgba,
+    StatefulInteractiveElement, Styled, div, px, rgb,
 };
 use jayjay_core::ShortId;
 
@@ -9,6 +9,7 @@ use super::dag_drag::DagRebaseRequest;
 use crate::app::theme::Theme;
 use crate::app::{config, fonts};
 use crate::ui::icons::glyph;
+use crate::ui::overlay::{overlay_actions, overlay_card, overlay_header, overlay_layer};
 use crate::ui::primitives::{button, checkbox_row, icon_label};
 
 pub(super) fn rebase_confirmation_overlay(
@@ -26,54 +27,21 @@ pub(super) fn rebase_confirmation_overlay(
         config::update(cx, |config| config.features.confirm_drag_rebase ^= true);
     });
 
-    div()
-        .absolute()
-        .top_0()
-        .left_0()
-        .right_0()
-        .bottom_0()
-        .flex()
-        .items_center()
-        .justify_center()
-        .bg(rgba(0x00000033))
-        .occlude()
+    overlay_layer()
         .child(
-            div()
-                .flex()
-                .flex_col()
-                .gap(px(12.))
-                .w(px(380.))
-                .px(px(18.))
-                .py(px(16.))
-                .rounded_lg()
-                .border_1()
-                .border_color(rgb(t.border))
-                .bg(rgb(t.header_bg))
+            overlay_card(t, 380.)
                 .debug_selector(|| "rebase-confirmation".to_owned())
-                .child(
-                    div()
-                        .flex()
-                        .flex_row()
-                        .items_center()
-                        .child(
-                            icon_label(glyph::ARROW_UP, "Rebase Change?", 16., t.fg_dim)
-                                .text_size(px(14.))
-                                .font_weight(gpui::FontWeight::SEMIBOLD)
-                                .text_color(rgb(t.fg)),
-                        )
-                        .child(div().flex_1())
-                        .child(
-                            div()
-                                .font_family(fonts::mono())
-                                .text_size(px(11.))
-                                .text_color(rgb(t.fg_dim))
-                                .child(format!(
-                                    "{} -> {}",
-                                    request.source_commit_id.prefix(12),
-                                    request.dest_commit_id.prefix(12)
-                                )),
-                        ),
-                )
+                .child(overlay_header(
+                    glyph::ARROW_UP,
+                    t.fg_dim,
+                    "Rebase Change?",
+                    format!(
+                        "{} -> {}",
+                        request.source_commit_id.prefix(12),
+                        request.dest_commit_id.prefix(12)
+                    ),
+                    t,
+                ))
                 .child(summary_row(
                     "Change",
                     &request.source_label,
@@ -99,27 +67,14 @@ pub(super) fn rebase_confirmation_overlay(
                         .text_color(rgb(t.fg_dim))
                         .child("Any conflicts will appear inline after the rebase."),
                 )
-                .child(
-                    div()
-                        .flex()
-                        .flex_row()
-                        .justify_end()
-                        .gap(px(8.))
-                        .child(
-                            button("rebase-confirm-cancel", "Cancel", t, false)
-                                .debug_selector(|| "rebase-confirm-cancel".to_owned())
-                                .on_click(
-                                    cx.listener(|view, _, _, cx| view.cancel_drag_rebase(cx)),
-                                ),
-                        )
-                        .child(
-                            button("rebase-confirm-submit", "Rebase", t, true)
-                                .debug_selector(|| "rebase-confirm-submit".to_owned())
-                                .on_click(
-                                    cx.listener(|view, _, _, cx| view.confirm_drag_rebase(cx)),
-                                ),
-                        ),
-                ),
+                .child(overlay_actions(
+                    button("rebase-confirm-cancel", "Cancel", t, false)
+                        .debug_selector(|| "rebase-confirm-cancel".to_owned())
+                        .on_click(cx.listener(|view, _, _, cx| view.cancel_drag_rebase(cx))),
+                    button("rebase-confirm-submit", "Rebase", t, true)
+                        .debug_selector(|| "rebase-confirm-submit".to_owned())
+                        .on_click(cx.listener(|view, _, _, cx| view.confirm_drag_rebase(cx))),
+                )),
         )
         .into_any_element()
 }

--- a/shell/gpui/src/repo/window/render/interaction.rs
+++ b/shell/gpui/src/repo/window/render/interaction.rs
@@ -65,8 +65,13 @@ impl RepoWindow {
         {
             return true;
         }
-        self.text_modal
-            .as_ref()
-            .is_some_and(|modal| modal.input.read(cx).focus_handle(cx).is_focused(window))
+        self.text_modal.as_ref().is_some_and(|modal| {
+            modal
+                .prompt
+                .input
+                .read(cx)
+                .focus_handle(cx)
+                .is_focused(window)
+        })
     }
 }

--- a/shell/gpui/src/repo/window/render/overlays.rs
+++ b/shell/gpui/src/repo/window/render/overlays.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    AnyElement, Context, InteractiveElement, IntoElement, MouseButton, MouseDownEvent,
-    ParentElement, SharedString, StatefulInteractiveElement, Styled, div, px, rgb, rgba,
+    AnyElement, Context, InteractiveElement, IntoElement, ParentElement, SharedString,
+    StatefulInteractiveElement, Styled, div, px, rgb, rgba,
 };
 use jayjay_core::diff::DiffSpanStyle;
 
@@ -8,55 +8,20 @@ use crate::app::theme::{Theme, with_alpha};
 use crate::repo::window::note_composer::NoteContextLine;
 use crate::repo::window::{RepoWindow, TextModalState};
 use crate::ui::icons::glyph;
-use crate::ui::primitives::{button, checkbox_row, icon_label};
+use crate::ui::overlay::{PromptSlots, PromptStyle, overlay_card, overlay_header, overlay_layer};
+use crate::ui::primitives::{button, checkbox_row};
 
 pub(super) fn text_modal_overlay(
     modal: &TextModalState,
     t: &Theme,
     cx: &mut Context<RepoWindow>,
 ) -> AnyElement {
-    let mut panel = div()
-        .flex()
-        .flex_col()
-        .gap(px(12.))
-        .w(px(520.))
-        .max_w_full()
-        .px(px(18.))
-        .py(px(16.))
-        .rounded_lg()
-        .border_1()
-        .border_color(rgb(t.border))
-        .bg(rgb(t.header_bg))
-        .child(
-            div()
-                .flex()
-                .flex_row()
-                .items_center()
-                .child(
-                    icon_label(glyph::PENCIL_CIRCLE, modal.title.clone(), 16., t.fg_dim)
-                        .text_size(px(14.))
-                        .font_weight(gpui::FontWeight::SEMIBOLD)
-                        .text_color(rgb(t.fg)),
-                )
-                .child(div().flex_1())
-                .child(
-                    div()
-                        .font_family(crate::app::fonts::mono())
-                        .text_size(px(11.))
-                        .text_color(rgb(t.fg_dim))
-                        .child(modal.subtitle.clone()),
-                ),
-        );
-    if let Some(context) = modal.context.as_ref() {
-        // Composer's own key context: mod+Return saves only while this overlay's input has focus, never the commit box or other text modals, which don't set `context` so never wrap in it.
-        panel = panel.key_context("NoteComposer");
-        if !context.lines.is_empty() {
-            panel = panel.child(note_context_preview(&context.lines, &context.input, t));
-        }
-    }
-    panel = panel.child(modal.input.clone());
+    let before_input = modal.context.as_ref().and_then(|context| {
+        (!context.lines.is_empty()).then(|| note_context_preview(&context.lines, &context.input, t))
+    });
+    let mut after_input = Vec::new();
     if let Some(checkbox) = modal.checkbox.as_ref() {
-        panel = panel.child(
+        after_input.push(
             checkbox_row(
                 "text-modal-checkbox",
                 checkbox.label.clone(),
@@ -65,49 +30,25 @@ pub(super) fn text_modal_overlay(
             )
             .on_click(cx.listener(|view, _, _, cx| {
                 view.toggle_text_modal_checkbox(cx);
-            })),
+            }))
+            .into_any_element(),
         );
     }
     if let Some(paths) = modal.file_list.as_ref() {
-        panel = panel.child(file_list_preview(paths, t));
+        after_input.push(file_list_preview(paths, t));
     }
-    panel = panel.child(
-        div()
-            .flex()
-            .flex_row()
-            .justify_end()
-            .gap(px(8.))
-            .child(
-                button("text-modal-cancel", "Cancel", t, false).on_click(cx.listener(
-                    |view, _, _, cx| {
-                        view.close_text_modal(cx);
-                    },
-                )),
-            )
-            .child(
-                button("text-modal-primary", modal.primary_label.clone(), t, true).on_click(
-                    cx.listener(|view, _, _, cx| {
-                        view.submit_text_modal(cx);
-                    }),
-                ),
-            ),
-    );
-
-    div()
-        .absolute()
-        .top_0()
-        .left_0()
-        .right_0()
-        .bottom_0()
-        .flex()
-        .items_center()
-        .justify_center()
-        .bg(rgba(0x00000033))
-        // occlude() also swallows scroll-wheel events, or scrolling the modal's file list scrolls the diff underneath.
-        .occlude()
-        .on_mouse_down(MouseButton::Left, |_: &MouseDownEvent, _, _| {})
-        .child(panel)
-        .into_any_element()
+    modal.prompt.overlay(
+        &PromptStyle {
+            // Composer's own key context: mod+Return saves only while this overlay's input has focus, never the commit box or other text modals, which don't set `context` so never wrap in it.
+            key_context: modal.context.is_some().then_some("NoteComposer"),
+            ..PromptStyle::new(520., "text-modal-cancel", "text-modal-primary")
+        },
+        t,
+        cx,
+        PromptSlots::new(before_input, after_input),
+        |view, cx| view.close_text_modal(cx),
+        |view, cx| view.submit_text_modal(cx),
+    )
 }
 
 fn note_context_preview(
@@ -211,38 +152,16 @@ pub(super) fn error_overlay(
     t: &Theme,
     cx: &mut Context<RepoWindow>,
 ) -> AnyElement {
-    div()
-        .absolute()
-        .top_0()
-        .left_0()
-        .right_0()
-        .bottom_0()
-        .flex()
-        .items_center()
-        .justify_center()
-        .bg(rgba(0x00000033))
-        .on_mouse_down(MouseButton::Left, |_: &MouseDownEvent, _, _| {})
+    overlay_layer()
         .child(
-            div()
-                .flex()
-                .flex_col()
-                .gap(px(12.))
-                .w(px(460.))
-                .max_w_full()
-                .px(px(20.))
-                .py(px(18.))
-                .rounded_lg()
-                .border_1()
-                .border_color(rgb(t.border))
-                .bg(rgb(t.header_bg))
-                .child(
-                    div().flex().flex_row().items_center().child(
-                        icon_label(glyph::WARNING, "Operation failed", 18., t.error_fg)
-                            .text_size(px(14.))
-                            .font_weight(gpui::FontWeight::SEMIBOLD)
-                            .text_color(rgb(t.fg)),
-                    ),
-                )
+            overlay_card(t, 460.)
+                .child(overlay_header(
+                    glyph::WARNING,
+                    t.error_fg,
+                    "Operation failed",
+                    "",
+                    t,
+                ))
                 .child(
                     div()
                         .text_size(px(12.))
@@ -252,22 +171,14 @@ pub(super) fn error_overlay(
                 )
                 .child(
                     div().flex().flex_row().justify_end().child(
-                        div()
-                            .id("error-ok")
-                            .px(px(12.))
-                            .py(px(5.))
-                            .rounded_md()
-                            .bg(rgb(t.toggle_active_bg))
-                            .text_color(rgb(t.toggle_active_fg))
-                            .text_size(px(12.))
-                            .cursor_pointer()
+                        button("error-ok", "OK", t, true)
+                            .debug_selector(|| "error-ok".to_owned())
                             .on_click(cx.listener(|view, _, _, cx| {
                                 view.vm.update(cx, |vm, cx| {
                                     vm.clear_error();
                                     cx.notify();
                                 });
-                            }))
-                            .child("OK"),
+                            })),
                     ),
                 ),
         )

--- a/shell/gpui/src/repo/window/render/view.rs
+++ b/shell/gpui/src/repo/window/render/view.rs
@@ -1,4 +1,4 @@
-use gpui::{Context, Focusable, IntoElement, ParentElement, Render, Styled, Window, div};
+use gpui::{Context, IntoElement, ParentElement, Render, Styled, Window, div};
 
 use super::super::bookmark_picker::render_bookmark_picker;
 use super::super::confirmation::confirmation_overlay;
@@ -189,20 +189,8 @@ impl Render for RepoWindow {
         if self.diff_edit_take_pending_focus() {
             window.focus(&self.focus_handle, cx);
         }
-        if self.text_modal.as_ref().is_some_and(|m| m.focus_pending) {
-            let handle = self
-                .text_modal
-                .as_ref()
-                .unwrap()
-                .input
-                .read(cx)
-                .focus_handle(cx);
-            window.focus(&handle, cx);
-            if let Some(m) = self.text_modal.as_mut() {
-                m.focus_pending = false;
-            }
-        }
-        if let Some(modal) = self.text_modal.as_ref() {
+        if let Some(modal) = self.text_modal.as_mut() {
+            modal.prompt.take_focus(window, cx);
             root = root.child(text_modal_overlay(modal, &t, cx));
         }
         if let Some(confirmation) = self.confirmation.as_ref() {

--- a/shell/gpui/src/repo/window/stacked_pr_render.rs
+++ b/shell/gpui/src/repo/window/stacked_pr_render.rs
@@ -4,11 +4,12 @@ use super::stacked_pr_layers::layer_list;
 use super::stacked_pr_results::{centered_message, error_body, results_body};
 use crate::app::theme::Theme;
 use crate::ui::icons::{glyph, icon};
+use crate::ui::overlay::overlay_layer;
 use crate::ui::primitives::{button, icon_label};
 use gpui::prelude::FluentBuilder;
 use gpui::{
     AnyElement, Context, InteractiveElement, IntoElement, ParentElement,
-    StatefulInteractiveElement, Styled, div, px, rgb, rgba,
+    StatefulInteractiveElement, Styled, div, px, rgb,
 };
 use jayjay_core::Stack;
 
@@ -64,19 +65,7 @@ pub(super) fn stacked_pr_overlay(
         )
         .child(phase_body(state, t, cx));
 
-    div()
-        .absolute()
-        .top_0()
-        .left_0()
-        .right_0()
-        .bottom_0()
-        .flex()
-        .items_center()
-        .justify_center()
-        .bg(rgba(0x00000033))
-        .occlude()
-        .child(panel)
-        .into_any_element()
+    overlay_layer().child(panel).into_any_element()
 }
 
 fn phase_body(state: &StackedPrState, t: &Theme, cx: &mut Context<RepoWindow>) -> AnyElement {

--- a/shell/gpui/src/repo/window/view.rs
+++ b/shell/gpui/src/repo/window/view.rs
@@ -16,6 +16,7 @@ use crate::repo::view_model::RepoViewModel;
 use crate::ui::app_menu::AppMenuState;
 use crate::ui::context_menu::ContextMenuState;
 use crate::ui::input::LineInput;
+use crate::ui::overlay::TextPrompt;
 use crate::ui::text_area::TextArea;
 
 use super::bookmark_picker::BookmarkPickerState;
@@ -184,18 +185,26 @@ pub(crate) struct FeedbackState {
 }
 
 pub(crate) struct TextModalState {
-    pub(crate) title: SharedString,
-    pub(crate) subtitle: SharedString,
-    pub(crate) primary_label: SharedString,
+    pub(crate) prompt: TextPrompt,
     pub(crate) action: TextModalAction,
-    pub(crate) input: Entity<TextArea>,
-    pub(crate) focus_pending: bool,
     /// Read-only diff excerpt shown above the input; only the review-note composer sets this, and its presence is also the render-time signal that gates the `"NoteComposer"` key context so mod+Return doesn't grow a new shortcut on every other text modal.
     pub(crate) context: Option<TextModalContext>,
     /// Optional labeled toggle rendered below the input; only the split-files modal sets this (SwiftUI's "Parallel split" checkbox).
     pub(crate) checkbox: Option<TextModalCheckbox>,
     /// Optional monospace path list rendered below the checkbox; only the split-files modal sets this.
     pub(crate) file_list: Option<Vec<SharedString>>,
+}
+
+impl TextModalState {
+    pub(crate) fn new(prompt: TextPrompt, action: TextModalAction) -> Self {
+        Self {
+            prompt,
+            action,
+            context: None,
+            checkbox: None,
+            file_list: None,
+        }
+    }
 }
 
 pub(crate) struct TextModalContext {
@@ -480,7 +489,7 @@ impl RepoWindow {
 
     /// Mirrors `summary_input()`/`description_input()`: `pub` so the separate `tests/` crate can drive the review-note composer without reaching `pub(crate)` state.
     pub fn text_modal_input(&self) -> Option<Entity<TextArea>> {
-        self.text_modal.as_ref().map(|m| m.input.clone())
+        self.text_modal.as_ref().map(|m| m.prompt.input.clone())
     }
 
     pub fn text_modal_context_input(&self) -> Option<Entity<TextArea>> {
@@ -492,7 +501,7 @@ impl RepoWindow {
 
     /// Mirrors `text_modal_input()`: lets the tests crate assert header hints such as the New Workspace destination.
     pub fn text_modal_subtitle(&self) -> Option<SharedString> {
-        self.text_modal.as_ref().map(|m| m.subtitle.clone())
+        self.text_modal.as_ref().map(|m| m.prompt.subtitle.clone())
     }
 
     /// `None` when the current modal has no checkbox row (only the split-files modal does).

--- a/shell/gpui/src/repo/window/workspace.rs
+++ b/shell/gpui/src/repo/window/workspace.rs
@@ -2,10 +2,10 @@
 
 use std::path::{Path, PathBuf};
 
-use gpui::{AppContext, Context};
+use gpui::Context;
 
 use super::{RepoWindow, TextModalAction, TextModalState};
-use crate::ui::text_area::TextArea;
+use crate::ui::overlay::TextPrompt;
 
 impl RepoWindow {
     pub fn open_create_workspace(&mut self, cx: &mut Context<Self>) {
@@ -21,18 +21,17 @@ impl RepoWindow {
             self.show_toast("Repository has no parent directory for a workspace", cx);
             return;
         };
-        let input = cx.new(|cx| TextArea::new("", "Workspace name", false, 32., cx));
-        self.text_modal = Some(TextModalState {
-            title: "New Workspace".into(),
-            subtitle: format!("{}{}<name>", parent.display(), std::path::MAIN_SEPARATOR).into(),
-            primary_label: "Create".into(),
-            action: TextModalAction::CreateWorkspace(parent),
-            input,
-            focus_pending: true,
-            context: None,
-            checkbox: None,
-            file_list: None,
-        });
+        self.text_modal = Some(TextModalState::new(
+            TextPrompt::single_line(
+                "New Workspace",
+                format!("{}{}<name>", parent.display(), std::path::MAIN_SEPARATOR),
+                "",
+                "Workspace name",
+                "Create",
+                cx,
+            ),
+            TextModalAction::CreateWorkspace(parent),
+        ));
         cx.notify();
     }
 

--- a/shell/gpui/src/ui/loading_hud.rs
+++ b/shell/gpui/src/ui/loading_hud.rs
@@ -1,12 +1,13 @@
 use std::time::Duration;
 
 use gpui::{
-    Animation, AnimationExt as _, AnyElement, InteractiveElement, IntoElement, MouseButton,
-    MouseDownEvent, ParentElement, Styled, Transformation, div, percentage, px, rgb, rgba, svg,
+    Animation, AnimationExt as _, AnyElement, IntoElement, ParentElement, Styled, Transformation,
+    div, percentage, px, rgb, svg,
 };
 
 use crate::app::theme::Theme;
 use crate::ui::icons;
+use crate::ui::overlay::overlay_layer;
 
 pub(crate) fn loading_hud(t: &Theme) -> AnyElement {
     let spinner = svg()
@@ -35,18 +36,5 @@ pub(crate) fn loading_hud(t: &Theme) -> AnyElement {
         .child(spinner)
         .child("Loading...");
 
-    div()
-        .absolute()
-        .top_0()
-        .left_0()
-        .right_0()
-        .bottom_0()
-        .flex()
-        .items_center()
-        .justify_center()
-        .bg(rgba(0x00000033))
-        .occlude()
-        .on_mouse_down(MouseButton::Left, |_: &MouseDownEvent, _, _| {})
-        .child(hud)
-        .into_any_element()
+    overlay_layer().child(hud).into_any_element()
 }

--- a/shell/gpui/src/ui/mod.rs
+++ b/shell/gpui/src/ui/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod logo;
 pub(crate) mod merge_editor;
 pub(crate) mod merge_nav;
 pub mod navigation;
+pub(crate) mod overlay;
 pub mod primitives;
 pub mod scrollbar;
 pub mod text_area;

--- a/shell/gpui/src/ui/overlay/chrome.rs
+++ b/shell/gpui/src/ui/overlay/chrome.rs
@@ -1,0 +1,75 @@
+use gpui::{
+    Div, FontWeight, InteractiveElement, IntoElement, MouseButton, MouseDownEvent, ParentElement,
+    SharedString, Styled, div, px, rgb, rgba,
+};
+
+use crate::app::theme::Theme;
+use crate::ui::primitives::icon_label;
+
+/// Dimmed, occluding full-window layer. Centers its child; callers add the card or sheet.
+pub(crate) fn overlay_layer() -> Div {
+    div()
+        .absolute()
+        .top_0()
+        .left_0()
+        .right_0()
+        .bottom_0()
+        .flex()
+        .items_center()
+        .justify_center()
+        .bg(rgba(0x00000033))
+        // occlude() also swallows scroll-wheel events, or scrolling a modal list scrolls the view underneath.
+        .occlude()
+        .on_mouse_down(MouseButton::Left, |_: &MouseDownEvent, _, _| {})
+}
+
+pub(crate) fn overlay_card(t: &Theme, width: f32) -> Div {
+    div()
+        .flex()
+        .flex_col()
+        .gap(px(12.))
+        .w(px(width))
+        .max_w_full()
+        .px(px(18.))
+        .py(px(16.))
+        .rounded_lg()
+        .border_1()
+        .border_color(rgb(t.border))
+        .bg(rgb(t.header_bg))
+}
+
+pub(crate) fn overlay_header(
+    icon: &'static str,
+    icon_color: u32,
+    title: impl Into<SharedString>,
+    subtitle: impl Into<SharedString>,
+    t: &Theme,
+) -> Div {
+    let subtitle = subtitle.into();
+    let mut row = div().flex().flex_row().items_center().child(
+        icon_label(icon, title, 16., icon_color)
+            .text_size(px(14.))
+            .font_weight(FontWeight::SEMIBOLD)
+            .text_color(rgb(t.fg)),
+    );
+    if !subtitle.is_empty() {
+        row = row.child(div().flex_1()).child(
+            div()
+                .font_family(crate::app::fonts::mono())
+                .text_size(px(11.))
+                .text_color(rgb(t.fg_dim))
+                .child(subtitle),
+        );
+    }
+    row
+}
+
+pub(crate) fn overlay_actions(cancel: impl IntoElement, primary: impl IntoElement) -> Div {
+    div()
+        .flex()
+        .flex_row()
+        .justify_end()
+        .gap(px(8.))
+        .child(cancel)
+        .child(primary)
+}

--- a/shell/gpui/src/ui/overlay/mod.rs
+++ b/shell/gpui/src/ui/overlay/mod.rs
@@ -1,0 +1,5 @@
+mod chrome;
+mod prompt;
+
+pub(crate) use chrome::{overlay_actions, overlay_card, overlay_header, overlay_layer};
+pub(crate) use prompt::{PromptSlots, PromptStyle, TextPrompt};

--- a/shell/gpui/src/ui/overlay/prompt.rs
+++ b/shell/gpui/src/ui/overlay/prompt.rs
@@ -1,0 +1,183 @@
+use gpui::{
+    AnyElement, App, AppContext, Context, Entity, Focusable, InteractiveElement, IntoElement,
+    ParentElement, SharedString, StatefulInteractiveElement, Styled, Window, div,
+};
+
+use super::{overlay_actions, overlay_card, overlay_header, overlay_layer};
+use crate::app::theme::Theme;
+use crate::ui::icons::glyph;
+use crate::ui::primitives::button;
+use crate::ui::text_area::TextArea;
+
+/// Window-agnostic single-field prompt. Each window owns one and supplies submit/cancel.
+pub(crate) struct TextPrompt {
+    pub title: SharedString,
+    pub subtitle: SharedString,
+    pub primary_label: SharedString,
+    pub input: Entity<TextArea>,
+    focus_pending: bool,
+}
+
+pub(crate) struct PromptStyle {
+    pub width: f32,
+    pub input_id: Option<&'static str>,
+    pub cancel_id: &'static str,
+    pub primary_id: &'static str,
+    pub key_context: Option<&'static str>,
+    pub primary_enabled: bool,
+}
+
+impl PromptStyle {
+    pub fn new(width: f32, cancel_id: &'static str, primary_id: &'static str) -> Self {
+        Self {
+            width,
+            input_id: None,
+            cancel_id,
+            primary_id,
+            key_context: None,
+            primary_enabled: true,
+        }
+    }
+}
+
+pub(crate) struct PromptSlots {
+    before_input: Vec<AnyElement>,
+    after_input: Vec<AnyElement>,
+}
+
+impl PromptSlots {
+    pub fn new(
+        before_input: impl IntoIterator<Item = AnyElement>,
+        after_input: impl IntoIterator<Item = AnyElement>,
+    ) -> Self {
+        Self {
+            before_input: before_input.into_iter().collect(),
+            after_input: after_input.into_iter().collect(),
+        }
+    }
+}
+
+impl TextPrompt {
+    pub fn single_line<V: 'static>(
+        title: impl Into<SharedString>,
+        subtitle: impl Into<SharedString>,
+        initial: impl Into<SharedString>,
+        placeholder: impl Into<SharedString>,
+        primary_label: impl Into<SharedString>,
+        cx: &mut Context<V>,
+    ) -> Self {
+        Self::build(
+            title,
+            subtitle,
+            initial,
+            placeholder,
+            primary_label,
+            false,
+            32.,
+            cx,
+        )
+    }
+
+    pub fn multiline<V: 'static>(
+        title: impl Into<SharedString>,
+        subtitle: impl Into<SharedString>,
+        initial: impl Into<SharedString>,
+        placeholder: impl Into<SharedString>,
+        primary_label: impl Into<SharedString>,
+        height: f32,
+        cx: &mut Context<V>,
+    ) -> Self {
+        Self::build(
+            title,
+            subtitle,
+            initial,
+            placeholder,
+            primary_label,
+            true,
+            height,
+            cx,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build<V: 'static>(
+        title: impl Into<SharedString>,
+        subtitle: impl Into<SharedString>,
+        initial: impl Into<SharedString>,
+        placeholder: impl Into<SharedString>,
+        primary_label: impl Into<SharedString>,
+        multiline: bool,
+        height: f32,
+        cx: &mut Context<V>,
+    ) -> Self {
+        let input = cx.new(|cx| TextArea::new(initial, placeholder, multiline, height, cx));
+        Self {
+            title: title.into(),
+            subtitle: subtitle.into(),
+            primary_label: primary_label.into(),
+            input,
+            focus_pending: true,
+        }
+    }
+
+    pub fn take_focus(&mut self, window: &mut Window, cx: &mut App) {
+        if !self.focus_pending {
+            return;
+        }
+        window.focus(&self.input.read(cx).focus_handle(cx), cx);
+        self.focus_pending = false;
+    }
+
+    pub fn text(&self, cx: &App) -> String {
+        self.input.read(cx).text()
+    }
+
+    pub(crate) fn overlay<V: 'static>(
+        &self,
+        style: &PromptStyle,
+        t: &Theme,
+        cx: &mut Context<V>,
+        slots: PromptSlots,
+        on_cancel: impl Fn(&mut V, &mut Context<V>) + 'static,
+        on_submit: impl Fn(&mut V, &mut Context<V>) + 'static,
+    ) -> AnyElement {
+        let mut panel = overlay_card(t, style.width).child(overlay_header(
+            glyph::PENCIL_CIRCLE,
+            t.fg_dim,
+            self.title.clone(),
+            self.subtitle.clone(),
+            t,
+        ));
+        if let Some(key_context) = style.key_context {
+            panel = panel.key_context(key_context);
+        }
+        for child in slots.before_input {
+            panel = panel.child(child);
+        }
+        panel = panel.child(match style.input_id {
+            Some(id) => div()
+                .id(id)
+                .debug_selector(|| id.to_owned())
+                .child(self.input.clone())
+                .into_any_element(),
+            None => self.input.clone().into_any_element(),
+        });
+        for child in slots.after_input {
+            panel = panel.child(child);
+        }
+        let primary = button(style.primary_id, self.primary_label.clone(), t, true)
+            .debug_selector(|| style.primary_id.to_owned());
+        let primary = if style.primary_enabled {
+            primary.on_click(cx.listener(move |view, _, _, cx| on_submit(view, cx)))
+        } else {
+            primary.opacity(0.45)
+        };
+        panel = panel.child(overlay_actions(
+            button(style.cancel_id, "Cancel", t, false)
+                .debug_selector(|| style.cancel_id.to_owned())
+                .on_click(cx.listener(move |view, _, _, cx| on_cancel(view, cx))),
+            primary,
+        ));
+        overlay_layer().child(panel).into_any_element()
+    }
+}

--- a/shell/gpui/src/windows/bookmark_manager.rs
+++ b/shell/gpui/src/windows/bookmark_manager.rs
@@ -17,7 +17,8 @@ use crate::app::theme::{Theme, observe_window_appearance, theme};
 use crate::repo::revset;
 use crate::repo::view_model::RepoViewModel;
 use crate::repo::window::RepoWindow;
-use crate::ui::text_area::TextArea;
+use crate::ui::overlay::{PromptSlots, PromptStyle, TextPrompt};
+use crate::ui::text_area::{Newline, TextArea};
 use chrome::{BookmarkStats, footer, header, placeholder, placeholder_err, stats_bar};
 use context_menu::render_context_menu as render_bookmark_context_menu;
 use context_menu::{BookmarkContextAction, BookmarkContextMenuState, bookmark_menu_items};
@@ -34,6 +35,7 @@ pub struct BookmarkManagerView {
     loading: bool,
     error: Option<SharedString>,
     context_menu: Option<BookmarkContextMenuState>,
+    rename: Option<TextPrompt>,
     focus_handle: FocusHandle,
 }
 
@@ -86,6 +88,7 @@ impl BookmarkManagerView {
                             loading: false,
                             error: None,
                             context_menu: None,
+                            rename: None,
                             focus_handle: cx.focus_handle(),
                         }
                     })
@@ -181,6 +184,65 @@ impl BookmarkManagerView {
         }
     }
 
+    fn open_rename_modal(&mut self, name: String, cx: &mut Context<Self>) {
+        self.error = None;
+        self.rename = Some(TextPrompt::single_line(
+            "Rename Bookmark",
+            name.clone(),
+            name,
+            "New name",
+            "Rename",
+            cx,
+        ));
+        cx.notify();
+    }
+
+    fn close_rename_modal(&mut self, cx: &mut Context<Self>) {
+        if self.rename.take().is_some() {
+            self.error = None;
+            cx.notify();
+        }
+    }
+
+    fn ready_rename(&self, cx: &App) -> Option<(String, String)> {
+        let rename = self.rename.as_ref()?;
+        if self.loading {
+            return None;
+        }
+        let new_name = rename.text(cx);
+        let new_name = new_name.trim();
+        if new_name.is_empty()
+            || new_name == rename.subtitle.as_ref()
+            || !jayjay_core::is_valid_bookmark_name(new_name)
+        {
+            return None;
+        }
+        Some((rename.subtitle.to_string(), new_name.to_string()))
+    }
+
+    fn submit_rename(&mut self, cx: &mut Context<Self>) {
+        let Some((old_name, new_name)) = self.ready_rename(cx) else {
+            return;
+        };
+        self.run_bookmark_action(
+            move |repo| repo.rename_bookmark(&old_name, &new_name),
+            |view, cx| view.close_rename_modal(cx),
+            cx,
+        );
+    }
+
+    fn dismiss_overlay(&mut self, cx: &mut Context<Self>) -> bool {
+        if self.rename.is_some() {
+            self.close_rename_modal(cx);
+            true
+        } else if self.context_menu.is_some() {
+            self.close_context_menu(cx);
+            true
+        } else {
+            false
+        }
+    }
+
     fn toggle_deleted(&mut self, cx: &mut Context<Self>) {
         self.show_deleted ^= true;
         cx.notify();
@@ -207,6 +269,7 @@ impl BookmarkManagerView {
                 cx,
             ),
             BookmarkContextAction::OpenPullRequest(name) => self.open_pull_request(name, cx),
+            BookmarkContextAction::Rename(name) => self.open_rename_modal(name, cx),
             BookmarkContextAction::Delete(name) => {
                 self.run_bookmark_action(move |repo| repo.delete_bookmark(&name), |_, _| {}, cx)
             }
@@ -225,12 +288,42 @@ impl Focusable for BookmarkManagerView {
 }
 
 impl Render for BookmarkManagerView {
-    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if let Some(rename) = self.rename.as_mut() {
+            rename.take_focus(window, cx);
+        }
         let t = theme(cx).clone();
         let context_menu_overlay = self
             .context_menu
             .as_ref()
             .map(|state| render_bookmark_context_menu(state, &t, &cx.entity()));
+        let can_submit_rename = self.ready_rename(cx).is_some();
+        let rename_error = self.error.clone();
+        let rename_modal_overlay = self.rename.as_ref().map(|rename| {
+            rename.overlay(
+                &PromptStyle {
+                    input_id: Some("bookmark-rename-input"),
+                    primary_enabled: can_submit_rename,
+                    ..PromptStyle::new(360., "bookmark-rename-cancel", "bookmark-rename-primary")
+                },
+                &t,
+                cx,
+                PromptSlots::new(
+                    [],
+                    rename_error.map(|message| {
+                        div()
+                            .id("bookmark-rename-error")
+                            .debug_selector(|| "bookmark-rename-error".to_owned())
+                            .text_size(px(12.))
+                            .text_color(rgb(t.error_fg))
+                            .child(message)
+                            .into_any_element()
+                    }),
+                ),
+                |view, cx| view.close_rename_modal(cx),
+                |view, cx| view.submit_rename(cx),
+            )
+        });
         let query = self.filter.read(cx).text().trim().to_lowercase();
         let stats = BookmarkStats::from_bookmarks(&self.bookmarks);
         let mut bookmarks: Vec<_> = self
@@ -244,9 +337,11 @@ impl Render for BookmarkManagerView {
             bookmarks.retain(|bookmark| bookmark.name.to_lowercase().contains(&query));
         }
         let count = bookmarks.len();
-        let body = if self.loading {
+        let body = if self.rename.is_none() && self.loading {
             placeholder("Loading bookmarks...", &t)
-        } else if let Some(error) = self.error.clone() {
+        } else if self.rename.is_none()
+            && let Some(error) = self.error.clone()
+        {
             placeholder_err(&error, &t)
         } else if count == 0 {
             placeholder("No bookmarks found.", &t)
@@ -258,17 +353,18 @@ impl Render for BookmarkManagerView {
             .track_focus(&self.focus_handle)
             .key_context("BookmarkManagerView")
             .on_action(cx.listener(|view, _: &CloseWindow, window, cx| {
-                if view.context_menu.is_some() {
-                    view.close_context_menu(cx);
-                } else {
+                if !view.dismiss_overlay(cx) {
                     window.remove_window();
                 }
             }))
             .on_action(cx.listener(|view, _: &Dismiss, window, cx| {
-                if view.context_menu.is_some() {
-                    view.close_context_menu(cx);
-                } else {
+                if !view.dismiss_overlay(cx) {
                     window.remove_window();
+                }
+            }))
+            .on_action(cx.listener(|view, _: &Newline, _, cx| {
+                if view.rename.is_some() {
+                    view.submit_rename(cx);
                 }
             }))
             .relative()
@@ -283,6 +379,9 @@ impl Render for BookmarkManagerView {
             .child(footer(&t, cx));
         if let Some(menu) = context_menu_overlay {
             root = root.child(menu);
+        }
+        if let Some(modal) = rename_modal_overlay {
+            root = root.child(modal);
         }
         root
     }

--- a/shell/gpui/src/windows/bookmark_manager/context_menu.rs
+++ b/shell/gpui/src/windows/bookmark_manager/context_menu.rs
@@ -18,6 +18,7 @@ pub(super) enum BookmarkContextAction {
     Push(String),
     Resolve(String),
     OpenPullRequest(String),
+    Rename(String),
     Delete(String),
     Forget(String),
 }
@@ -102,6 +103,11 @@ pub(super) fn bookmark_menu_items(
             BookmarkContextAction::Forget(bookmark.name.clone()),
         ));
     } else if bookmark.has_local_target {
+        items.push(BookmarkContextMenuItem::new(
+            "Rename",
+            glyph::PENCIL_CIRCLE,
+            BookmarkContextAction::Rename(bookmark.name.clone()),
+        ));
         items.push(BookmarkContextMenuItem::new(
             "Delete",
             glyph::X_CIRCLE,
@@ -267,7 +273,14 @@ mod tests {
 
         assert_eq!(
             labels,
-            ["Reveal", "Diff", "Push", "Pull Request on GitHub", "Delete",]
+            [
+                "Reveal",
+                "Diff",
+                "Push",
+                "Pull Request on GitHub",
+                "Rename",
+                "Delete",
+            ]
         );
     }
 }

--- a/shell/gpui/tests/gpui/repo_bookmark_manager.rs
+++ b/shell/gpui/tests/gpui/repo_bookmark_manager.rs
@@ -21,6 +21,40 @@ fn open_manager(view: &Entity<RepoWindow>, repo_cx: &mut VisualTestContext) -> V
     manager_cx
 }
 
+fn open_rename(manager_cx: &mut VisualTestContext) {
+    let row = manager_cx
+        .debug_bounds("bookmark-row-rename-me")
+        .expect("bookmark to rename");
+    manager_cx.simulate_mouse_down(row.center(), MouseButton::Right, Modifiers::default());
+    settle_visual(manager_cx);
+    let rename = manager_cx
+        .debug_bounds("bookmark-context-Rename")
+        .expect("rename menu item");
+    manager_cx.simulate_click(rename.center(), Modifiers::default());
+    settle_visual(manager_cx);
+}
+
+fn replace_rename_name(manager_cx: &mut VisualTestContext, name: &str) {
+    let input = manager_cx
+        .debug_bounds("bookmark-rename-input")
+        .expect("rename input");
+    manager_cx.simulate_click(input.center(), Modifiers::default());
+    manager_cx.simulate_keystrokes(&format!("{}-a", jayjay_gpui::platform::MOD_KEY));
+    manager_cx.simulate_input(name);
+    settle_visual(manager_cx);
+}
+
+fn live_bookmark_names(path: &std::path::Path) -> Vec<String> {
+    Repo::open(path)
+        .expect("open fixture")
+        .list_bookmarks()
+        .expect("list bookmarks")
+        .into_iter()
+        .filter(|bookmark| !bookmark.is_deleted)
+        .map(|bookmark| bookmark.name)
+        .collect()
+}
+
 #[gpui::test]
 fn bookmark_count_and_manager_ignore_deleted_until_requested(cx: &mut TestAppContext) {
     let fixture = LinearFixture::build();
@@ -91,4 +125,91 @@ fn bookmark_manager_push_goes_through_the_repo_window(cx: &mut TestAppContext) {
             "the repo window's push pipeline reports the result"
         );
     });
+}
+
+#[gpui::test]
+fn bookmark_manager_rename_rewrites_the_local_name(cx: &mut TestAppContext) {
+    let fixture = LinearFixture::build();
+    run_jj_in(
+        &fixture.path,
+        &["bookmark", "create", "rename-me", "-r", "@"],
+    );
+    let (view, repo_cx) = open_fixture(&fixture, cx);
+    let mut manager_cx = open_manager(&view, repo_cx);
+    open_rename(&mut manager_cx);
+
+    assert!(
+        manager_cx.debug_bounds("bookmark-rename-primary").is_some(),
+        "rename modal should open"
+    );
+    replace_rename_name(&mut manager_cx, "renamed");
+    let primary = manager_cx
+        .debug_bounds("bookmark-rename-primary")
+        .expect("rename submit");
+    manager_cx.simulate_click(primary.center(), Modifiers::default());
+    settle_visual(&mut manager_cx);
+
+    assert!(manager_cx.debug_bounds("bookmark-row-renamed").is_some());
+    assert!(manager_cx.debug_bounds("bookmark-row-rename-me").is_none());
+    assert!(manager_cx.debug_bounds("bookmark-rename-primary").is_none());
+
+    let names = live_bookmark_names(&fixture.path);
+    assert!(names.iter().any(|name| name == "renamed"));
+    assert!(!names.iter().any(|name| name == "rename-me"));
+}
+
+#[gpui::test]
+fn bookmark_manager_rename_keeps_the_prompt_when_the_name_is_taken(cx: &mut TestAppContext) {
+    let fixture = LinearFixture::build();
+    run_jj_in(
+        &fixture.path,
+        &["bookmark", "create", "rename-me", "-r", "@"],
+    );
+    let (view, repo_cx) = open_fixture(&fixture, cx);
+    let mut manager_cx = open_manager(&view, repo_cx);
+    open_rename(&mut manager_cx);
+
+    replace_rename_name(&mut manager_cx, "main");
+    let primary = manager_cx
+        .debug_bounds("bookmark-rename-primary")
+        .expect("rename submit");
+    manager_cx.simulate_click(primary.center(), Modifiers::default());
+    settle_visual(&mut manager_cx);
+
+    assert!(
+        manager_cx.debug_bounds("bookmark-rename-primary").is_some(),
+        "occupied rename must keep the prompt open"
+    );
+    assert!(manager_cx.debug_bounds("bookmark-rename-error").is_some());
+    assert!(manager_cx.debug_bounds("bookmark-row-rename-me").is_some());
+    assert!(manager_cx.debug_bounds("bookmark-row-main").is_some());
+
+    let names = live_bookmark_names(&fixture.path);
+    assert!(names.iter().any(|name| name == "rename-me"));
+    assert!(names.iter().any(|name| name == "main"));
+}
+
+#[gpui::test]
+fn bookmark_manager_rename_ignores_an_unchanged_name(cx: &mut TestAppContext) {
+    let fixture = LinearFixture::build();
+    run_jj_in(
+        &fixture.path,
+        &["bookmark", "create", "rename-me", "-r", "@"],
+    );
+    let (view, repo_cx) = open_fixture(&fixture, cx);
+    let mut manager_cx = open_manager(&view, repo_cx);
+    open_rename(&mut manager_cx);
+
+    let primary = manager_cx
+        .debug_bounds("bookmark-rename-primary")
+        .expect("rename submit");
+    manager_cx.simulate_click(primary.center(), Modifiers::default());
+    settle_visual(&mut manager_cx);
+
+    assert!(
+        manager_cx.debug_bounds("bookmark-rename-primary").is_some(),
+        "unchanged name must not submit"
+    );
+    assert!(manager_cx.debug_bounds("bookmark-rename-error").is_none());
+    assert!(manager_cx.debug_bounds("bookmark-row-rename-me").is_some());
 }


### PR DESCRIPTION
The Bookmark Manager context menu had no Rename entry even though SwiftUI already exposes `renameBookmark` via `Repo::rename_bookmark`.

This adds **Rename** for local bookmarks in the manager menu. Choosing it opens a modal prefilled with the current name; submit calls the same core rename used by SwiftUI.

The modal uses a shared `ui/overlay` text prompt (dimmed layer, card, input, cancel/primary) so every GPUI window can host the same overlay. Repo-window text modals, confirmations, editors, and the loading HUD now go through that chrome.

- Menu unit test now expects Rename next to Delete
- Component test renames a local bookmark through the menu and modal

User-facing docs and the shell-parity matrix are left for the release docs pass.