### PR TITLE
fix(mac): reseed the commit box after edit

### DIFF
--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+ChangeActions.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+ChangeActions.swift
@@ -133,7 +133,14 @@ extension RepoViewModel {
     }
 
     func edit(rev: String) {
-        perform(selecting: rev) { try $0.edit(rev: rev) }
+        perform(selecting: rev, beforeRefresh: { viewModel in
+            guard viewModel.change(for: rev)?.isWorkingCopy != true else { return }
+            // Explicit Edit changes which revision @ points to, so discard any draft for the old working copy before the new description is loaded.
+            viewModel.commitSummaryDraft = commitSummary(message: viewModel.workingCopyDescription)
+            viewModel.commitDescriptionDraft = commitBody(message: viewModel.workingCopyDescription)
+        }, {
+            try $0.edit(rev: rev)
+        })
     }
 
     func absorb(rev: String) {


### PR DESCRIPTION
## Summary

- reseed the commit box from the edited revision after an explicit Edit action
- keep typed drafts intact for background working-copy updates and edits targeting the current working copy

## Cause

The background-refresh draft-preservation rule also applied to explicit Edit actions, so the old working-copy draft won over the newly edited revision description.

## Tests

- `just test-ui JayJayUITests/CommitBoxEditScene/testEditReplacesStaleDraftWithCommitDescription`
- `just test-app`
- `just lint`