### PR TITLE
fix(mac): count only open notes in the side-by-side banner

### DIFF
--- a/scripts/ui-test-fixtures.sh
+++ b/scripts/ui-test-fixtures.sh
@@ -149,6 +149,8 @@ fixture_review_notes() {
       '    lines.append("total: \(total)")' \
       '    return lines.joined(separator: "\n")' \
       '}' > scoring.swift
+    # A modified tracked file gives the scene a two-column diff, which is the only layout that offers side-by-side.
+    printf '# Sample scoring project\n' > README.md
   )
 }
 

--- a/shell/mac/Sources/JayJay/Diff/DiffSection+Content.swift
+++ b/shell/mac/Sources/JayJay/Diff/DiffSection+Content.swift
@@ -77,7 +77,7 @@ extension DiffSection {
                     if settings.sideBySideDiff, canUseSideBySide(diff) {
                         VStack(alignment: .leading, spacing: 0) {
                             // Side-by-side has no review gutter yet; without this bridge the file's advertised notes would be unreachable until the user guesses to switch views.
-                            if reviewNotesEnabled, !loadedReviewNoteSummaries().isEmpty {
+                            if reviewNotesEnabled, !unresolvedReviewNoteSummaries.isEmpty {
                                 sideBySideNotesBanner
                                 Divider()
                             }
@@ -223,8 +223,12 @@ extension DiffSection {
         )
     }
 
+    private var unresolvedReviewNoteSummaries: [DiffReviewNoteSummary] {
+        loadedReviewNoteSummaries().filter { !$0.isResolved }
+    }
+
     private var sideBySideNotesBanner: some View {
-        let count = loadedReviewNoteSummaries().count
+        let count = unresolvedReviewNoteSummaries.count
         return HStack(spacing: 8) {
             Image(systemName: "text.bubble.fill")
                 .foregroundStyle(.orange)

--- a/shell/mac/Tests/JayJayUITests/Scenes/ReviewNotesScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/ReviewNotesScene.swift
@@ -91,6 +91,52 @@ final class ReviewNotesScene: SceneBase {
         )
     }
 
+    /// Side-by-side has no gutter, so open notes are bridged by a banner; resolved ones must not count.
+    func testSideBySideBannerCountsOnlyOpenNotes() throws {
+        let app = try XCTUnwrap(app)
+        XCTAssertTrue(dagRows(of: app).element(boundBy: 0).waitForExistence(timeout: 10), "DAG never populated")
+        let file = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "identifier == %@", AID.FileList.row("README.md")))
+            .firstMatch
+        clickCenter(file, timeout: 5, message: "README.md row missing")
+        let diffText = app.textViews[AID.Diff.text]
+        XCTAssertTrue(diffText.waitForExistence(timeout: 5), "Unified diff did not appear")
+
+        let add = openFirstChangeGroupMenu(app, expecting: "Add Review Note")
+        XCTAssertTrue(add.waitForExistence(timeout: 5), "\"Add Review Note\" menu item missing")
+        add.click()
+        XCTAssertTrue(app.textViews[AID.ReviewNote.body].waitForExistence(timeout: 5), "Review note editor did not appear")
+        paste("Keep the old title")
+        clickCenter(app.buttons["Add Note"], timeout: 3, message: "\"Add Note\" button missing")
+        let activeCount = app.descendants(matching: .any)[AID.ReviewNote.activeCount(1)]
+        XCTAssertTrue(activeCount.waitForExistence(timeout: 5), "Active note count did not update")
+
+        clickCenter(app.buttons["Unified"], timeout: 5, message: "Diff layout toggle missing")
+        let banner = app.staticTexts["1 review note on this file"]
+        XCTAssertTrue(banner.waitForExistence(timeout: 5), "Side-by-side note banner missing for an open note")
+        clickCenter(app.buttons["Show in Unified"], timeout: 3, message: "\"Show in Unified\" missing")
+        XCTAssertTrue(diffText.waitForExistence(timeout: 5), "Unified diff did not come back")
+
+        clickFirstChangeGroupMarker(app)
+        clickCenter(app.buttons["Resolve"], timeout: 3, message: "\"Resolve\" popover action missing")
+        let countCleared = NSPredicate { _, _ in !activeCount.exists }
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [XCTNSPredicateExpectation(predicate: countCleared, object: nil)], timeout: 5),
+            .completed,
+            "Active note count did not clear after resolve"
+        )
+
+        clickCenter(app.buttons["Unified"], timeout: 5, message: "Diff layout toggle missing after resolve")
+        let sideBySideShown = NSPredicate { _, _ in !diffText.exists }
+        XCTAssertEqual(
+            XCTWaiter().wait(for: [XCTNSPredicateExpectation(predicate: sideBySideShown, object: nil)], timeout: 5),
+            .completed,
+            "Side-by-side view did not appear after resolve"
+        )
+        let bannerTexts = app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", "review note"))
+        XCTAssertEqual(bannerTexts.count, 0, "Side-by-side banner still counts a resolved note")
+    }
+
     /// The review context can lag the gutter's first render on cold CI runners; dismiss the incomplete menu and retry once.
     private func openFirstChangeGroupMenu(_ app: XCUIApplication, expecting title: String) -> XCUIElement {
         let item = app.menuItems[title]


### PR DESCRIPTION
The side-by-side diff has no review gutter, so a banner bridges the file's notes back to the unified view. It counted every note on the file, including resolved ones, so a file whose notes were all resolved kept showing "1 review note on this file". Resolved notes are now excluded (`unresolvedReviewNoteSummaries`).

Side-by-side is only offered for two-column diffs and the review-notes fixture only had added files, so the fixture gains a modified `README.md`, and a dedicated `ReviewNotesScene` test adds a note there, checks the banner and its "Show in Unified" bridge, resolves the note, and checks the banner is gone. The scene drives the layout toggle and banner by label: identifiers on elements inside the diff section are overridden by the section's own.

Local: `just test-app` (99 tests pass) and the UI test bundle compiles (`build-for-testing`). The scene itself runs in CI's UI shards since a JayJay instance is in use on this machine.