### PR TITLE
fix(gpui): dispatch menu bar item actions through the window

### DIFF
--- a/shell/gpui/src/ui/app_menu.rs
+++ b/shell/gpui/src/ui/app_menu.rs
@@ -250,10 +250,11 @@ fn action_row(
         let view = view.clone();
         row.cursor_pointer()
             .hover(|s| s.bg(rgb(t.selected_bg)))
-            .on_mouse_down(MouseButton::Left, move |_: &MouseDownEvent, _, cx| {
+            .on_mouse_down(MouseButton::Left, move |_: &MouseDownEvent, window, cx| {
                 cx.stop_propagation();
                 view.update(cx, |this, cx| this.close_app_menu(cx));
-                cx.dispatch_action(action.as_ref());
+                // App-level dispatch re-enters this window's update from inside its own event handler and fails silently.
+                window.dispatch_action(action.boxed_clone(), cx);
             })
             .into_any_element()
     }
@@ -276,3 +277,6 @@ fn section_gap(t: &Theme) -> AnyElement {
         .bg(rgb(t.border))
         .into_any_element()
 }
+
+#[cfg(test)]
+mod tests;

--- a/shell/gpui/src/ui/app_menu/tests.rs
+++ b/shell/gpui/src/ui/app_menu/tests.rs
@@ -1,0 +1,53 @@
+use gpui::{
+    Context, Entity, IntoElement, Modifiers, ParentElement, Render, Styled, VisualTestContext,
+    Window, div, px, size,
+};
+
+use super::action_row;
+use crate::app::actions::OpenSettings;
+use crate::app::config::{AppConfig, AppConfigStore};
+use crate::app::theme::Theme;
+use crate::repo::window::RepoWindow;
+
+struct MenuRowHost {
+    repo: Entity<RepoWindow>,
+}
+
+impl Render for MenuRowHost {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        div().size_full().child(action_row(
+            "Settings...".to_owned(),
+            Box::new(OpenSettings),
+            false,
+            false,
+            &Theme::light(),
+            &self.repo,
+        ))
+    }
+}
+
+#[gpui::test]
+fn menu_item_click_dispatches_its_action(cx: &mut gpui::TestAppContext) {
+    cx.update(|cx| {
+        cx.set_global(Theme::light());
+        cx.set_global(AppConfigStore::new(AppConfig::default()));
+        crate::app::menus::install(cx);
+    });
+    let dir = tempfile::tempdir().unwrap();
+    let (repo, _) =
+        cx.add_window_view(|_, cx| RepoWindow::new_with_onboarding(dir.path().to_path_buf(), cx));
+    let (_, cx) = cx.add_window_view(|_, _| MenuRowHost { repo });
+    let cx: &mut VisualTestContext = cx;
+    cx.update(|window, _| window.activate_window());
+    cx.simulate_resize(size(px(300.), px(40.)));
+    cx.run_until_parked();
+    let row = cx
+        .debug_bounds("app-menu-item-Settings...")
+        .expect("menu row bounds");
+    let windows_before = cx.windows().len();
+
+    cx.simulate_click(row.center(), Modifiers::default());
+    cx.run_until_parked();
+
+    assert_eq!(cx.windows().len(), windows_before + 1);
+}


### PR DESCRIPTION
Clicking an item in the in-window menu bar (Linux/Windows) closed the dropdown but ran nothing. The item handler used the app-level `dispatch_action`, which looks up the active window and calls `update` on it; the handler already runs inside that window's event dispatch, where GPUI has taken the window out of its table, so the nested update failed with "window not found" and was only logged (no logger is installed). Keyboard shortcuts never re-enter the window, which is why they worked, and X11 sessions that report no active window fell back to the global handlers, which is why LXDE looked fine.

Dispatch through the `Window` the handler already receives.

Regression test: `ui::app_menu::tests::menu_item_click_dispatches_its_action` renders the real `action_row` in a test window, activates it, clicks the row, and expects the Settings window to open. Verified on Linux (aarch64, Ubuntu 22.04): fails on main, passes with the fix; `cargo test -p jayjay-gpui` unit tests and `cargo clippy --all-targets -D warnings` pass there. The module is compiled out on macOS, so CI's Linux/Windows jobs are the gate.