### PR TITLE
Faster DAG scrolling

### DIFF
--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGView.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGView.swift
@@ -25,7 +25,11 @@ struct DAGView: View {
     @State private var contextTargetId: String?
     @State private var dagLayout: DAGLayout
     @State private var dagLayoutEntries: [GraphEntry]
-    @State var rebaseRowFrames: [String: CGRect] = [:]
+    @State private var rowFrameStore = DAGRowFrameStore()
+    var rebaseRowFrames: [String: CGRect] {
+        rowFrameStore.frames
+    }
+
     @State var rebaseDrag: DAGRebaseDragState?
     @State var rebaseArmTask: Task<Void, Never>?
     @State var rebasePreviewTargetId: String?
@@ -175,7 +179,7 @@ struct DAGView: View {
                     )
                     .overlay(alignment: .topLeading) { rebaseDragOverlay }
                     .overlay(alignment: .topLeading) { bookmarkDragOverlay }
-                    .onPreferenceChange(DAGRebaseRowFramePreferenceKey.self) { rebaseRowFrames = $0 }
+                    .onPreferenceChange(DAGRebaseRowFramePreferenceKey.self) { rowFrameStore.frames = $0 }
                     .onChange(of: entries.map(\.change.commitId)) { _, _ in
                         if viewModel.shouldCancelRebaseDrag(for: rebaseDrag?.hoveredCommitId) {
                             cancelRebaseDrag()
@@ -298,4 +302,9 @@ struct DAGView: View {
             .trimmingCharacters(in: .whitespaces) ?? ""
         return firstLine.isEmpty ? shortCommit : "\(shortCommit) — \(firstLine)"
     }
+}
+
+/// Stores continuously changing row frames without invalidating `DAGView` on every update.
+private final class DAGRowFrameStore {
+    var frames: [String: CGRect] = [:]
 }


### PR DESCRIPTION
Trying to improve left pane DAG scrolling performance while holding down up/down key, so every rev is highlighted in turn. I got about 10-13% improvement which isn't bad. Its a very small change:

Store continuously changing DAG row frames in a stable reference store instead of `@State`. This prevents geometry preference updates from invalidating and re-evaluating the full DAG row list while scrolling.

Immediate scrolling remains enabled for every repeated arrow-key selection, keeping the highlighted row visible while a key is held.

## Performance

A 40-key XCUITest over the 24-row `dag-long` fixture measured:

  - Baseline: 3.397 seconds
  - With this change: 2.967–3.046 seconds
  - Observed improvement: approximately 10–13%

The benchmark runs were noisy, so the result should be treated as directional rather than a precise guarantee.

Debouncing selection reveals was rejected because it prevented the pane from visibly scrolling until the key was released.