### PR TITLE
ci(mac): split the UI test bundle across three runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,12 @@ jobs:
         run: just test-app
 
   swift-ui:
+    name: swift-ui (${{ matrix.shard }}/3)
     runs-on: macos-26
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -89,18 +94,18 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          save-if: ${{ github.ref == 'refs/heads/main' && matrix.shard == 1 }}
 
       - name: Build app
         run: just build
 
       - name: UI tests
-        run: just test-ui
+        run: just test-ui-shard ${{ matrix.shard }} 3
 
       - name: Upload xcresult on failure
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ui-test-xcresult
+          name: ui-test-xcresult-${{ matrix.shard }}
           path: build/DerivedData/Logs/Test/*.xcresult
           if-no-files-found: warn

--- a/justfile
+++ b/justfile
@@ -14,7 +14,8 @@ list:
   @echo "just list              Show available commands"
   @echo "just test-rust crate   Package-scoped cargo test (inner loop)"
   @echo "just test-wasm         Link the portable UniFFI WASM surface with LLVM clang"
-  @echo "just test-ui [test-id] UI tests; pass a test id to run one scene"
+  @echo "just test-ui [test-ids] UI tests; pass test ids to run some scenes"
+  @echo "just test-ui-shard i n UI tests for every n-th scene class from i; CI shards"
   @echo "just test              All workspace Rust tests (publish)"
   @echo "just test-app          Run macOS app tests"
   @echo "just test-gpui         Run GPUI shell tests (via shell::gpui-test, needs jj on PATH)"
@@ -48,8 +49,16 @@ test:
 test-app:
   just shell::test
 
-test-ui test_id='':
-  just shell::ui-test "{{test_id}}"
+test-ui *test_ids:
+  just shell::ui-test {{test_ids}}
+
+# Run every count-th UI scene class starting at index (1-based), so CI can split the serial XCUITest bundle across runners.
+test-ui-shard index count:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  scenes=$(grep -hoE '^final class [A-Za-z0-9_]+' "{{justfile_directory()}}/shell/mac/Tests/JayJayUITests/Scenes/"*.swift \
+    | awk '{print "JayJayUITests/" $3}' | sort | awk -v i="{{index}}" -v n="{{count}}" 'NR % n == i % n')
+  just shell::ui-test $scenes
 
 test-gpui:
   just shell::gpui-test

--- a/shell/justfile
+++ b/shell/justfile
@@ -133,9 +133,9 @@ test: ffi sync-icon help
 ui-test-setup:
   bash "{{root}}/scripts/ui-test-fixtures.sh" "{{bundle_id}}"
 
-# Run the macOS UI test bundle. Pass a test-id to narrow the run, e.g.:
+# Run the macOS UI test bundle. Pass test ids to narrow the run, e.g.:
 #   just shell::ui-test JayJayUITests/CommandPaletteScene/testOpenAndSearch
-ui-test test_id='': ffi sync-icon help ui-test-setup
+ui-test *test_ids: ffi sync-icon help ui-test-setup
   #!/usr/bin/env bash
   set -euo pipefail
   xcodegen --spec "{{project}}/project.yml" --project "{{project}}"
@@ -146,9 +146,9 @@ ui-test test_id='': ffi sync-icon help ui-test-setup
     -sdk macosx
     -derivedDataPath "{{derived_data}}"
   )
-  if [[ -n "{{test_id}}" ]]; then
-    args+=(-only-testing:"{{test_id}}")
-  fi
+  for test_id in {{test_ids}}; do
+    args+=(-only-testing:"$test_id")
+  done
   xcodebuild "${args[@]}" test | xcbeautify
 
 reset-help-cache:


### PR DESCRIPTION
The `swift-ui` job runs 55 XCUITests across 40 scene classes serially, about 12.8 min of its 17. In-process parallelism is off on purpose: two runners launching the same macOS bundle terminate each other's app. This splits the scene classes across three runners instead.

- `just test-ui` takes any number of test ids (it took one) and passes each as `-only-testing:`.
- `just test-ui-shard <index> <count>` lists the scene classes under `Tests/JayJayUITests/Scenes`, sorts them, and runs every count-th one starting at index, so a new scene file joins a shard without registration.
- `swift-ui` becomes a 3-way matrix with `fail-fast: false`; each shard uploads its own xcresult, and only shard 1 saves the Rust cache on main.

With the last green run's per-scene timings the shards carry about 4.0, 4.5, and 3.0 min of tests on top of the 3 min build, so the job's wall time drops from about 17 min to 8 or 9. The repo is public, so the extra runner minutes are free.

Verified locally: `just -n` dry runs of both recipes and the shard selection (14/13/13 classes). Not run locally: a real sharded xcodebuild pass, because XCUITest terminates the running JayJay instance; this PR's own swift-ui jobs are that check.
