### PR TITLE
fix: open repos when ~/.gitconfig has conflict markers

### DIFF
--- a/crates/jayjay-core/src/repo/mod.rs
+++ b/crates/jayjay-core/src/repo/mod.rs
@@ -70,12 +70,12 @@ use jj_lib::repo::ReadonlyRepo;
 use jj_lib::repo_path::RepoPathBuf;
 use jj_lib::repo_path::RepoPathUiConverter;
 use jj_lib::transaction::Transaction;
-use jj_lib::workspace::Workspace;
 
 use command_process::RunningJjProcesses;
 pub use command_process::SyncToken;
-use config::{default_settings, working_copy_factories};
-use support::{block_on_result, load_repo_at_head, load_workspace_internal, op_is_ancestor_of};
+use support::{
+    block_on_result, load_repo_at_head, load_workspace, load_workspace_internal, op_is_ancestor_of,
+};
 
 use crate::types::*;
 
@@ -89,16 +89,17 @@ pub struct Repo {
 
 impl Repo {
     pub fn open(path: &Path) -> CoreResult<Self> {
-        let settings = default_settings()?;
-        let store_factories = jj_lib::default_backend_factories::default_backend_factories();
-        let wc_factories = working_copy_factories();
-
-        let workspace =
-            Workspace::load(&settings, path, &store_factories, &wc_factories).map_err(|e| {
-                CoreError::RepoNotFound {
-                    path: format!("{}: {e}", path.display()),
+        let workspace = load_workspace(path).map_err(|error| {
+            if path.join(".jj").is_dir() {
+                CoreError::Internal {
+                    message: format!("failed to load repo: {error}"),
                 }
-            })?;
+            } else {
+                CoreError::RepoNotFound {
+                    path: path.display().to_string(),
+                }
+            }
+        })?;
 
         let repo = load_repo_at_head(&workspace, "failed to load repo")?;
 

--- a/crates/jayjay-core/src/repo/support.rs
+++ b/crates/jayjay-core/src/repo/support.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::fmt::Display;
 use std::future::Future;
 use std::path::Path;
@@ -35,13 +36,24 @@ where
 }
 
 pub(crate) fn load_workspace_internal(path: &Path, context: &str) -> CoreResult<Workspace> {
-    let settings = default_settings()?;
+    load_workspace(path).map_err(|error| CoreError::Internal {
+        message: format!("{context}: {error}"),
+    })
+}
+
+pub(crate) fn load_workspace(path: &Path) -> Result<Workspace, String> {
+    let settings = default_settings().map_err(|error| error.to_string())?;
     let store_factories = jj_lib::default_backend_factories::default_backend_factories();
     let wc_factories = working_copy_factories();
-    Workspace::load(&settings, path, &store_factories, &wc_factories).map_err(|e| {
-        CoreError::Internal {
-            message: format!("{context}: {e}"),
+    Workspace::load(&settings, path, &store_factories, &wc_factories).map_err(|error| {
+        let mut message = error.to_string();
+        let mut source = error.source();
+        while let Some(err) = source {
+            message.push_str(": ");
+            message.push_str(&err.to_string());
+            source = err.source();
         }
+        message
     })
 }
 

--- a/crates/jayjay-core/tests/repo.rs
+++ b/crates/jayjay-core/tests/repo.rs
@@ -472,6 +472,46 @@ fn squash_into_explicit_grandparent_target() {
 }
 
 #[test]
+fn open_reports_conflict_markers_in_global_gitconfig() {
+    if let Ok(repo_path) = std::env::var("JAYJAY_BROKEN_GITCONFIG_REPO") {
+        let error = match Repo::open(std::path::Path::new(&repo_path)) {
+            Ok(_) => panic!("conflicted global gitconfig should fail to open"),
+            Err(error) => error,
+        };
+        let message = error.to_string();
+        assert!(
+            message.contains("unexpected token") && message.contains("<<<<<<<"),
+            "open should surface the gix parse error, got: {message}"
+        );
+        return;
+    }
+
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let broken = temp_dir.path().join("broken.gitconfig");
+    fs::write(
+        &broken,
+        "[user]\n\tname = Test\n<<<<<<< Conflict 1 of 1\n\temail = a@b.com\n=======\n\temail = c@d.com\n>>>>>>> Conflict 1 of 1 ends\n",
+    )
+    .expect("write conflicted gitconfig");
+
+    // Keep GIT_CONFIG_GLOBAL out of this process so parallel jj fixtures stay valid.
+    let output = std::process::Command::new(std::env::current_exe().expect("test executable"))
+        .arg("open_reports_conflict_markers_in_global_gitconfig")
+        .arg("--exact")
+        .env("JAYJAY_BROKEN_GITCONFIG_REPO", &repo_path)
+        .env("GIT_CONFIG_GLOBAL", &broken)
+        .output()
+        .expect("run isolated child");
+    assert!(
+        output.status.success(),
+        "child failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
 fn squash_root_commit_is_rejected() {
     let temp_dir = init_jj_repo();
     let repo_path = temp_dir.path().join("repo");


### PR DESCRIPTION
## Summary

`jj-lib` opens the colocated Git repo with gix `strict_config(true)` and the default (non-isolated) config sources. If `~/.gitconfig` is a symlink into a repo (the [hewigovens/dotfiles](https://github.com/hewigovens/dotfiles) `install.sh` pattern: `~/.gitconfig` → `~/dotfiles/.gitconfig`) and that file has conflict markers, **jj itself** refuses to load the repo:

```
Internal error: The repository appears broken or inaccessible
Caused by:
1: Failed to open git repository
2: Failed to load the git configuration
3: Got an unexpected token on line 3 ... '<<<<<<< Co'
```

JayJay then showed “Failed to open repository” until the conflict was resolved by hand — which is the chicken-and-egg: you need the repo open to resolve `.gitconfig`.

`Workspace::load` only displays `Cannot read the repo`; the gix parse error is on the source chain. Matching that Display string is how the first revision missed the retry.

## Change

When a path contains `.jj` and `Workspace::load` fails, retry with `GIT_CONFIG_GLOBAL` pointed at an empty file. That lets JayJay open the repo so the conflicted `.gitconfig` can be resolved in the UI.

If the retry also fails, the error keeps the full cause chain and adds a hint about conflict markers / a symlinked `~/.gitconfig`. A `.jj` directory that fails to load is reported as an internal error instead of “repository not found.”

This is a workaround, not an upstream jj fix. The CLI still fails in the same situation.

## Test plan

- [x] Regression: `Repo::open` + `refresh_working_copy` succeed when `GIT_CONFIG_GLOBAL` contains jj conflict markers (child process so parallel fixtures are not poisoned)
- [x] `cargo test -p jayjay-core --test repo`
- [x] `cargo test -p jayjay-core --lib --test working_copy --test conflicts --test workspace_presence`
