### PR TITLE
docs: add a subagent dispatch contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Keep this file as always-loaded guidance. Load a focused doc only when the task 
 | parity matrix | [Parity](agents/shell-parity.md) — **release only** |
 | version bump, notarize, appcast | [Release](agents/release.md) |
 | run or drive the app, debug a CI or test-runner failure | [Run & Debug](agents/run-debug.md) |
+| dispatching subagents or parallel search | [Subagents](agents/subagents.md) |
 | refresh agent guidance from past sessions | skill `refresh-agent-guidance` in `.agents/skills/` |
 
 ## Task Authority
@@ -32,6 +33,15 @@ Keep this file as always-loaded guidance. Load a focused doc only when the task 
 - Code review is findings-only by default. Fix only when asked, and limit a selected-fix request to the selected findings.
 - Implementation does not authorize commit, rebase, bookmark movement, push, pull-request or release actions, external comments, or hosted review-thread resolution. A meaningful sibling-workspace implementation normally ends with a local `jj describe`; publication still requires a separate request and the relevant focused guide.
 - Report evidence as separate claims: generation (`just ffi`), build, focused tests, real CLI/UI behavior, gated live integration, platform compatibility, and measurements. One does not imply the next. Name the command, target, and test slice behind each claim, and list what was skipped or blocked.
+
+## Subagents
+
+Parent plans, evaluates, and mutates. Spawn a worker only for a well-specified locate, inventory, or read job the parent should not spend turns searching for. Prefer a cheaper or faster model when the harness allows. Load [Subagents](agents/subagents.md) before dispatching.
+
+- Unknown-layout search across crates or shells: spawn. Independent areas may run in parallel.
+- Needle query (known path, one symbol, one URL): Grep or Read in the parent.
+- Workers in this checkout must not run `jj` or `jayjay review`. Parallel jj still means a sibling workspace.
+- Cursor Grok: use `Task` on the spawn cases above. Do not search unknown layout in the parent.
 
 ## Feature Loop
 

--- a/agents/subagents.md
+++ b/agents/subagents.md
@@ -1,0 +1,78 @@
+# Subagents
+
+Load this file before dispatching a worker, choosing its model, or deciding whether parallel search belongs in the parent session. Isolation rules for jj itself stay in [Version Control](version-control.md); this guide is only the dispatch contract.
+
+The rules are the same for every harness: spawn for unknown-layout or parallel locate work; keep planning, mutations, and review on the parent. Claude Code and Codex already fan out workers. Cursor Grok must use `Task` on the spawn cases below instead of searching unknown layout in the parent.
+
+## Roles
+
+- **Parent** (this session): plans, evaluates, and mutates. Owns crate-boundary decisions, jj in this workspace, inner-loop tests, cleanup rounds, `jj describe`, and review judgment.
+- **Worker**: a well-specified locate, inventory, or read job. Returns evidence — paths, line-level claims, and what it did not find. It does not implement the user's task and does not "finish the PR."
+
+## When to spawn
+
+Spawn when all of these hold:
+
+1. The subtask is well-specified: inputs, question, and return shape.
+2. The parent would otherwise spend turns mapping unknown layout, or two or more independent areas can run at once.
+3. The worker will not run `jj` or `jayjay review` in this checkout.
+
+Typical spawns:
+
+- Unknown-layout search: where a behavior lives in core vs SwiftUI vs GPUI.
+- One failing CI check, with the job name and log pinned.
+- Summarize a large log or trace so the parent does not ingest it whole.
+- A named read-only skill (`gpui-parity-audit` inventory, `ci-workflow-audit` table) that is not the whole user request.
+
+Do not spawn when:
+
+- The query is a needle: known path, one symbol, one URL, one file you can Read. Grep or Read in the parent.
+- You would only forward the user's whole task to a general-purpose worker.
+- The next step is a write, `jj`, or `jayjay review` in this checkout.
+- The worker would need the parent conversation to make sense.
+
+## Isolation
+
+A worker in this checkout is not a sibling workspace.
+
+- Workers here may read files, grep, and run non-jj commands. They must not invoke `jj` or `jayjay review`.
+- Parallel jj still means another sibling workspace, with one agent serializing jj there. Two workers in one checkout that both talk to jj are the divergence bug in [Version Control](version-control.md#command-concurrency).
+- If a subtask must run jj (rebase, describe, tests that snapshot), create the sibling first and treat that agent as the parent of that checkout.
+
+## Prompts
+
+Workers do not see the parent conversation. The prompt must stand alone:
+
+- Repo root, the question, which focused guide to load, and the return shape.
+- Stop conditions: do not edit, do not run `jj` or `jayjay review`, do not run `just test` / `just lint` / `just build`.
+- Ask for a short evidence report, not a dump of file bodies the parent will re-read.
+- Do not attach host MCP catalogs or SaaS tool schemas. The interface is this repo's files and CLI (`just`, `gh`).
+
+## Models
+
+- Parent keeps the session's stronger model for planning, architecture, jj mutations, and review.
+- Worker default: the cheaper or faster tier the harness exposes. Locate, inventory, log fetch, and "where does X live" do not need frontier reasoning.
+- Give a worker the parent's model only when the subtask itself is architecture or adversarial review.
+- Do not hard-code vendor model slugs in this guide; they rot. Use the harness's cheaper/faster vs default/frontier tiers.
+
+## Cursor
+
+Cursor dispatches through `Task`. Use:
+
+| Job | `subagent_type` |
+| --- | --- |
+| Unknown-layout search across crates or shells | `explore` |
+| One failing PR check, already identified | `ci-investigator` |
+| Drive the running app | `computerUse` |
+
+Do not use `generalPurpose` to re-delegate the whole user task. When the tool lets you pick a model, pick the cheaper/faster tier for locate and inventory. Launch independent explores in one turn; do not serialize three searches the parent could have fanned out. Load [Run & Debug](run-debug.md) before `computerUse` or `ci-investigator`.
+
+If the harness has no worker tool, search in-process with Grep/Read. That is still better than concurrent `jj` in this checkout.
+
+## Anti-patterns
+
+- Spawning because another harness would. Spawn because the search is unknown-layout or parallelizable.
+- Three workers grepping the same symbol.
+- A worker that returns fifty files for the parent to re-read.
+- A worker running `just test`, `just lint`, `jj`, or `jayjay review` in this checkout.
+- Loading extra MCP servers so a worker can "also do GitHub." Use `gh` / `just` / files.

--- a/agents/version-control.md
+++ b/agents/version-control.md
@@ -12,6 +12,7 @@ Never run JJ-aware commands concurrently in the same workspace. Read-only comman
 - Serialize `jayjay review ...` and any script or tool that opens the repository through JJ with other JJ-aware commands.
 - Parallelize only commands known not to read, snapshot, or update JJ's working-copy or operation state.
 - Parallel **workspaces** may run jj at the same time; parallel jj in **one** workspace may not.
+- A subagent in this checkout is not a sibling workspace. It must not run `jj` or `jayjay review`. Load [Subagents](subagents.md) before dispatching workers.
 - Running JayJay instances (SwiftUI or GPUI) that watch the repository snapshot on every filesystem event and fork the working-copy change while files churn. Quit them before divergence cleanup or history rewrites; otherwise operation reconciliation resurrects the stale siblings.
 - If divergence appears, compare each divergent commit to `@` by commit ID and abandon only snapshots proven stale; never abandon every commit for the shared change ID.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Parent plans and mutates; workers only locate or inventory, and must not run `jj` in this checkout. Cursor Grok should use `Task` for unknown-layout search the way Claude and Codex already fan out workers.

Docs only: `AGENTS.md`, `agents/subagents.md`, and `agents/version-control.md`. No `jayjay measure` or other code.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34568bcc-8b52-44a4-b948-427e0ccf9df4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34568bcc-8b52-44a4-b948-427e0ccf9df4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

