### PR TITLE
fix(ci): make the tools and refresh tests runner-independent

### DIFF
--- a/crates/jayjay-core/src/tools/launcher.rs
+++ b/crates/jayjay-core/src/tools/launcher.rs
@@ -141,8 +141,10 @@ mod tests {
 
     #[test]
     fn custom_editor_command_keeps_arguments_separate() {
-        let (binary, args) = resolved_command("sh -c 'exit 0'").expect("sh command");
-        assert!(binary.ends_with("/sh"));
+        let exe = std::env::current_exe().unwrap();
+        let command = format!("{} -c 'exit 0'", shell_words::quote(&exe.to_string_lossy()));
+        let (binary, args) = resolved_command(&command).expect("test binary");
+        assert_eq!(Path::new(&binary), exe);
         assert_eq!(args, ["-c", "exit 0"]);
     }
 

--- a/shell/mac/Tests/JayJayTests/RepoViewModelRefreshTests.swift
+++ b/shell/mac/Tests/JayJayTests/RepoViewModelRefreshTests.swift
@@ -8,9 +8,7 @@ final class RepoViewModelRefreshTests: RepoViewModelTestCase {
     func testWorkingCopyChangeWaitsForEditingAndDefersAnInFlightResult() async throws {
         let viewModel = try XCTUnwrap(viewModel)
         viewModel.refresh()
-        for _ in 0 ..< 200 where viewModel.isRefreshingInFlight {
-            try await Task.sleep(for: .milliseconds(20))
-        }
+        try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
         XCTAssertTrue(viewModel.selectedChange?.info.isWorkingCopy == true)
 
         try "refresh me\n".write(
@@ -28,17 +26,13 @@ final class RepoViewModelRefreshTests: RepoViewModelTestCase {
         XCTAssertTrue(viewModel.isRefreshingInFlight)
         viewModel.setBackgroundRefreshSuspended(true)
 
-        for _ in 0 ..< 200 where viewModel.isRefreshingInFlight {
-            try await Task.sleep(for: .milliseconds(20))
-        }
+        try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
         XCTAssertTrue(viewModel.hasPendingBackgroundRefresh)
         XCTAssertFalse(viewModel.selectedChange?.diff.contains { $0.path == "late-edit.txt" } == true)
 
         viewModel.setBackgroundRefreshSuspended(false)
         XCTAssertTrue(viewModel.isRefreshingInFlight)
-        for _ in 0 ..< 200 where viewModel.isRefreshingInFlight {
-            try await Task.sleep(for: .milliseconds(20))
-        }
+        try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
         XCTAssertNil(viewModel.error)
         XCTAssertTrue(viewModel.selectedChange?.diff.contains { $0.path == "late-edit.txt" } == true)
     }

--- a/shell/mac/Tests/JayJayTests/RepoViewModelSyncCancelTests.swift
+++ b/shell/mac/Tests/JayJayTests/RepoViewModelSyncCancelTests.swift
@@ -38,15 +38,4 @@ final class RepoViewModelSyncCancelTests: RepoViewModelTestCase {
         process.waitUntilExit()
         XCTAssertEqual(process.terminationStatus, 0, "jj \(arguments.joined(separator: " ")) failed")
     }
-
-    private func waitUntil(_ what: String, _ condition: @MainActor () -> Bool) async throws {
-        let deadline = Date().addingTimeInterval(10)
-        while !condition() {
-            if Date() >= deadline {
-                XCTFail("timed out waiting until \(what)")
-                throw CancellationError()
-            }
-            try await Task.sleep(for: .milliseconds(20))
-        }
-    }
 }

--- a/shell/mac/Tests/JayJayTests/RepoViewModelTestCase.swift
+++ b/shell/mac/Tests/JayJayTests/RepoViewModelTestCase.swift
@@ -29,4 +29,15 @@ class RepoViewModelTestCase: XCTestCase {
         }
         tempDirectory = nil
     }
+
+    func waitUntil(_ what: String, _ condition: @escaping @MainActor () -> Bool) async throws {
+        let deadline = Date().addingTimeInterval(30)
+        while !condition() {
+            if Date() >= deadline {
+                XCTFail("timed out waiting until \(what)")
+                throw CancellationError()
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
 }

--- a/shell/mac/Tests/JayJayTests/RepoViewModelTests.swift
+++ b/shell/mac/Tests/JayJayTests/RepoViewModelTests.swift
@@ -79,9 +79,7 @@ final class RepoViewModelTests: RepoViewModelTestCase {
 
         viewModel.newChange(parent: "@")
 
-        for _ in 0 ..< 100 where viewModel.successActionSignal == previousSignal {
-            try await Task.sleep(for: .milliseconds(20))
-        }
+        try await waitUntil("the new change succeeds") { viewModel.successActionSignal != previousSignal }
         XCTAssertGreaterThan(viewModel.successActionSignal, previousSignal)
         XCTAssertEqual(viewModel.commitSummaryDraft, "")
         XCTAssertEqual(viewModel.commitDescriptionDraft, "")
@@ -225,8 +223,8 @@ final class RepoViewModelTests: RepoViewModelTestCase {
 
         viewModel.squash(revs: [newest.selectionRevision, destination.selectionRevision])
 
-        for _ in 0 ..< 300 where viewModel.isRefreshingInFlight || viewModel.successActionSignal == 0 {
-            try await Task.sleep(for: .milliseconds(20))
+        try await waitUntil("the squash finishes") {
+            !viewModel.isRefreshingInFlight && viewModel.successActionSignal != 0
         }
         XCTAssertNil(viewModel.error)
         XCTAssertEqual(viewModel.selectedChange?.info.changeId.id, destinationChangeId)


### PR DESCRIPTION
Two tests that only fail on CI runners, seen on the `afab51e2` landing.

**Windows (GPUI CI, run 33836063126):** `tools::launcher::tests::custom_editor_command_keeps_arguments_separate` resolved `sh`, which is not on PATH on the Windows runner. The test now resolves the test binary itself, which exists on every platform, and still proves that the command is shell-split and the arguments stay separate.

**macOS (CI, run 33836063118):** `RepoViewModelRefreshTests.testWorkingCopyChangeWaitsForEditingAndDefersAnInFlightResult` waited at most 4 s for the first refresh with a counted loop and then asserted on whatever state it found. On a slow runner the first load takes longer, so the selection was still empty, the deferred snapshot landed early, and three asserts failed. The `waitUntil` deadline helper from the sync-cancel tests moves to `RepoViewModelTestCase` with a 30 s deadline, and the counted loops in the refresh and view-model tests use it: a slow load waits, and a hang fails with `timed out waiting until …` instead of a downstream assert.

Verified locally: `cargo test -p jayjay-core custom_editor_command` and `just test-app`.
