### PR TITLE
fix(tools): make the Linux system editor usable and name it in menus

### DIFF
--- a/crates/jayjay-core/src/tools/file_url.rs
+++ b/crates/jayjay-core/src/tools/file_url.rs
@@ -30,7 +30,7 @@ fn existing_repo_file_path(repo_path: &str, file_path: &str) -> Option<PathBuf> 
     Some(candidate)
 }
 
-fn file_url_from_path(path: &Path) -> String {
+pub(super) fn file_url_from_path(path: &Path) -> String {
     let mut path = path.to_string_lossy().replace('\\', "/");
     if cfg!(windows) && path.as_bytes().get(1) == Some(&b':') {
         path.insert(0, '/');

--- a/crates/jayjay-core/src/tools/launcher.rs
+++ b/crates/jayjay-core/src/tools/launcher.rs
@@ -5,7 +5,7 @@ use crate::repo::{find_existing_binary, subprocess_command};
 use super::config::ToolsConfig;
 use super::editor::Editor;
 use super::platform;
-use super::terminal::{Terminal, escape_single_quotes};
+use super::terminal::Terminal;
 
 /// Open `file_path` (relative to `repo_path`, or absolute) in the user's editor.
 /// Returns false when the binary is missing or spawn fails.
@@ -13,41 +13,83 @@ pub fn open_in_editor(repo_path: &str, file_path: &str, cfg: &ToolsConfig) -> bo
     let editor = Editor::from_id(&cfg.external_editor);
     let absolute = absolutize(repo_path, file_path);
 
-    let cmd = match editor {
-        Some(Editor::SystemDefault) => system_editor_command(),
-        Some(e) if e != Editor::Custom => e.command().to_owned(),
-        _ => cfg.custom_editor_command.clone(),
+    let launch = match editor {
+        Some(Editor::SystemDefault) => {
+            system_editor_launch(env_command(&["VISUAL", "EDITOR"]), &absolute)
+        }
+        other => {
+            let cmd = match other {
+                Some(e) if e != Editor::Custom => e.command().to_owned(),
+                _ => cfg.custom_editor_command.clone(),
+            };
+            let launch_args = other.map(Editor::launch_args).unwrap_or_default();
+            let in_terminal = classify_editor(&cmd) == EditorKind::Terminal;
+            EditorLaunch::from_command(&cmd, launch_args, &absolute, in_terminal)
+        }
     };
-    if cmd.is_empty() {
-        return false;
-    }
-    if command_is_terminal_editor(&cmd) {
-        return open_in_terminal(
-            repo_path,
-            Some(&editor_terminal_command(&cmd, &absolute)),
-            cfg,
-        );
-    }
-    let Some((binary, args)) = resolved_command(&cmd) else {
-        return false;
-    };
-    let mut launch_args: Vec<_> = editor
-        .map(Editor::launch_args)
-        .unwrap_or_default()
-        .iter()
-        .map(|arg| (*arg).to_owned())
-        .collect();
-    launch_args.extend(args);
-    subprocess_command(&binary)
-        .args(launch_args)
-        .arg(&absolute)
-        .spawn()
-        .is_ok()
+    launch.is_some_and(|launch| launch.spawn(repo_path, cfg))
 }
 
-fn system_editor_command() -> String {
-    env_command(&["VISUAL", "EDITOR"]).unwrap_or_else(|| "xdg-open".to_owned())
+/// `argv[0]` is the resolved executable and the target path is already included.
+pub(super) struct EditorLaunch {
+    pub(super) argv: Vec<String>,
+    pub(super) in_terminal: bool,
 }
+
+impl EditorLaunch {
+    fn from_command(
+        cmd: &str,
+        launch_args: &[&str],
+        path: &str,
+        in_terminal: bool,
+    ) -> Option<Self> {
+        let (binary, args) = resolved_command(cmd)?;
+        let mut argv = vec![binary];
+        argv.extend(launch_args.iter().map(|arg| (*arg).to_owned()));
+        argv.extend(args);
+        argv.push(path.to_owned());
+        Some(Self { argv, in_terminal })
+    }
+
+    fn terminal_line(&self) -> String {
+        shell_words::join(&self.argv)
+    }
+
+    fn spawn(self, repo_path: &str, cfg: &ToolsConfig) -> bool {
+        if self.in_terminal {
+            return open_in_terminal(repo_path, Some(&self.terminal_line()), cfg);
+        }
+        subprocess_command(&self.argv[0])
+            .args(&self.argv[1..])
+            .spawn()
+            .is_ok()
+    }
+}
+
+/// `$VISUAL`/`$EDITOR` are terminal-context commands (git runs them inside a terminal), so on Linux only a known GUI editor launches directly.
+fn system_editor_launch(env_editor: Option<String>, path: &str) -> Option<EditorLaunch> {
+    match env_editor {
+        Some(cmd) => EditorLaunch::from_command(&cmd, &[], path, env_editor_needs_terminal(&cmd)),
+        None => default_text_editor(path)
+            .or_else(|| EditorLaunch::from_command("xdg-open", &[], path, false)),
+    }
+}
+
+fn env_editor_needs_terminal(cmd: &str) -> bool {
+    match classify_editor(cmd) {
+        EditorKind::Terminal => true,
+        EditorKind::Gui => false,
+        EditorKind::Unknown => cfg!(target_os = "linux"),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn default_text_editor(_path: &str) -> Option<EditorLaunch> {
+    None
+}
+
+#[cfg(not(target_os = "macos"))]
+use platform::default_text_editor;
 
 pub(super) fn env_command(names: &[&str]) -> Option<String> {
     names.iter().find_map(|name| {
@@ -63,22 +105,39 @@ pub(super) fn resolved_command(command: &str) -> Option<(String, Vec<String>)> {
     Some((binary, words.collect()))
 }
 
-fn command_is_terminal_editor(command: &str) -> bool {
+#[derive(Debug, PartialEq, Eq)]
+enum EditorKind {
+    Terminal,
+    Gui,
+    Unknown,
+}
+
+fn classify_editor(command: &str) -> EditorKind {
     let Ok(words) = shell_words::split(command) else {
-        return false;
+        return EditorKind::Unknown;
     };
     let Some(binary) = words
         .first()
         .and_then(|binary| Path::new(binary).file_name()?.to_str())
     else {
-        return false;
+        return EditorKind::Unknown;
     };
     match binary {
-        "vi" | "vim" | "nvim" | "nano" | "micro" | "hx" | "helix" | "kak" => true,
-        "emacs" => words
-            .iter()
-            .any(|arg| arg == "-nw" || arg == "--no-window-system"),
-        _ => false,
+        "vi" | "vim" | "nvim" | "nano" | "micro" | "hx" | "helix" | "kak" => EditorKind::Terminal,
+        "emacs" | "emacsclient" => {
+            if words
+                .iter()
+                .any(|arg| matches!(arg.as_str(), "-nw" | "--no-window-system" | "-t" | "--tty"))
+            {
+                EditorKind::Terminal
+            } else {
+                EditorKind::Gui
+            }
+        }
+        "code" | "code-insiders" | "codium" | "cursor" | "zed" | "subl" | "sublime_text"
+        | "gnome-text-editor" | "gedit" | "kate" | "kwrite" | "mousepad" | "xed" | "pluma"
+        | "geany" | "gvim" => EditorKind::Gui,
+        _ => EditorKind::Unknown,
     }
 }
 
@@ -87,13 +146,6 @@ fn command_is_terminal_editor(command: &str) -> bool {
 pub fn open_in_terminal(repo_path: &str, command: Option<&str>, cfg: &ToolsConfig) -> bool {
     let term = Terminal::from_id(&cfg.terminal).unwrap_or(Terminal::SystemDefault);
     platform::spawn_terminal(term, repo_path, command, &cfg.custom_terminal_command)
-}
-
-/// Build the `<editor> '<path>'` shell command for a terminal editor.
-/// `path` is attacker-controlled (any cloned repo), so single-quote escape it
-/// before splicing into the shell line the terminal executes.
-fn editor_terminal_command(cmd: &str, path: &str) -> String {
-    format!("{cmd} '{}'", escape_single_quotes(path))
 }
 
 fn absolutize(repo_path: &str, file_path: &str) -> String {
@@ -112,31 +164,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn editor_command_quotes_plain_path() {
-        assert_eq!(
-            editor_terminal_command("vim", "/repo/src/main.rs"),
-            "vim '/repo/src/main.rs'"
-        );
-    }
-
-    #[test]
-    fn editor_command_keeps_apostrophe_filename_intact() {
-        // A legitimate filename with an apostrophe must stay a single word.
-        assert_eq!(
-            editor_terminal_command("vim", "/repo/don't.md"),
-            "vim '/repo/don'\\''t.md'"
-        );
-    }
-
-    #[test]
-    fn editor_command_neutralizes_injection_payload() {
-        // Crafted filename in a cloned repo: the closing quote + payload must not escape the single-quoted word.
-        let cmd = editor_terminal_command("vim", "/repo/a'$(touch /tmp/pwned)'.rs");
-        // The only unescaped single quotes are the wrapping pair we added.
-        assert!(cmd.starts_with("vim '"));
-        assert!(cmd.ends_with('\''));
-        // The payload's quotes are escaped via the '\'' idiom, so `$(...)` stays literal inside the quoted word rather than running as a command.
-        assert!(cmd.contains("a'\\''$(touch /tmp/pwned)'\\''.rs"));
+    fn terminal_line_keeps_hostile_paths_as_one_quoted_word() {
+        let launch = EditorLaunch {
+            argv: vec![
+                "vim".to_owned(),
+                "/repo/a'$(touch /tmp/pwned)'.rs".to_owned(),
+            ],
+            in_terminal: true,
+        };
+        let line = launch.terminal_line();
+        assert_eq!(shell_words::split(&line).unwrap(), launch.argv);
+        assert!(line.contains("a'\\''$(touch /tmp/pwned)'\\''.rs"));
     }
 
     #[test]
@@ -149,12 +187,26 @@ mod tests {
     }
 
     #[test]
-    fn terminal_editor_detection_covers_common_editors() {
-        assert!(command_is_terminal_editor("nvim --clean"));
-        assert!(command_is_terminal_editor("/usr/bin/vim -f"));
-        assert!(command_is_terminal_editor("nano"));
-        assert!(command_is_terminal_editor("emacs -nw"));
-        assert!(!command_is_terminal_editor("emacs"));
-        assert!(!command_is_terminal_editor("code --wait"));
+    fn editor_classification_covers_common_editors() {
+        assert_eq!(classify_editor("nvim --clean"), EditorKind::Terminal);
+        assert_eq!(classify_editor("/usr/bin/vim -f"), EditorKind::Terminal);
+        assert_eq!(classify_editor("emacs -nw"), EditorKind::Terminal);
+        assert_eq!(classify_editor("emacsclient -t"), EditorKind::Terminal);
+        assert_eq!(classify_editor("emacs"), EditorKind::Gui);
+        assert_eq!(classify_editor("code --wait"), EditorKind::Gui);
+        assert_eq!(
+            classify_editor("omarchy-launch-editor --inline"),
+            EditorKind::Unknown
+        );
+    }
+
+    #[test]
+    fn env_editor_runs_in_terminal_unless_gui() {
+        assert!(!env_editor_needs_terminal("code --wait"));
+        assert!(env_editor_needs_terminal("nvim"));
+        assert_eq!(
+            env_editor_needs_terminal("omarchy-launch-editor --inline"),
+            cfg!(target_os = "linux")
+        );
     }
 }

--- a/crates/jayjay-core/src/tools/platform.rs
+++ b/crates/jayjay-core/src/tools/platform.rs
@@ -5,6 +5,6 @@ mod macos;
 mod linux;
 
 #[cfg(not(target_os = "macos"))]
-pub use linux::{EDITOR_OPTIONS, TERMINAL_OPTIONS, spawn_terminal};
+pub use linux::{EDITOR_OPTIONS, TERMINAL_OPTIONS, default_text_editor, spawn_terminal};
 #[cfg(target_os = "macos")]
 pub use macos::{EDITOR_OPTIONS, TERMINAL_OPTIONS, spawn_terminal};

--- a/crates/jayjay-core/src/tools/platform/linux.rs
+++ b/crates/jayjay-core/src/tools/platform/linux.rs
@@ -1,10 +1,14 @@
 use std::process::Command;
 
+mod desktop_entry;
+
+pub use desktop_entry::default_text_editor;
+
 use super::super::launcher::{env_command, resolved_command};
 use super::super::terminal::{Terminal, shell_line};
 
 pub const EDITOR_OPTIONS: &[(&str, &str)] = &[
-    ("system", "System Default"),
+    ("system", "System Editor"),
     ("vscode", "Visual Studio Code"),
     ("vscodium", "VSCodium"),
     ("cursor", "Cursor"),
@@ -18,7 +22,7 @@ pub const EDITOR_OPTIONS: &[(&str, &str)] = &[
 ];
 
 pub const TERMINAL_OPTIONS: &[(&str, &str)] = &[
-    ("terminal", "System Default"),
+    ("terminal", "System Terminal"),
     ("gnome-terminal", "GNOME Terminal"),
     ("konsole", "Konsole"),
     ("lxterminal", "LXTerminal"),

--- a/crates/jayjay-core/src/tools/platform/linux/desktop_entry.rs
+++ b/crates/jayjay-core/src/tools/platform/linux/desktop_entry.rs
@@ -1,0 +1,193 @@
+use std::path::{Path, PathBuf};
+
+use crate::repo::{find_existing_binary, subprocess_command};
+
+use super::super::super::file_url::file_url_from_path;
+use super::super::super::launcher::EditorLaunch;
+
+/// The `text/plain` handler's desktop entry as a launch for `path`.
+pub fn default_text_editor(path: &str) -> Option<EditorLaunch> {
+    let desktop_id = xdg_mime_default("text/plain")?;
+    let entry = find_desktop_file(&desktop_id, &application_dirs())?;
+    let (exec, in_terminal) = parse_desktop_entry(&std::fs::read_to_string(entry).ok()?)?;
+    let mut argv = expand_exec(&exec, path)?;
+    argv[0] = find_existing_binary(&argv[0])?;
+    Some(EditorLaunch { argv, in_terminal })
+}
+
+fn xdg_mime_default(mime: &str) -> Option<String> {
+    let binary = find_existing_binary("xdg-mime")?;
+    let output = subprocess_command(&binary)
+        .args(["query", "default", mime])
+        .output()
+        .ok()?;
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    (output.status.success() && !value.is_empty()).then_some(value)
+}
+
+/// Absolute directories only: a relative XDG entry would resolve against the repository the app was launched in.
+fn application_dirs() -> Vec<PathBuf> {
+    let env_path = |name: &str| {
+        std::env::var_os(name)
+            .filter(|value| !value.is_empty())
+            .map(PathBuf::from)
+    };
+    let data_home = env_path("XDG_DATA_HOME")
+        .or_else(|| env_path("HOME").map(|home| home.join(".local/share")));
+    let data_dirs = std::env::var("XDG_DATA_DIRS")
+        .ok()
+        .filter(|dirs| !dirs.is_empty())
+        .unwrap_or_else(|| "/usr/local/share:/usr/share".to_owned());
+    data_home
+        .into_iter()
+        .chain(data_dirs.split(':').map(PathBuf::from))
+        .filter(|dir| dir.is_absolute())
+        .map(|dir| dir.join("applications"))
+        .collect()
+}
+
+/// Desktop IDs encode subdirectories as `-`, so `vendor-nvim.desktop` may live at `vendor/nvim.desktop`.
+fn find_desktop_file(desktop_id: &str, dirs: &[PathBuf]) -> Option<PathBuf> {
+    dirs.iter().find_map(|dir| {
+        let direct = dir.join(desktop_id);
+        if direct.is_file() {
+            return Some(direct);
+        }
+        desktop_files(dir, 3).into_iter().find(|file| {
+            file.strip_prefix(dir).is_ok_and(|relative| {
+                let id: Vec<_> = relative.iter().map(|part| part.to_string_lossy()).collect();
+                id.join("-") == desktop_id
+            })
+        })
+    })
+}
+
+fn desktop_files(dir: &Path, depth: usize) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .flat_map(|entry| {
+            let path = entry.path();
+            match entry.file_type() {
+                Ok(kind) if kind.is_dir() && depth > 0 => desktop_files(&path, depth - 1),
+                Ok(kind)
+                    if kind.is_file() && path.extension().is_some_and(|ext| ext == "desktop") =>
+                {
+                    vec![path]
+                }
+                _ => Vec::new(),
+            }
+        })
+        .collect()
+}
+
+fn parse_desktop_entry(contents: &str) -> Option<(String, bool)> {
+    let mut in_main_group = false;
+    let mut exec = None;
+    let mut terminal = false;
+    for line in contents.lines().map(str::trim) {
+        if line.starts_with('[') {
+            in_main_group = line == "[Desktop Entry]";
+        } else if !in_main_group {
+            continue;
+        } else if let Some(value) = line.strip_prefix("Exec=") {
+            exec = Some(value.trim().to_owned());
+        } else if let Some(value) = line.strip_prefix("Terminal=") {
+            terminal = value.trim() == "true";
+        }
+    }
+    exec.filter(|exec| !exec.is_empty())
+        .map(|exec| (exec, terminal))
+}
+
+fn expand_exec(exec: &str, path: &str) -> Option<Vec<String>> {
+    let mut argv = Vec::new();
+    let mut has_target = false;
+    for word in shell_words::split(exec).ok()? {
+        match word.as_str() {
+            "%f" | "%F" => {
+                has_target = true;
+                argv.push(path.to_owned());
+            }
+            "%u" | "%U" => {
+                has_target = true;
+                argv.push(file_url_from_path(Path::new(path)));
+            }
+            "%%" => argv.push("%".to_owned()),
+            code if code.len() == 2 && code.starts_with('%') => {}
+            _ => argv.push(word),
+        }
+    }
+    if argv.is_empty() {
+        return None;
+    }
+    if !has_target {
+        argv.push(path.to_owned());
+    }
+    Some(argv)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{expand_exec, find_desktop_file, parse_desktop_entry};
+
+    #[test]
+    fn desktop_entry_reads_exec_and_terminal_from_the_main_group() {
+        let nvim = "[Desktop Entry]\nExec=nvim %F\nTerminal=true\n";
+        assert_eq!(
+            parse_desktop_entry(nvim),
+            Some(("nvim %F".to_owned(), true))
+        );
+        let gui = "[Desktop Entry]\nExec=editor --new-window %U\nTerminal=false\n[Desktop Action Console]\nExec=editor --console %F\nTerminal=true\n";
+        assert_eq!(
+            parse_desktop_entry(gui),
+            Some(("editor --new-window %U".to_owned(), false))
+        );
+        assert_eq!(parse_desktop_entry("[Desktop Entry]\nName=Broken\n"), None);
+    }
+
+    #[test]
+    fn exec_field_codes_expand_in_place() {
+        let path = "/repo/a b.rs";
+        assert_eq!(expand_exec("nvim %F", path).unwrap(), ["nvim", path]);
+        assert_eq!(
+            expand_exec("wrapper %f fixed", path).unwrap(),
+            ["wrapper", path, "fixed"]
+        );
+        assert_eq!(
+            expand_exec("browser %U", path).unwrap(),
+            ["browser", "file:///repo/a%20b.rs"]
+        );
+        assert_eq!(
+            expand_exec("editor --new-window %i", path).unwrap(),
+            ["editor", "--new-window", path]
+        );
+        assert_eq!(expand_exec("", path), None);
+    }
+
+    #[test]
+    fn desktop_ids_resolve_encoded_subdirectories_without_following_symlink_loops() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join("vendor")).unwrap();
+        std::fs::write(
+            dir.path().join("vendor").join("nvim.desktop"),
+            "[Desktop Entry]\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("gedit.desktop"), "[Desktop Entry]\n").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(".", dir.path().join("loop")).unwrap();
+        let dirs = [dir.path().to_path_buf()];
+        assert_eq!(
+            find_desktop_file("gedit.desktop", &dirs),
+            Some(dir.path().join("gedit.desktop"))
+        );
+        assert_eq!(
+            find_desktop_file("vendor-nvim.desktop", &dirs),
+            Some(dir.path().join("vendor").join("nvim.desktop"))
+        );
+        assert_eq!(find_desktop_file("missing.desktop", &dirs), None);
+    }
+}


### PR DESCRIPTION
Two Linux findings from testing on Omarchy.

**Ambiguous menu labels.** The Repository menu showed "Open in System Default" twice, once for the editor and once for the terminal. The Linux catalog entries are now "System Editor" and "System Terminal", so the menu reads "Open in System Editor" / "Open in System Terminal" and Settings shows the same names.

**System editor rarely worked.** `$VISUAL`/`$EDITOR` is a terminal-context command: git and distro wrappers run it inside a terminal, and Omarchy's session sets `EDITOR="omarchy-launch-editor --inline"`, which execs nvim and expects a tty. JayJay spawned it directly unless it recognised a terminal editor by name, so the wrapper died silently. With neither variable set it used `xdg-open`, which opens a file manager for the repository directory and cannot launch a `Terminal=true` desktop default (`nvim.desktop` on Omarchy) from a GUI process.

Editor launches are now resolved into an argv (`EditorLaunch`) before spawning. Commands are classified as terminal, GUI, or unknown (`classify_editor`); for the system editor on Linux only a known GUI editor launches directly and everything else runs inside the configured terminal, after `resolved_command` confirms the executable exists so a missing editor is reported rather than leaving a shell error in a terminal. Without `$VISUAL`/`$EDITOR`, the desktop's default text editor is used: `xdg-mime query default text/plain` (resolved through the login-shell PATH like the other tools) → desktop file found in the absolute XDG application dirs, including subdirectory-encoded ids, with a bounded walk that does not follow directory symlinks → `Exec` and `Terminal` from the `[Desktop Entry]` group only, with `%f`/`%F`/`%u`/`%U` expanded in place (path appended only when no field names it). Catalog and custom editors keep their previous behaviour, and so does Windows, where unknown commands still launch directly.

Tests: `classify_editor` incl. emacs/emacsclient flags and an unknown wrapper; the env-editor decision; the terminal line keeping a hostile path as one quoted word; desktop-entry parsing (main group vs action group); `Exec` field-code expansion incl. URL fields; desktop-id resolution incl. `vendor-nvim.desktop` → `vendor/nvim.desktop` with a `loop -> .` symlink present. Verified on Linux (aarch64): core tools tests, `cargo test -p jayjay-gpui` (190 + 323), `cargo clippy --all-targets -D warnings`; macOS `cargo check --all-targets`.

Verified on Omarchy with the branch AppImage: with no editor variables the palette action opened a terminal running `nvim` on the repository (resolved from the `text/plain` handler); with the session's `EDITOR="omarchy-launch-editor --inline"` the terminal ran the wrapper, which execed the editor inside it. The palette lists the action as "Open in System Editor".