### PR TITLE
feat(dag): insert a change before or after a revision (jj new -B / -A)

### DIFF
--- a/agents/design.md
+++ b/agents/design.md
@@ -25,7 +25,7 @@ The public site at [jayjay.hewig.dev](https://jayjay.hewig.dev) (sources in `doc
 ## Interaction Principles
 
 1. **Native first** - Use SwiftUI forms, system fonts, SF Symbols, and platform conventions.
-2. **Keyboard-driven** - Every action should be reachable through command palette or shortcut.
+2. **Keyboard-driven** - Every major, high-frequency action should be reachable through command palette or shortcut.
 3. **Dense, not cluttered** - Optimize for scanning, comparison, and repeated developer workflows.
 4. **Performance is UX** - Prefer quiet refreshes over loading spinners where possible.
 5. **Jujutsu-native** - Embrace changes, bookmarks, revsets, and working-copy semantics rather than forcing git branch/commit mental models.

--- a/crates/jayjay-core/src/dag.rs
+++ b/crates/jayjay-core/src/dag.rs
@@ -215,6 +215,11 @@ mod tests {
                 is_empty: false,
                 is_immutable: false,
                 is_divergent: false,
+                new_change: crate::types::NewChangeEligibility {
+                    on_top: true,
+                    before: true,
+                    after: true,
+                },
             },
             edges: parents
                 .iter()

--- a/crates/jayjay-core/src/repo/log.rs
+++ b/crates/jayjay-core/src/repo/log.rs
@@ -15,6 +15,11 @@ use super::Repo;
 use super::support::block_on;
 use crate::types::*;
 
+pub(crate) struct ImmutableIds {
+    pub(crate) commits: HashSet<String>,
+    pub(crate) parents: HashSet<String>,
+}
+
 impl Repo {
     pub fn log(&self, revset_str: &str) -> CoreResult<Vec<ChangeInfo>> {
         let repo = self.get_repo();
@@ -37,7 +42,7 @@ impl Repo {
         repo: &Arc<ReadonlyRepo>,
         revset: Box<dyn jj_lib::revset::Revset + 'a>,
     ) -> CoreResult<Vec<ChangeInfo>> {
-        let immutable_ids = self.immutable_commit_ids(repo);
+        let immutable_ids = self.immutable_ids(repo);
         let mut changes = Vec::new();
         let mut stream = revset.stream();
         while let Some(result) = block_on(stream.next()) {
@@ -60,7 +65,7 @@ impl Repo {
 
     pub fn log_graph(&self, revset_str: &str) -> CoreResult<Vec<GraphEntry>> {
         let repo = self.get_repo();
-        let immutable_ids = self.immutable_commit_ids(&repo);
+        let immutable_ids = self.immutable_ids(&repo);
         let revset_result = self.evaluate_revset(&repo, revset_str)?;
 
         let mut entries = Vec::new();
@@ -124,18 +129,39 @@ impl Repo {
         repo: &Arc<ReadonlyRepo>,
         commit: &jj_lib::commit::Commit,
     ) -> CoreResult<bool> {
-        let revset = self.evaluate_revset(repo, "immutable()")?;
+        self.revset_contains(repo, "immutable()", commit)
+    }
+
+    pub(crate) fn has_immutable_child(
+        &self,
+        repo: &Arc<ReadonlyRepo>,
+        commit: &jj_lib::commit::Commit,
+    ) -> CoreResult<bool> {
+        self.revset_contains(repo, "parents(immutable())", commit)
+    }
+
+    fn revset_contains(
+        &self,
+        repo: &Arc<ReadonlyRepo>,
+        revset_str: &str,
+        commit: &jj_lib::commit::Commit,
+    ) -> CoreResult<bool> {
+        let revset = self.evaluate_revset(repo, revset_str)?;
         block_on(revset.containing_fn()(commit.id())).map_err(|e| CoreError::Internal {
-            message: format!("immutable check: {e}"),
+            message: format!("{revset_str} check: {e}"),
         })
     }
 
-    /// Evaluate `immutable()` once and return the set of commit ID hex strings.
-    fn immutable_commit_ids(
-        &self,
-        repo: &std::sync::Arc<jj_lib::repo::ReadonlyRepo>,
-    ) -> HashSet<String> {
-        let Ok(result) = self.evaluate_revset(repo, "immutable()") else {
+    fn immutable_ids(&self, repo: &Arc<ReadonlyRepo>) -> ImmutableIds {
+        ImmutableIds {
+            commits: self.revset_commit_ids(repo, "immutable()"),
+            parents: self.revset_commit_ids(repo, "parents(immutable())"),
+        }
+    }
+
+    /// Evaluate `revset_str` once and return its commit ID hex strings; an invalid revset yields an empty set so display loading stays resilient.
+    fn revset_commit_ids(&self, repo: &Arc<ReadonlyRepo>, revset_str: &str) -> HashSet<String> {
+        let Ok(result) = self.evaluate_revset(repo, revset_str) else {
             return HashSet::new();
         };
         let mut stream = result.stream();
@@ -209,7 +235,7 @@ impl Repo {
         count
     }
 
-    fn evaluate_typed_revset<'a>(
+    pub(crate) fn evaluate_typed_revset<'a>(
         &self,
         repo: &'a Arc<ReadonlyRepo>,
         expression: Arc<UserRevsetExpression>,

--- a/crates/jayjay-core/src/repo/mutations.rs
+++ b/crates/jayjay-core/src/repo/mutations.rs
@@ -1,5 +1,11 @@
+use std::sync::Arc;
+
+use futures::TryStreamExt as _;
+use jj_lib::backend::CommitId;
+use jj_lib::commit::Commit;
 use jj_lib::object_id::ObjectId as _;
-use jj_lib::repo::Repo as _;
+use jj_lib::repo::{ReadonlyRepo, Repo as _};
+use jj_lib::revset::UserRevsetExpression;
 
 use super::Repo;
 use super::path_operands::fileset_literal;
@@ -40,6 +46,70 @@ impl Repo {
                 self.edit_working_copy_commit(repo_mut, &new_commit, "edit working copy")
             },
         )
+    }
+
+    pub fn new_change_inserted(
+        &self,
+        rev: &str,
+        position: InsertPosition,
+        message: &str,
+    ) -> CoreResult<()> {
+        self.refresh_working_copy()?;
+        self.with_resolved_commit_transaction(rev, "new change", true, |repo, target, repo_mut| {
+            let (parents, displaced) = match position {
+                InsertPosition::Before => {
+                    self.ensure_commit_mutable(repo, target, rev)?;
+                    let parents = block_on_result("load parents", target.parents())?;
+                    (parents, vec![target.clone()])
+                }
+                InsertPosition::After => {
+                    let children = self.children(repo, target)?;
+                    for child in &children {
+                        self.ensure_commit_mutable(repo, child, &format!("a child of {rev}"))?;
+                    }
+                    (vec![target.clone()], children)
+                }
+            };
+            let tree = block_on_result(
+                "merge parent trees",
+                jj_lib::rewrite::merge_commit_trees(repo.as_ref(), &parents),
+            )?;
+            let parent_ids: Vec<CommitId> =
+                parents.iter().map(|parent| parent.id().clone()).collect();
+            let new_commit = repo_mut
+                .new_commit(parent_ids.clone(), tree)
+                .set_description(message)
+                .write();
+            let new_commit = block_on_result("new change", new_commit)?;
+            for commit in displaced {
+                let mut new_parents: Vec<CommitId> = Vec::new();
+                for parent_id in commit.parent_ids() {
+                    let parent_id = if parent_ids.contains(parent_id) {
+                        new_commit.id()
+                    } else {
+                        parent_id
+                    };
+                    if !new_parents.contains(parent_id) {
+                        new_parents.push(parent_id.clone());
+                    }
+                }
+                let rebase = jj_lib::rewrite::rebase_commit(repo_mut, commit, new_parents);
+                block_on_result("rebase through new change", rebase)?;
+            }
+            self.edit_working_copy_commit(repo_mut, &new_commit, "edit working copy")
+        })
+    }
+
+    fn children(&self, repo: &Arc<ReadonlyRepo>, commit: &Commit) -> CoreResult<Vec<Commit>> {
+        let expression = UserRevsetExpression::commit(commit.id().clone()).children();
+        let revset = self.evaluate_typed_revset(repo, expression)?;
+        let ids: Vec<CommitId> = block_on_result("children revset", revset.stream().try_collect())?;
+        ids.iter()
+            .map(|id| repo.store().get_commit(id))
+            .collect::<Result<_, _>>()
+            .map_err(|e| CoreError::Internal {
+                message: format!("get child: {e}"),
+            })
     }
 
     pub fn squash(&self, rev: &str, into: Option<&str>) -> CoreResult<()> {
@@ -120,8 +190,8 @@ impl Repo {
     pub fn rebase(&self, rev: &str, dest: &str) -> CoreResult<String> {
         self.refresh_working_copy()?;
         let repo = self.get_repo();
-        let commit = self.resolve_commit(&repo, rev)?;
-        let dest_commit = self.resolve_commit(&repo, dest)?;
+        let commit = self.follow_rewrites(&repo, self.resolve_commit(&repo, rev)?, rev)?;
+        let dest_commit = self.follow_rewrites(&repo, self.resolve_commit(&repo, dest)?, dest)?;
         // jj-lib rewrites even an already-in-place commit, which would only record an operation and stale any other checkout of the change.
         if commit.parent_ids() == std::slice::from_ref(dest_commit.id()) {
             return Ok(commit.id().hex());

--- a/crates/jayjay-core/src/repo/resolve/changes.rs
+++ b/crates/jayjay-core/src/repo/resolve/changes.rs
@@ -8,6 +8,7 @@ use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo::Repo as JjRepo;
 
 use super::super::Repo;
+use super::super::log::ImmutableIds;
 use super::super::support::block_on;
 use crate::types::*;
 
@@ -16,7 +17,7 @@ impl Repo {
         &self,
         repo: &Arc<ReadonlyRepo>,
         commit: &JjCommit,
-        immutable_ids: Option<&HashSet<String>>,
+        immutable_ids: Option<&ImmutableIds>,
         divergent_change_ids: Option<&HashSet<String>>,
     ) -> ChangeInfo {
         let change_id = encode_reverse_hex(commit.change_id().as_bytes());
@@ -55,9 +56,34 @@ impl Repo {
         let has_conflict = commit.has_conflict();
         let is_empty = block_on(commit.is_empty(repo.as_ref())).unwrap_or(false);
         // Keep display loading resilient to an invalid immutable() revset; mutation paths still enforce immutability.
-        let is_immutable = match immutable_ids {
-            Some(ids) => ids.contains(&commit_id),
-            None => self.is_commit_immutable(repo, commit).unwrap_or(false),
+        let (is_immutable, has_immutable_child) = match immutable_ids {
+            Some(ids) => (
+                ids.commits.contains(&commit_id),
+                ids.parents.contains(&commit_id),
+            ),
+            None => {
+                let is_immutable = self.is_commit_immutable(repo, commit).unwrap_or(false);
+                let has_immutable_child =
+                    is_immutable && self.has_immutable_child(repo, commit).unwrap_or(false);
+                (is_immutable, has_immutable_child)
+            }
+        };
+        let has_children = !repo.view().heads().contains(commit.id());
+        let discardable_working_copy = is_working_copy
+            && is_empty
+            && commit.description().is_empty()
+            && bookmarks.is_empty()
+            && tags.is_empty()
+            && workspaces.is_empty()
+            && !has_children
+            && !repo
+                .view()
+                .all_remote_bookmarks()
+                .any(|(_, remote_ref)| remote_ref.target.added_ids().any(|id| id == commit.id()));
+        let new_change = NewChangeEligibility {
+            on_top: !discardable_working_copy,
+            before: !is_immutable,
+            after: has_children && !has_immutable_child,
         };
         let is_divergent = divergent_change_ids
             .map(|ids| ids.contains(&change_id))
@@ -81,6 +107,7 @@ impl Repo {
             is_empty,
             is_immutable,
             is_divergent,
+            new_change,
         }
     }
 

--- a/crates/jayjay-core/src/repo/resolve/mod.rs
+++ b/crates/jayjay-core/src/repo/resolve/mod.rs
@@ -2,3 +2,4 @@ mod aliases;
 mod changes;
 mod expressions;
 mod lookup;
+mod rewrites;

--- a/crates/jayjay-core/src/repo/resolve/rewrites.rs
+++ b/crates/jayjay-core/src/repo/resolve/rewrites.rs
@@ -1,0 +1,91 @@
+use std::sync::Arc;
+
+use futures::StreamExt as _;
+use jj_lib::backend::CommitId;
+use jj_lib::commit::Commit;
+use jj_lib::op_walk;
+use jj_lib::repo::{ReadonlyRepo, Repo as JjRepo};
+use jj_lib::revset::ResolvedRevsetExpression;
+
+use super::super::Repo;
+use super::super::support::block_on;
+use crate::types::*;
+
+const MAX_REWRITE_HOPS: usize = 100;
+const MAX_OP_SCAN: usize = 1000;
+
+impl Repo {
+    // A mutation must not target a hidden commit: a snapshot may have just rewritten the commit the shell selected, so follow the operation log's predecessor records to its visible successor.
+    pub(crate) fn follow_rewrites(
+        &self,
+        repo: &Arc<ReadonlyRepo>,
+        commit: Commit,
+        rev: &str,
+    ) -> CoreResult<Commit> {
+        let revset = ResolvedRevsetExpression::all()
+            .evaluate(repo.as_ref())
+            .map_err(|e| CoreError::Internal {
+                message: format!("visibility revset: {e}"),
+            })?;
+        let contains = revset.containing_fn();
+        let is_visible = |id: &CommitId| {
+            block_on(contains(id)).map_err(|e| CoreError::Internal {
+                message: format!("visibility check: {e}"),
+            })
+        };
+        if is_visible(commit.id())? {
+            return Ok(commit);
+        }
+        let mut current = commit.id().clone();
+        for _ in 0..MAX_REWRITE_HOPS {
+            let successors = self.direct_successors(repo, &current)?;
+            current = match successors.as_slice() {
+                [] => break,
+                [next] => next.clone(),
+                _ => {
+                    return Err(CoreError::Internal {
+                        message: format!(
+                            "{rev} was rewritten into multiple commits; reselect the target"
+                        ),
+                    });
+                }
+            };
+            if is_visible(&current)? {
+                return repo
+                    .store()
+                    .get_commit(&current)
+                    .map_err(|e| CoreError::Internal {
+                        message: format!("get successor: {e}"),
+                    });
+            }
+        }
+        Err(CoreError::Internal {
+            message: format!("{rev} is hidden and has no visible successor; reselect the target"),
+        })
+    }
+
+    fn direct_successors(
+        &self,
+        repo: &Arc<ReadonlyRepo>,
+        id: &CommitId,
+    ) -> CoreResult<Vec<CommitId>> {
+        // Merged operation heads can each record a rewrite of the same commit, so scan the whole capped ancestry and let the fork surface instead of taking the first branch's answer.
+        let ops = op_walk::walk_ancestors(std::slice::from_ref(repo.operation())).take(MAX_OP_SCAN);
+        futures::pin_mut!(ops);
+        let mut successors: Vec<CommitId> = Vec::new();
+        while let Some(op) = block_on(ops.next()) {
+            let op = op.map_err(|e| CoreError::Internal {
+                message: format!("walk operations: {e}"),
+            })?;
+            let Some(map) = &op.store_operation().commit_predecessors else {
+                continue;
+            };
+            for (successor, predecessors) in map {
+                if predecessors.contains(id) && !successors.contains(successor) {
+                    successors.push(successor.clone());
+                }
+            }
+        }
+        Ok(successors)
+    }
+}

--- a/crates/jayjay-core/src/repo/transaction.rs
+++ b/crates/jayjay-core/src/repo/transaction.rs
@@ -71,6 +71,7 @@ impl Repo {
     {
         let repo = self.get_repo();
         let commit = self.resolve_commit(&repo, rev)?;
+        let commit = self.follow_rewrites(&repo, commit, rev)?;
         self.with_existing_commit_transaction(repo, commit, description, rebase_descendants, update)
     }
 

--- a/crates/jayjay-core/tests/insert_change.rs
+++ b/crates/jayjay-core/tests/insert_change.rs
@@ -1,0 +1,223 @@
+use std::fs;
+
+use jayjay_core::{InsertPosition, Repo};
+use jj_test::{change_by_description, current_op_id, init_jj_repo, run_git, run_jj, run_jj_in};
+
+#[test]
+fn new_change_before_moves_the_working_copy_under_the_target_and_keeps_its_content() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let repo = Repo::open(&repo_path).expect("open repo");
+    fs::write(repo_path.join("work.txt"), "work in progress\n").expect("write work.txt");
+    repo.refresh_working_copy().expect("snapshot work.txt");
+    repo.describe("@", "target").expect("describe target");
+    let ops_before = repo.op_log().expect("op log").len();
+
+    repo.new_change_inserted("@", InsertPosition::Before, "prerequisite")
+        .expect("insert before the working copy");
+
+    let changes = repo.log("all()").expect("log all");
+    let inserted = change_by_description(&changes, "prerequisite");
+    let target = change_by_description(&changes, "target");
+    assert!(inserted.is_working_copy && inserted.is_empty);
+    assert_eq!(inserted.parents, vec!["0".repeat(40)]);
+    assert_eq!(target.parents, vec![inserted.commit_id.id.clone()]);
+    let target_diff = repo.show(&target.commit_id).expect("show target").diff;
+    assert!(
+        target_diff.iter().any(|hunk| hunk.path == "work.txt"),
+        "the displaced change must keep its content"
+    );
+    assert!(
+        !repo_path.join("work.txt").exists(),
+        "the checkout must follow the working copy below the target"
+    );
+    assert_eq!(repo.op_log().expect("op log").len(), ops_before + 1);
+}
+
+#[test]
+fn insert_after_keeps_a_merge_childs_unrelated_parent() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    run_jj_in(&repo_path, &["describe", "-m", "target"]);
+    run_jj_in(&repo_path, &["new", "-m", "other", "root()"]);
+    run_jj_in(
+        &repo_path,
+        &[
+            "new",
+            "-m",
+            "merge",
+            "subject(\"target\")",
+            "subject(\"other\")",
+        ],
+    );
+    let repo = Repo::open(&repo_path).expect("open repo");
+
+    repo.new_change_inserted("subject(\"target\")", InsertPosition::After, "inserted")
+        .expect("insert after the merge child's first parent");
+
+    let changes = repo.log("all()").expect("log all");
+    let inserted = change_by_description(&changes, "inserted");
+    let target = change_by_description(&changes, "target");
+    let other = change_by_description(&changes, "other");
+    assert_eq!(inserted.parents, vec![target.commit_id.id.clone()]);
+    assert_eq!(
+        change_by_description(&changes, "merge").parents,
+        vec![inserted.commit_id.id.clone(), other.commit_id.id.clone()],
+        "the merge child must keep its unrelated parent"
+    );
+}
+
+#[test]
+fn insert_follows_a_working_copy_rewritten_by_the_snapshot() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let repo_str = repo_path.to_str().expect("repo path utf-8");
+    let base_op = current_op_id(&repo_path);
+    fs::write(repo_path.join("hello.txt"), "left\n").expect("write left");
+    run_jj(&["-R", repo_str, "describe", "-m", "left"]);
+    fs::write(repo_path.join("hello.txt"), "right\n").expect("write right");
+    run_jj(&[
+        "-R", repo_str, "--at-op", &base_op, "describe", "-m", "right",
+    ]);
+
+    let repo = Repo::open(&repo_path).expect("open repo");
+    let stale = repo
+        .log("all()")
+        .expect("log")
+        .into_iter()
+        .find(|change| change.is_working_copy)
+        .expect("working copy in log");
+    assert!(stale.is_divergent, "fixture working copy must be divergent");
+    fs::write(repo_path.join("work.txt"), "fresh edit\n").expect("write unsnapshotted edit");
+
+    repo.new_change_inserted(&stale.commit_id.id, InsertPosition::Before, "prereq")
+        .expect("insert before the stale working-copy commit id");
+
+    let changes = repo.log("all()").expect("log after insert");
+    let siblings: Vec<_> = changes
+        .iter()
+        .filter(|change| change.change_id.id == stale.change_id.id)
+        .collect();
+    assert_eq!(
+        siblings.len(),
+        2,
+        "the hidden pre-snapshot commit must not be resurrected"
+    );
+    let inserted = change_by_description(&changes, "prereq");
+    assert!(inserted.is_working_copy);
+    let moved = siblings
+        .iter()
+        .find(|change| change.parents == vec![inserted.commit_id.id.clone()])
+        .expect("the displaced sibling sits on the inserted change");
+    let diff = repo.show(&moved.commit_id).expect("show displaced").diff;
+    assert!(
+        diff.iter().any(|hunk| hunk.path == "work.txt"),
+        "the freshly snapshotted edit must stay in the displaced change"
+    );
+}
+
+#[test]
+fn on_top_hides_only_for_a_discardable_working_copy() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    run_jj_in(&repo_path, &["new"]);
+    let repo = Repo::open(&repo_path).expect("open repo");
+
+    let wc = |changes: &[jayjay_core::ChangeInfo]| {
+        changes
+            .iter()
+            .find(|change| change.is_working_copy)
+            .expect("working copy in log")
+            .clone()
+    };
+    assert!(!wc(&repo.log("all()").expect("log")).new_change.on_top);
+    assert!(
+        change_by_description(&repo.log("all()").expect("log"), "initial change")
+            .new_change
+            .on_top,
+        "a described change keeps new change on top"
+    );
+
+    run_jj_in(&repo_path, &["bookmark", "create", "wip", "-r", "@"]);
+    let repo = Repo::open(&repo_path).expect("reopen repo");
+    let referenced = wc(&repo.log("all()").expect("log"));
+    assert!(
+        referenced.new_change.on_top,
+        "a referenced working copy is not discardable"
+    );
+
+    run_jj_in(&repo_path, &["bookmark", "delete", "wip"]);
+    run_git(
+        &repo_path,
+        &[
+            "update-ref",
+            "refs/remotes/origin/keeper",
+            &referenced.commit_id.id,
+        ],
+    );
+    run_jj_in(&repo_path, &["st"]);
+    run_jj_in(&repo_path, &["bookmark", "track", "keeper@origin"]);
+    run_jj_in(&repo_path, &["bookmark", "delete", "keeper"]);
+    run_jj_in(&repo_path, &["edit", &referenced.commit_id.id]);
+    let repo = Repo::open(&repo_path).expect("reopen repo after remote ref");
+    let retained = wc(&repo.log("all()").expect("log"));
+    assert_eq!(retained.commit_id.id, referenced.commit_id.id);
+    assert!(
+        retained.new_change.on_top,
+        "a tracked remote bookmark retains the working copy"
+    );
+}
+
+#[test]
+fn insert_after_gate_counts_children_hidden_from_the_revset() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    run_jj_in(&repo_path, &["describe", "-m", "protected"]);
+    run_jj_in(&repo_path, &["new", "-m", "child"]);
+    run_jj_in(&repo_path, &["new", "-m", "grandchild"]);
+    run_git(&repo_path, &["tag", "release"]);
+    run_jj_in(&repo_path, &["st"]);
+    let repo = Repo::open(&repo_path).expect("open repo");
+
+    let protected = repo
+        .log("subject(\"protected\")")
+        .expect("log protected only");
+    assert!(
+        !protected[0].new_change.after,
+        "the immutable child stays counted while the revset hides it"
+    );
+    let changes = repo.log("all()").expect("log all");
+    let child = change_by_description(&changes, "child");
+    assert!(child.is_immutable && child.new_change.after);
+    let grandchild = change_by_description(&changes, "grandchild");
+    assert!(
+        !grandchild.new_change.after,
+        "a head has nothing to insert after"
+    );
+}
+
+#[test]
+fn new_change_after_reparents_every_child_onto_the_inserted_change() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    run_jj_in(&repo_path, &["describe", "-m", "base"]);
+    run_jj_in(&repo_path, &["new", "-m", "left"]);
+    run_jj_in(&repo_path, &["new", "-m", "right", "@-"]);
+    let repo = Repo::open(&repo_path).expect("open repo");
+
+    repo.new_change_inserted("@-", InsertPosition::After, "inserted")
+        .expect("insert after base");
+
+    let changes = repo.log("all()").expect("log all");
+    let base = change_by_description(&changes, "base");
+    let inserted = change_by_description(&changes, "inserted");
+    assert!(inserted.is_working_copy);
+    assert_eq!(inserted.parents, vec![base.commit_id.id.clone()]);
+    for child in ["left", "right"] {
+        assert_eq!(
+            change_by_description(&changes, child).parents,
+            vec![inserted.commit_id.id.clone()],
+            "{child} must now descend from the inserted change"
+        );
+    }
+}

--- a/crates/jayjay-core/tests/mutations_immutable.rs
+++ b/crates/jayjay-core/tests/mutations_immutable.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-use jayjay_core::Repo;
+use jayjay_core::{InsertPosition, Repo};
 use jj_test::{init_jj_repo, run_git, run_jj_in};
 
 /// Defense in depth behind the shells' menu gating: these mutations rewrite through jj-lib directly, so core must refuse immutable targets itself.
@@ -33,6 +33,14 @@ fn mutations_refuse_to_rewrite_an_immutable_commit() {
         ("rebase", Box::new(|| repo.rebase(rev, "@").map(drop))),
         ("squash", Box::new(|| repo.squash(rev, Some("@")))),
         ("squash into", Box::new(|| repo.squash("@", Some(rev)))),
+        (
+            "new before",
+            Box::new(|| repo.new_change_inserted(rev, InsertPosition::Before, "")),
+        ),
+        (
+            "new after",
+            Box::new(|| repo.new_change_inserted("root()", InsertPosition::After, "")),
+        ),
     ];
     for (name, attempt) in attempts {
         let err = attempt().expect_err(&format!("{name} on an immutable change must fail"));

--- a/crates/jayjay-core/tests/repo.rs
+++ b/crates/jayjay-core/tests/repo.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use jayjay_core::Repo;
 use jayjay_core::diff::{ConflictLineKind, compute_file_diff_full};
-use jj_test::{current_op_id, init_jj_repo, run_git, run_jj, run_jj_in};
+use jj_test::{change_by_description, current_op_id, init_jj_repo, run_git, run_jj, run_jj_in};
 
 #[test]
 fn show_summary_marks_divergent_revision_loaded_by_commit_id() {
@@ -358,16 +358,6 @@ fn revert_change_uses_jj_revert_and_creates_reverse_change() {
     assert_eq!(reverted.parents, vec![current.info.commit_id.id.clone()]);
 }
 /// Look up a revision in the log by its description (trimmed).
-fn change_by_description<'a>(
-    changes: &'a [jayjay_core::ChangeInfo],
-    description: &str,
-) -> &'a jayjay_core::ChangeInfo {
-    changes
-        .iter()
-        .find(|change| change.description.trim() == description)
-        .unwrap_or_else(|| panic!("missing change with description {description:?}"))
-}
-
 #[test]
 fn squash_merges_descriptions_and_moves_content_into_parent() {
     let temp_dir = init_jj_repo();

--- a/crates/jayjay-primitives/src/change.rs
+++ b/crates/jayjay-primitives/src/change.rs
@@ -75,6 +75,20 @@ pub struct ChangeInfo {
     pub is_empty: bool,
     pub is_immutable: bool,
     pub is_divergent: bool,
+    pub new_change: NewChangeEligibility,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NewChangeEligibility {
+    pub on_top: bool,
+    pub before: bool,
+    pub after: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InsertPosition {
+    Before,
+    After,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/jayjay-uniffi/src/repo.rs
+++ b/crates/jayjay-uniffi/src/repo.rs
@@ -4,9 +4,10 @@ use std::sync::Arc;
 use jayjay_core::{
     AnnotationLine, BookmarkInfo, ChangeDetail, ChangeInfo, CliStatus, ConflictEditorData,
     DiffEditDestination, DiffEditFileSelection, DiffHunk, DiffStats, EvologEntry, EvologRow,
-    FetchResult, FileDiffStats, FileEditorData, GitSubmoduleStatus, GraphEntry, JjCommand,
-    JjCommandResult, OpLogEntry, PrInfo, Repo, ReviewNoteOutputFormat, RevsetPreset, Stack,
-    StackedPrResult, SubmitStackLayer, SyncToken, ToolsConfig, WorkspaceInfo, WorkspacePresence,
+    FetchResult, FileDiffStats, FileEditorData, GitSubmoduleStatus, GraphEntry, InsertPosition,
+    JjCommand, JjCommandResult, OpLogEntry, PrInfo, Repo, ReviewNoteOutputFormat, RevsetPreset,
+    Stack, StackedPrResult, SubmitStackLayer, SyncToken, ToolsConfig, WorkspaceInfo,
+    WorkspacePresence,
     diff::{self, CollapsedDiff, FileDiff, ReviewFileSnapshot},
     review_display_group_map_from_hunk, review_snapshot_from_hunk,
 };
@@ -798,6 +799,15 @@ impl JayJayRepo {
 
     fn new_change(&self, parent: String, message: String) -> Result<(), JayJayError> {
         Ok(self.inner.new_change(&parent, &message)?)
+    }
+
+    fn new_change_inserted(
+        &self,
+        rev: String,
+        position: InsertPosition,
+        message: String,
+    ) -> Result<(), JayJayError> {
+        Ok(self.inner.new_change_inserted(&rev, position, &message)?)
     }
 
     fn squash(&self, rev: String, into_rev: Option<String>) -> Result<(), JayJayError> {

--- a/crates/jayjay-uniffi/src/types/changes.rs
+++ b/crates/jayjay-uniffi/src/types/changes.rs
@@ -47,6 +47,16 @@ pub struct ChangeInfo {
     pub is_empty: bool,
     pub is_immutable: bool,
     pub is_divergent: bool,
+    pub new_change: core::NewChangeEligibility,
+}
+
+use jayjay_core::NewChangeEligibility;
+
+#[uniffi::remote(Record)]
+pub struct NewChangeEligibility {
+    pub on_top: bool,
+    pub before: bool,
+    pub after: bool,
 }
 
 #[uniffi::remote(Record)]

--- a/crates/jayjay-uniffi/src/types/repo.rs
+++ b/crates/jayjay-uniffi/src/types/repo.rs
@@ -1,8 +1,8 @@
 use jayjay_core as core;
 use jayjay_core::{
     AnnotationLine, BookmarkInfo, ChecksStatus, CliStatus, FetchResult, GitSubmoduleStatus,
-    JjCommandResult, PrInfo, PrState, RemoteBookmarkTarget, RemoteSyncStatus, RevsetPreset,
-    ShortId, WorkspaceInfo, WorkspacePresence,
+    InsertPosition, JjCommandResult, PrInfo, PrState, RemoteBookmarkTarget, RemoteSyncStatus,
+    RevsetPreset, ShortId, WorkspaceInfo, WorkspacePresence,
 };
 
 #[uniffi::remote(Record)]
@@ -68,6 +68,12 @@ pub struct WorkspaceInfo {
     pub timestamp: i64,
     pub has_conflict: bool,
     pub files_changed: u32,
+}
+
+#[uniffi::remote(Enum)]
+pub enum InsertPosition {
+    Before,
+    After,
 }
 
 #[uniffi::remote(Enum)]

--- a/crates/jj-test/src/lib.rs
+++ b/crates/jj-test/src/lib.rs
@@ -9,6 +9,6 @@ pub use cmd::{configure_test_user, init_colocated, run_command, run_git, run_jj,
 pub use formats::FormatFixture;
 pub use linear::LinearFixture;
 pub use repo::{
-    current_op_id, init_jj_repo, selection_for_lines, setup_source_change_with_child,
-    whole_file_selection,
+    change_by_description, current_op_id, init_jj_repo, selection_for_lines,
+    setup_source_change_with_child, whole_file_selection,
 };

--- a/crates/jj-test/src/repo.rs
+++ b/crates/jj-test/src/repo.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use jayjay_core::diff::compute_file_diff_full;
-use jayjay_core::{DiffEditFileSelection, DiffEditRange, Repo};
+use jayjay_core::{ChangeInfo, DiffEditFileSelection, DiffEditRange, Repo};
 use tempfile::TempDir;
 
 use crate::{configure_test_user, init_colocated, run_jj_in};
@@ -28,6 +28,13 @@ pub fn init_jj_repo() -> TempDir {
     run_jj_in(&repo_path, &["describe", "-m", "initial change"]);
 
     temp_dir
+}
+
+pub fn change_by_description<'a>(changes: &'a [ChangeInfo], description: &str) -> &'a ChangeInfo {
+    changes
+        .iter()
+        .find(|change| change.description.trim() == description)
+        .unwrap_or_else(|| panic!("missing change with description {description:?}"))
 }
 
 fn hunk_for_path(repo: &Repo, rev: &str, path: &str) -> jayjay_core::DiffHunk {

--- a/scripts/ui-test-fixtures.sh
+++ b/scripts/ui-test-fixtures.sh
@@ -77,6 +77,7 @@ fixture_mutating_scenes() {
   copy_fixture simple save-description
   copy_fixture simple diff-stats
   copy_fixture simple new-change
+  copy_fixture simple insert-change
   copy_fixture simple file-editor
 }
 

--- a/shell/gpui/src/repo/revset/change.rs
+++ b/shell/gpui/src/repo/revset/change.rs
@@ -78,6 +78,11 @@ mod tests {
             is_empty: false,
             is_immutable: false,
             is_divergent: false,
+            new_change: jayjay_core::NewChangeEligibility {
+                on_top: true,
+                before: true,
+                after: true,
+            },
         }
     }
 }

--- a/shell/gpui/src/repo/revset/compare.rs
+++ b/shell/gpui/src/repo/revset/compare.rs
@@ -178,6 +178,11 @@ mod tests {
             is_empty: false,
             is_immutable: false,
             is_divergent: false,
+            new_change: jayjay_core::NewChangeEligibility {
+                on_top: true,
+                before: true,
+                after: true,
+            },
         }
     }
 }

--- a/shell/gpui/src/repo/view_model/mutations.rs
+++ b/shell/gpui/src/repo/view_model/mutations.rs
@@ -1,7 +1,7 @@
 use gpui::Context;
 use jayjay_core::{
-    CoreResult, DiffEditDestination, DiffEditFileSelection, FetchResult, Repo, StackedPrResult,
-    SubmitStackLayer, init_jj_git_repo,
+    CoreResult, DiffEditDestination, DiffEditFileSelection, FetchResult, InsertPosition, Repo,
+    StackedPrResult, SubmitStackLayer, init_jj_git_repo,
 };
 
 use std::sync::Arc;
@@ -81,6 +81,19 @@ impl RepoViewModel {
         self.repo_write_task(
             cx,
             move |repo| repo.new_change(&parent, ""),
+            |vm, cx| vm.refresh_selecting_revision(None, cx),
+        )
+    }
+
+    pub(crate) fn insert_change(
+        &mut self,
+        rev: String,
+        position: InsertPosition,
+        cx: &mut Context<Self>,
+    ) -> gpui::Task<CoreResult<()>> {
+        self.repo_write_task(
+            cx,
+            move |repo| repo.new_change_inserted(&rev, position, ""),
             |vm, cx| vm.refresh_selecting_revision(None, cx),
         )
     }

--- a/shell/gpui/src/repo/window/change_actions.rs
+++ b/shell/gpui/src/repo/window/change_actions.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use gpui::{App, Context};
-use jayjay_core::ChangeInfo;
+use jayjay_core::{ChangeInfo, InsertPosition};
 
 use super::RepoWindow;
 use crate::repo::revset;
@@ -10,6 +10,7 @@ use crate::ui::icons::glyph;
 
 pub enum ChangeAction {
     Edit { rev: String },
+    Insert { rev: String, at: InsertPosition },
     Squash { rev: String, into: Option<String> },
     Rebase { rev: String, dest: String },
     Merge { parents: Vec<String> },
@@ -31,11 +32,35 @@ impl RepoWindow {
                     .is_none_or(|parent| !parent.is_immutable)
             })
         };
-        let mut items = vec![ContextMenuItem::new(
-            "New change on top",
-            glyph::PLUS_CIRCLE,
-            ContextAction::NewChangeOnTop(rev.clone().into()),
-        )];
+        let mut items = Vec::new();
+        if change.new_change.on_top {
+            items.push(ContextMenuItem::new(
+                "New change on top",
+                glyph::PLUS_CIRCLE,
+                ContextAction::NewChangeOnTop(rev.clone().into()),
+            ));
+        }
+        if change.new_change.before {
+            items.push(ContextMenuItem::new(
+                "New change before",
+                glyph::ARROW_DOWN,
+                change_action(ChangeAction::Insert {
+                    rev: rev.clone(),
+                    at: InsertPosition::Before,
+                }),
+            ));
+        }
+        if change.new_change.after {
+            items.push(ContextMenuItem::new(
+                "New change after",
+                glyph::ARROW_UP,
+                change_action(ChangeAction::Insert {
+                    rev: rev.clone(),
+                    at: InsertPosition::After,
+                }),
+            ));
+        }
+        items.push(ContextMenuItem::separator());
         if !change.is_immutable {
             items.push(ContextMenuItem::new(
                 "Edit (modify this change)",
@@ -174,6 +199,9 @@ impl RepoWindow {
             ChangeAction::Edit { rev } => {
                 self.vm.update(cx, |vm, cx| vm.edit_change(rev.clone(), cx))
             }
+            ChangeAction::Insert { rev, at } => self
+                .vm
+                .update(cx, |vm, cx| vm.insert_change(rev.clone(), *at, cx)),
             ChangeAction::Squash { rev, into } => self
                 .vm
                 .update(cx, |vm, cx| vm.squash_change(rev.clone(), into.clone(), cx)),

--- a/shell/gpui/src/repo/window/dag_drag/payload.rs
+++ b/shell/gpui/src/repo/window/dag_drag/payload.rs
@@ -121,6 +121,11 @@ mod tests {
             is_empty: false,
             is_immutable: false,
             is_divergent: false,
+            new_change: jayjay_core::NewChangeEligibility {
+                on_top: true,
+                before: true,
+                after: true,
+            },
         };
         GraphEntry {
             change,

--- a/shell/gpui/src/ui/context_menu.rs
+++ b/shell/gpui/src/ui/context_menu.rs
@@ -68,6 +68,7 @@ pub struct ContextMenuItem {
     pub label: SharedString,
     glyph: &'static str,
     pub action: ContextAction,
+    is_separator: bool,
 }
 
 impl ContextMenuItem {
@@ -80,6 +81,16 @@ impl ContextMenuItem {
             label: label.into(),
             glyph,
             action,
+            is_separator: false,
+        }
+    }
+
+    pub(crate) fn separator() -> Self {
+        Self {
+            label: SharedString::default(),
+            glyph: "",
+            action: ContextAction::Noop,
+            is_separator: true,
         }
     }
 }
@@ -148,7 +159,11 @@ fn menu_panel(items: &[ContextMenuItem], t: &Theme, view: &Entity<RepoWindow>) -
         .rounded_sm();
 
     for (ix, item) in items.iter().enumerate() {
-        col = col.child(menu_row(ix, item, t, view));
+        if item.is_separator {
+            col = col.child(div().h(px(1.)).my(px(4.)).bg(rgb(t.border)));
+        } else {
+            col = col.child(menu_row(ix, item, t, view));
+        }
     }
     col.into_any_element()
 }

--- a/shell/gpui/tests/gpui/repo_mutations.rs
+++ b/shell/gpui/tests/gpui/repo_mutations.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::harness::*;
 use gpui::{AppContext, TestAppContext, VisualContext};
+use jayjay_core::InsertPosition;
 use jayjay_gpui::repo::RepoWindow;
 use jayjay_gpui::repo::revset;
 use jayjay_gpui::repo::view_model::RepoViewModel;
@@ -113,6 +114,48 @@ fn change_context_action_creates_new_change_on_top(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn change_context_action_inserts_change_before_target(cx: &mut TestAppContext) {
+    let fixture = LinearFixture::build();
+    suppress_fs_watcher(cx);
+    let view = cx.new(|cx| RepoWindow::new(fixture.path.clone(), cx));
+    settle(cx);
+
+    let target = view.read_with(cx, |view, cx| {
+        view.view_model()
+            .read(cx)
+            .graph
+            .changes
+            .iter()
+            .find(|change| change.description.trim() == "add feature")
+            .expect("fixture should contain add feature change")
+            .clone()
+    });
+    view.update(cx, |view, cx| {
+        let action = ChangeAction::Insert {
+            rev: target.change_id.id.clone(),
+            at: InsertPosition::Before,
+        };
+        view.dispatch_context_action(ContextAction::Change(Arc::new(action)), cx);
+    });
+    settle(cx);
+
+    view.read_with(cx, |view, cx| {
+        let vm = view.view_model().read(cx);
+        assert!(vm.error.is_none(), "insert errored: {:?}", vm.error);
+        let selected = vm.selected_change().expect("selected change after insert");
+        assert!(selected.is_working_copy);
+        assert_eq!(selected.parents, target.parents);
+        let moved = vm
+            .graph
+            .changes
+            .iter()
+            .find(|change| change.change_id.id == target.change_id.id)
+            .expect("target still visible");
+        assert_eq!(moved.parents, vec![selected.commit_id.id.clone()]);
+    });
+}
+
+#[gpui::test]
 fn change_context_action_abandons_change(cx: &mut TestAppContext) {
     let fixture = LinearFixture::build();
     suppress_fs_watcher(cx);
@@ -186,6 +229,8 @@ fn change_menu_exposes_full_mutation_set_and_selected_pair_actions(cx: &mut Test
             .map(|item| item.label.to_string())
             .collect();
         for expected in [
+            "New change before",
+            "New change after",
             "Edit (modify this change)",
             "Squash into parent",
             "Move changes to working copy",

--- a/shell/mac/Sources/JayJay/Detail/Evolog/EvologDisplay.swift
+++ b/shell/mac/Sources/JayJay/Detail/Evolog/EvologDisplay.swift
@@ -72,7 +72,8 @@ extension EvologEntry {
             hasConflict: false,
             isEmpty: false,
             isImmutable: false,
-            isDivergent: false
+            isDivergent: false,
+            newChange: NewChangeEligibility(onTop: false, before: false, after: false)
         )
     }
 }

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGView+ContextMenu.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGView+ContextMenu.swift
@@ -7,9 +7,22 @@ extension DAGView {
         let rev = entry.change.isDivergent
             ? entry.change.commitId.id : entry.change.changeId.id
         // Navigation
-        Button { actions?.newChange(parent: rev, message: "") } label: {
-            Label("New change on top", systemImage: "plus.circle")
+        if entry.change.newChange.onTop {
+            Button { actions?.newChange(parent: rev, message: "") } label: {
+                Label("New change on top", systemImage: "plus.circle")
+            }
         }
+        if entry.change.newChange.before {
+            Button { actions?.insertChange(rev: rev, position: .before) } label: {
+                Label("New change before", systemImage: "arrow.down.circle")
+            }
+        }
+        if entry.change.newChange.after {
+            Button { actions?.insertChange(rev: rev, position: .after) } label: {
+                Label("New change after", systemImage: "arrow.up.circle")
+            }
+        }
+        Divider()
         if !entry.change.isImmutable {
             Button { actions?.edit(rev: rev) } label: {
                 Label("Edit (modify this commit)", systemImage: "pencil.circle")

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+ChangeActions.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+ChangeActions.swift
@@ -86,12 +86,18 @@ extension RepoViewModel {
     }
 
     func newChange(parent: String, message: String = "") {
+        performClearingDrafts { try $0.newChange(parent: parent, message: message) }
+    }
+
+    func insertChange(rev: String, position: InsertPosition) {
+        performClearingDrafts { try $0.newChangeInserted(rev: rev, position: position, message: "") }
+    }
+
+    private func performClearingDrafts(_ action: @escaping RepoOperation<Void>) {
         perform(beforeRefresh: { viewModel in
             viewModel.commitSummaryDraft = ""
             viewModel.commitDescriptionDraft = ""
-        }, {
-            try $0.newChange(parent: parent, message: message)
-        })
+        }, action)
     }
 
     func abandon(rev: String) {

--- a/shell/mac/Sources/JayJay/Shared/DAGActions.swift
+++ b/shell/mac/Sources/JayJay/Shared/DAGActions.swift
@@ -1,9 +1,11 @@
 import Foundation
+import JayJayCore
 
 protocol DAGActions: AnyObject {
     func select(changeId: String?, coalescing: Bool)
     func edit(rev: String)
     func newChange(parent: String, message: String)
+    func insertChange(rev: String, position: InsertPosition)
     func duplicate(rev: String)
     func merge(parents: [String])
     func squash(rev: String)

--- a/shell/mac/Tests/JayJayTests/ChangeInfoTestFixtures.swift
+++ b/shell/mac/Tests/JayJayTests/ChangeInfoTestFixtures.swift
@@ -27,6 +27,7 @@ func mockChangeInfo(
         hasConflict: hasConflict,
         isEmpty: isEmpty,
         isImmutable: isImmutable,
-        isDivergent: isDivergent
+        isDivergent: isDivergent,
+        newChange: NewChangeEligibility(onTop: true, before: true, after: true)
     )
 }

--- a/shell/mac/Tests/JayJayUITests/Scenes/InsertChangeScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/InsertChangeScene.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+final class InsertChangeScene: SceneBase {
+    override class var fixtureName: String {
+        "insert-change"
+    }
+
+    func testContextMenuNewChangeBeforeInsertsTheWorkingCopyUnderTheTarget() throws {
+        let app = try XCTUnwrap(app)
+        let rows = dagRows(of: app)
+        XCTAssertTrue(rows.element(boundBy: 0).waitForExistence(timeout: 10), "DAG never populated")
+        let originalIds = rows.allElementsBoundByIndex.map(\.identifier)
+        let originalTopId = try XCTUnwrap(originalIds.first)
+
+        rows.element(boundBy: 0).rightClick()
+        let insertBefore = app.menuItems["New change before"]
+        XCTAssertTrue(insertBefore.waitForExistence(timeout: 3), "\"New change before\" menu item missing")
+        insertBefore.click()
+
+        let predicate = NSPredicate { _, _ in
+            let rowsNow = rows.allElementsBoundByIndex
+            let ids = rowsNow.map(\.identifier)
+            return ids.count == originalIds.count + 1
+                && ids[0] == originalTopId
+                && !originalIds.contains(ids[1])
+                && rowsNow[1].isSelected
+        }
+        let expectation = XCTNSPredicateExpectation(predicate: predicate, object: nil)
+        let result = XCTWaiter().wait(for: [expectation], timeout: 10)
+        let rowsAfter = rows.allElementsBoundByIndex.map { "\($0.identifier) selected=\($0.isSelected)" }
+        XCTAssertEqual(result, .completed, "Inserted change did not appear selected under the previous working copy: \(rowsAfter)")
+    }
+}

--- a/shell/mac/Tests/JayJayUITests/Scenes/NewChangeScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/NewChangeScene.swift
@@ -22,8 +22,12 @@ final class NewChangeScene: SceneBase {
         details.click()
         paste("old working-copy body")
 
-        // Right-click the parent of @ and create a new change on top of it.
-        rows.element(boundBy: 1).rightClick()
+        // Pick the row by its combined text: scene order mutates the fixture, and a row index can land on a row whose gates hide this item.
+        let target = try XCTUnwrap(
+            rows.allElementsBoundByIndex.first { ($0.value as? String)?.contains("add feature") == true },
+            "add feature row missing"
+        )
+        target.rightClick()
         let newChange = app.menuItems["New change on top"]
         XCTAssertTrue(newChange.waitForExistence(timeout: 3), "\"New change on top\" menu item missing")
         newChange.click()
@@ -45,4 +49,5 @@ final class NewChangeScene: SceneBase {
             "New working copy carried the previous change's commit message"
         )
     }
+
 }


### PR DESCRIPTION
Closes #164

Adds the jj tutorial's edit-workflow primitive to the DAG: insert an empty change *before* a revision (`jj new -B`) or *between* it and its children (`jj new -A`), with the working copy moving onto the inserted change.

## Core

- `Repo::new_change_inserted(rev, InsertPosition::{Before, After}, message)` in `repo/mutations.rs`, built on jj-lib in a single transaction: the new commit takes the target's parents (Before) or the target (After) as parents, the displaced commits are rebased through it (a merge child keeps its other parents), descendants follow, and `@` moves onto it. One op-log entry, so ⌘⇧U undoes it.
- Gates match the menus: Before refuses an immutable target, After refuses when any child is immutable (the target itself may be immutable, e.g. inserting after `root()`).
- Menu eligibility lives in the model as one record, `ChangeInfo.new_change { on_top, before, after }`, computed per log load in core: `before` needs a mutable target; `after` needs a child and no immutable child (from `parents(immutable())` — ancestor-closed — and the view heads, so a filtered revset cannot mislead the gate); `on_top` hides on a discardable working copy — an empty, undescribed head with no bookmarks (local or remote), tags, or other-workspace checkouts. Both shells just render the record.
- Mutations follow rewrites: resolving a mutation target that is hidden (e.g. a divergent working copy addressed by commit id that the pre-mutation snapshot just rewrote) now follows the operation log's predecessor records to the visible successor, erroring on a fork instead of guessing (successors are aggregated across the operation ancestry, so independent rewrites on merged operation branches also refuse). Centralized in `with_resolved_commit_transaction` (and `rebase`), so every mutation gets it.
- Inserting **before the first commit** works — the new change lands directly on the root (asserted in the tests).
- `InsertPosition` lives in `jayjay-primitives` and is bridged through UniFFI; the shared `change_by_description` test helper moved into `jj-test`.

## SwiftUI

- DAG context menu gains **New change before** / **New change after** next to *New change on top*, gated by `new_change`, with a separator after the new-change group. Selection follows the inserted change and the commit-box draft is cleared like *New change on top*.

## GPUI (second change in the stack)

- `ChangeAction::Insert { rev, at }` → `RepoViewModel::insert_change`; the change menu gets the same two entries and gates, and the context menu gains separator items (`ContextMenuItem::separator()`).

## Tests

- Rust: `tests/insert_change.rs` (Before keeps the target's content and drops it from disk, `@` is the new change, +1 op; After reparents both children and a merge child keeps its unrelated parent; `has_immutable_child` stays true when the revset hides the child) and both gates in `mutations_immutable.rs`.
- XCUITest: `InsertChangeScene` (own fixture copy) covers the insert-before flow; `NewChangeScene` keeps the draft-clearing flow on its own fixture.
- GPUI: `change_context_action_inserts_change_before_target`; the menu-label test lists both entries.

Not in this PR: drag-to-rebase drop zones between rows (Roadmap), command-palette entries, user docs (release pass).

## Screenshots

DAG context menu on `@` (taken before the gate polish — **New change after** is now hidden on childless targets like this one, and a separator follows the group):

<img width="1100" alt="New change before / New change after in the DAG context menu" src="https://github.com/user-attachments/assets/65abfbfd-673b-4357-80c6-aa2a0f819c71" />

After **New change before** on `@`: the old working copy keeps its change id on top, the inserted empty change is the new `@` and is selected:

<img width="1100" alt="Inserted change selected beneath the previous working copy" src="https://github.com/user-attachments/assets/78dedf0e-b00c-40f3-b6ad-66c50b988a6d" />
