### PR TITLE
fix(gpui): set the Linux app id on every window

### DIFF
--- a/shell/gpui/src/app/mod.rs
+++ b/shell/gpui/src/app/mod.rs
@@ -11,5 +11,11 @@ pub mod telemetry;
 pub mod theme;
 pub mod tools;
 
-#[cfg(target_os = "linux")]
 pub(crate) const APP_ID: &str = "dev.hewig.JayJay";
+
+pub fn window_options() -> gpui::WindowOptions {
+    gpui::WindowOptions {
+        app_id: Some(APP_ID.to_owned()),
+        ..Default::default()
+    }
+}

--- a/shell/gpui/src/external_tool/open.rs
+++ b/shell/gpui/src/external_tool/open.rs
@@ -29,7 +29,7 @@ pub fn open_external_tool(invocation: ExternalToolInvocation, cx: &mut App) -> R
                         y: px(14.),
                     }),
                 }),
-                ..Default::default()
+                ..crate::app::window_options()
             },
             move |_, cx| {
                 cx.new(|cx| {

--- a/shell/gpui/src/main.rs
+++ b/shell/gpui/src/main.rs
@@ -139,7 +139,7 @@ fn main() {
                         y: px(14.),
                     }),
                 }),
-                ..Default::default()
+                ..jayjay_gpui::app::window_options()
             },
             move |window, cx| {
                 cx.set_global(Theme::for_appearance(

--- a/shell/gpui/src/repo/window/open.rs
+++ b/shell/gpui/src/repo/window/open.rs
@@ -41,7 +41,7 @@ pub fn open_repo_window(path: PathBuf, cx: &mut App) {
                 y: px(14.),
             }),
         }),
-        ..Default::default()
+        ..crate::app::window_options()
     };
     let handle = cx.open_window(opts, move |_, cx| {
         cx.new(|cx| {

--- a/shell/gpui/src/windows/bookmark_manager.rs
+++ b/shell/gpui/src/windows/bookmark_manager.rs
@@ -62,7 +62,7 @@ impl BookmarkManagerView {
                         title: Some("Bookmark Manager".into()),
                         ..Default::default()
                     }),
-                    ..Default::default()
+                    ..crate::app::window_options()
                 },
                 |_, cx| {
                     cx.new(|cx| {

--- a/shell/gpui/src/windows/command_palette/input.rs
+++ b/shell/gpui/src/windows/command_palette/input.rs
@@ -45,7 +45,7 @@ impl CommandPalette {
                         ..Default::default()
                     }),
                     kind: WindowKind::PopUp,
-                    ..Default::default()
+                    ..crate::app::window_options()
                 },
                 |_, cx| {
                     let repo_path = repo_path.clone();

--- a/shell/gpui/src/windows/evolog.rs
+++ b/shell/gpui/src/windows/evolog.rs
@@ -70,7 +70,7 @@ impl EvologView {
                         title: Some(format!("Evolution: {title}").into()),
                         ..Default::default()
                     }),
-                    ..Default::default()
+                    ..crate::app::window_options()
                 },
                 |_, cx| {
                     cx.new(|cx| {

--- a/shell/gpui/src/windows/file_history.rs
+++ b/shell/gpui/src/windows/file_history.rs
@@ -47,7 +47,7 @@ impl FileHistoryView {
                         title: Some(title.into()),
                         ..Default::default()
                     }),
-                    ..Default::default()
+                    ..crate::app::window_options()
                 },
                 |_, cx| {
                     cx.new(|cx| {

--- a/shell/gpui/src/windows/keyboard_shortcuts.rs
+++ b/shell/gpui/src/windows/keyboard_shortcuts.rs
@@ -30,7 +30,7 @@ impl KeyboardShortcutsView {
                         title: Some("Keyboard Shortcuts".into()),
                         ..Default::default()
                     }),
-                    ..Default::default()
+                    ..crate::app::window_options()
                 },
                 |_, cx| {
                     cx.new(|cx| {

--- a/shell/gpui/src/windows/open_repository.rs
+++ b/shell/gpui/src/windows/open_repository.rs
@@ -28,7 +28,7 @@ impl OpenRepositoryPathView {
                         title: Some("Open Repository by Path".into()),
                         ..Default::default()
                     }),
-                    ..Default::default()
+                    ..crate::app::window_options()
                 },
                 |_, cx| {
                     cx.new(|cx| {

--- a/shell/gpui/src/windows/operation_log/mod.rs
+++ b/shell/gpui/src/windows/operation_log/mod.rs
@@ -46,7 +46,7 @@ impl OperationLogView {
                         title: Some("Operation Log".into()),
                         ..Default::default()
                     }),
-                    ..Default::default()
+                    ..crate::app::window_options()
                 },
                 |_, cx| {
                     cx.new(|cx| {

--- a/shell/gpui/src/windows/repo_list/window.rs
+++ b/shell/gpui/src/windows/repo_list/window.rs
@@ -55,7 +55,7 @@ impl RepoListWindow {
                             y: px(14.),
                         }),
                     }),
-                    ..Default::default()
+                    ..crate::app::window_options()
                 },
                 |_, cx| {
                     cx.new(|cx| {

--- a/shell/gpui/src/windows/settings/mod.rs
+++ b/shell/gpui/src/windows/settings/mod.rs
@@ -69,7 +69,7 @@ impl SettingsView {
                         title: Some("JayJay Settings".into()),
                         ..Default::default()
                     }),
-                    ..Default::default()
+                    ..crate::app::window_options()
                 },
                 |_, cx| {
                     cx.new(|cx| {


### PR DESCRIPTION
GPUI windows never set `WindowOptions.app_id`, so their Wayland app id was empty (Hyprland listed class `''`) and taskbars could not match them to `dev.hewig.JayJay.desktop`. All twelve window sites now spread `app::window_options()`, which sets the id; `APP_ID` is no longer Linux-only because the helper is used on every platform (ignored on macOS and Windows). Verified on Omarchy: `hyprctl clients` now reports class `dev.hewig.JayJay`.

The earlier revision of this PR also re-pinned gpui to upstream zed, dropping the fork's aarch64 swapchain workaround. That part is reverted: on a uConsole (Raspberry Pi CM4, V3D 4.2 Vulkan driver) a build without the patch panics at startup with `wgpu-hal … Trying to destroy a SwapchainAcquireSemaphore that is still in use by a SurfaceTexture`, while the patched fork survives repeated Settings open/close, fullscreen toggles, resizes, and quit (exit 0) on the same device. Lavapipe on the Omarchy VM never reproduced it, which is why the VM run looked clean. The fork stays.