### PR TITLE
feat(gpui): add a Super shortcut modifier option on Linux

### DIFF
--- a/shell/gpui/src/app/actions.rs
+++ b/shell/gpui/src/app/actions.rs
@@ -55,8 +55,7 @@ pub struct OpenRecentRepository {
 }
 
 /// The app keymap, shared by `main` and the component-test harness so key dispatch in tests matches production.
-pub fn app_key_bindings() -> Vec<gpui::KeyBinding> {
-    let mod_key = crate::platform::MOD_KEY;
+pub fn app_key_bindings(mod_key: &str) -> Vec<gpui::KeyBinding> {
     let mut key_bindings = vec![
         gpui::KeyBinding::new(format!("{mod_key}-o").as_str(), OpenRepository, None),
         gpui::KeyBinding::new(format!("{mod_key}-,").as_str(), OpenSettings, None),

--- a/shell/gpui/src/app/config/mod.rs
+++ b/shell/gpui/src/app/config/mod.rs
@@ -7,6 +7,7 @@ pub mod diff;
 pub mod features;
 pub mod layout;
 pub mod onboarding;
+pub mod shortcut_modifier;
 pub mod store;
 pub mod telemetry;
 pub mod tools;
@@ -22,6 +23,7 @@ pub use diff::DiffConfig;
 pub use features::FeaturesConfig;
 pub use layout::LayoutConfig;
 pub use onboarding::OnboardingConfig;
+pub use shortcut_modifier::ShortcutModifier;
 pub use store::{AppConfigStore, current, update};
 pub use telemetry::TelemetryConfig;
 pub use tools::ToolsConfig;
@@ -33,6 +35,7 @@ pub struct AppConfig {
     pub appearance: AppearanceMode,
     pub font_family: String,
     pub(crate) font_size: f32,
+    pub(crate) shortcut_modifier: ShortcutModifier,
     pub diff: DiffConfig,
     pub(crate) layout: LayoutConfig,
     pub(crate) tools: ToolsConfig,
@@ -50,6 +53,7 @@ impl Default for AppConfig {
             appearance: AppearanceMode::System,
             font_family: String::new(),
             font_size: 12.0,
+            shortcut_modifier: ShortcutModifier::default(),
             diff: DiffConfig::default(),
             layout: LayoutConfig::default(),
             tools: ToolsConfig::default(),
@@ -65,6 +69,23 @@ impl Default for AppConfig {
 
 impl AppConfig {
     const MAX_RECENT_REPOS: usize = 12;
+
+    /// Only Linux lets the user pick the modifier; macOS keeps Cmd and Windows keeps Ctrl.
+    pub fn mod_key(&self) -> &'static str {
+        if cfg!(target_os = "linux") {
+            self.shortcut_modifier.key()
+        } else {
+            crate::platform::MOD_KEY
+        }
+    }
+
+    pub(crate) fn mod_label(&self) -> &'static str {
+        match self.mod_key() {
+            "cmd" => "⌘",
+            "super" => "Super",
+            _ => "Ctrl",
+        }
+    }
 
     /// Resolve the config file path via `ProjectDirs` so each platform gets
     /// its native location:

--- a/shell/gpui/src/app/config/shortcut_modifier.rs
+++ b/shell/gpui/src/app/config/shortcut_modifier.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ShortcutModifier {
+    #[default]
+    Ctrl,
+    Super,
+}
+
+impl ShortcutModifier {
+    pub(crate) fn key(self) -> &'static str {
+        match self {
+            Self::Ctrl => "ctrl",
+            Self::Super => "super",
+        }
+    }
+}

--- a/shell/gpui/src/app/config/store.rs
+++ b/shell/gpui/src/app/config/store.rs
@@ -40,7 +40,7 @@ pub fn update<F>(cx: &mut App, mutate: F)
 where
     F: FnOnce(&mut AppConfig),
 {
-    cx.update_global::<AppConfigStore, _>(|store, _| {
+    let mod_key_changed = cx.update_global::<AppConfigStore, _>(|store, _| {
         let mut next = (*store.config).clone();
         mutate(&mut next);
         if store.persist
@@ -49,8 +49,14 @@ where
             eprintln!("[jayjay-gpui] failed to save config: {err}");
         }
         fonts::sync_from_config(&next);
+        let mod_key_changed = next.mod_key() != store.config.mod_key();
         store.config = Arc::new(next);
+        mod_key_changed
     });
+    if mod_key_changed {
+        cx.clear_key_bindings();
+        cx.bind_keys(crate::app::actions::app_key_bindings(current(cx).mod_key()));
+    }
     theme::refresh_for_current_appearance(cx);
     crate::app::menus::refresh(cx);
 }

--- a/shell/gpui/src/main.rs
+++ b/shell/gpui/src/main.rs
@@ -90,7 +90,7 @@ fn main() {
             cx.window_appearance(),
         ));
 
-        cx.bind_keys(jayjay_gpui::app::actions::app_key_bindings());
+        cx.bind_keys(jayjay_gpui::app::actions::app_key_bindings(cfg.mod_key()));
 
         if let Some(invocation) = external_tool.clone() {
             cx.set_global(AppConfigStore::new(cfg));

--- a/shell/gpui/src/windows/keyboard_shortcuts.rs
+++ b/shell/gpui/src/windows/keyboard_shortcuts.rs
@@ -6,7 +6,7 @@ use gpui::{
 };
 
 use crate::app::actions::{CloseWindow, Dismiss};
-use crate::app::config::AppConfigStore;
+use crate::app::config::{self, AppConfigStore};
 use crate::app::theme::{Theme, observe_window_appearance, theme};
 use crate::ui::icons::{self, glyph};
 use crate::ui::primitives::divider_h;
@@ -62,6 +62,7 @@ impl Focusable for KeyboardShortcutsView {
 impl Render for KeyboardShortcutsView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let t = theme(cx).clone();
+        let mod_label = config::current(cx).mod_label();
         let [left, right] = guide::columns();
         div()
             .id("keyboard-shortcuts-window")
@@ -89,8 +90,8 @@ impl Render for KeyboardShortcutsView {
                     .overflow_y_scroll()
                     .scrollbar_width(px(0.))
                     .p(px(20.))
-                    .child(column(left, &t))
-                    .child(column(right, &t)),
+                    .child(column(left, mod_label, &t))
+                    .child(column(right, mod_label, &t)),
             )
             .child(divider_h(&t))
             .child(
@@ -138,15 +139,15 @@ fn header(t: &Theme, cx: &mut Context<KeyboardShortcutsView>) -> AnyElement {
         .into_any_element()
 }
 
-fn column(sections: &[ShortcutSection], t: &Theme) -> AnyElement {
+fn column(sections: &[ShortcutSection], mod_label: &'static str, t: &Theme) -> AnyElement {
     let mut column = div().flex().flex_col().gap(px(20.)).flex_1().min_w_0();
     for section in sections {
-        column = column.child(section_block(section, t));
+        column = column.child(section_block(section, mod_label, t));
     }
     column.into_any_element()
 }
 
-fn section_block(section: &ShortcutSection, t: &Theme) -> AnyElement {
+fn section_block(section: &ShortcutSection, mod_label: &'static str, t: &Theme) -> AnyElement {
     let title = section.title;
     let mut block = div()
         .id(SharedString::from(format!("shortcut-section-{title}")))
@@ -162,16 +163,16 @@ fn section_block(section: &ShortcutSection, t: &Theme) -> AnyElement {
                 .child(title.to_uppercase()),
         );
     for entry in section.entries {
-        block = block.child(shortcut_row(entry, t));
+        block = block.child(shortcut_row(entry, mod_label, t));
     }
     block.into_any_element()
 }
 
-fn shortcut_row(entry: &ShortcutEntry, t: &Theme) -> AnyElement {
+fn shortcut_row(entry: &ShortcutEntry, mod_label: &'static str, t: &Theme) -> AnyElement {
     let label = entry.label;
     let mut caps = div().flex().items_center().gap(px(4.));
     for (ix, key) in entry.keys.iter().enumerate() {
-        caps = caps.child(key_cap(label, ix, display_key(key), t));
+        caps = caps.child(key_cap(label, ix, display_key(key, mod_label), t));
     }
     div()
         .id(SharedString::from(format!("shortcut-entry-{label}")))

--- a/shell/gpui/src/windows/keyboard_shortcuts/guide.rs
+++ b/shell/gpui/src/windows/keyboard_shortcuts/guide.rs
@@ -158,10 +158,9 @@ pub(super) fn columns() -> [&'static [ShortcutSection]; 2] {
     [left, right]
 }
 
-pub(super) fn display_key(key: &'static str) -> &'static str {
+pub(super) fn display_key(key: &'static str, mod_label: &'static str) -> &'static str {
     match (key, cfg!(target_os = "macos")) {
-        ("Mod", true) => "⌘",
-        ("Mod", false) => "Ctrl",
+        ("Mod", _) => mod_label,
         ("Shift", true) => "⇧",
         ("Alt", true) => "⌥",
         _ => key,

--- a/shell/gpui/src/windows/settings/appearance.rs
+++ b/shell/gpui/src/windows/settings/appearance.rs
@@ -1,4 +1,4 @@
-use crate::app::config::{AppConfig, AppearanceMode};
+use crate::app::config::{AppConfig, AppearanceMode, ShortcutModifier};
 use gpui::{
     AnyElement, ClickEvent, InteractiveElement, IntoElement, ParentElement, SharedString,
     StatefulInteractiveElement, Styled, div, px, rgb,
@@ -16,7 +16,7 @@ pub(super) fn appearance_section(
     t: &Theme,
     cx: &mut gpui::Context<SettingsView>,
 ) -> AnyElement {
-    div()
+    let mut section = div()
         .flex()
         .flex_col()
         .w_full()
@@ -45,8 +45,18 @@ pub(super) fn appearance_section(
             font_size_value(cfg.font_size, t),
             "Used by diff and editors.",
             t,
-        ))
-        .into_any_element()
+        ));
+    if cfg!(target_os = "linux") {
+        section = section
+            .child(subsection_title("Keyboard", t))
+            .child(field_row(
+                "Modifier",
+                modifier_segmented(cfg.shortcut_modifier, t),
+                "Combinations the window manager reserves never reach JayJay.",
+                t,
+            ));
+    }
+    section.into_any_element()
 }
 
 fn font_size_value(size: f32, t: &Theme) -> AnyElement {
@@ -64,38 +74,66 @@ fn appearance_segmented(current: AppearanceMode, t: &Theme) -> AnyElement {
         .flex()
         .flex_row()
         .gap(px(4.))
-        .child(appearance_option(
+        .child(segmented_option(
             AppearanceMode::System,
             "System",
             current,
             "appearance-system",
+            |c, mode| c.appearance = mode,
             t,
         ))
-        .child(appearance_option(
+        .child(segmented_option(
             AppearanceMode::Light,
             "Light",
             current,
             "appearance-light",
+            |c, mode| c.appearance = mode,
             t,
         ))
-        .child(appearance_option(
+        .child(segmented_option(
             AppearanceMode::Dark,
             "Dark",
             current,
             "appearance-dark",
+            |c, mode| c.appearance = mode,
             t,
         ))
         .into_any_element()
 }
 
-fn appearance_option(
-    mode: AppearanceMode,
+fn modifier_segmented(current: ShortcutModifier, t: &Theme) -> AnyElement {
+    div()
+        .flex()
+        .flex_row()
+        .gap(px(4.))
+        .child(segmented_option(
+            ShortcutModifier::Ctrl,
+            "Ctrl",
+            current,
+            "shortcut-modifier-ctrl",
+            |c, modifier| c.shortcut_modifier = modifier,
+            t,
+        ))
+        .child(segmented_option(
+            ShortcutModifier::Super,
+            "Super",
+            current,
+            "shortcut-modifier-super",
+            |c, modifier| c.shortcut_modifier = modifier,
+            t,
+        ))
+        .into_any_element()
+}
+
+fn segmented_option<T: Copy + PartialEq + 'static>(
+    value: T,
     label: &'static str,
-    current: AppearanceMode,
+    current: T,
     id: &'static str,
+    select: fn(&mut AppConfig, T),
     t: &Theme,
 ) -> AnyElement {
-    let active = mode == current;
+    let active = value == current;
     let (bg, fg) = if active {
         (t.toggle_active_bg, t.toggle_active_fg)
     } else {
@@ -103,6 +141,7 @@ fn appearance_option(
     };
     div()
         .id(SharedString::from(id))
+        .debug_selector(move || id.to_owned())
         .px(px(10.))
         .py(px(3.))
         .rounded_md()
@@ -111,7 +150,7 @@ fn appearance_option(
         .text_color(rgb(fg))
         .cursor_pointer()
         .on_click(move |_ev: &ClickEvent, _w, cx| {
-            config::update(cx, move |c| c.appearance = mode);
+            config::update(cx, move |c| select(c, value));
         })
         .child(label)
         .into_any_element()

--- a/shell/gpui/tests/gpui/harness.rs
+++ b/shell/gpui/tests/gpui/harness.rs
@@ -125,7 +125,9 @@ pub(crate) fn opened_url(cx: &mut TestAppContext) -> Option<String> {
 
 pub(crate) fn install_test_globals(cx: &mut TestAppContext) {
     cx.update(|cx| {
-        cx.bind_keys(jayjay_gpui::app::actions::app_key_bindings());
+        cx.bind_keys(jayjay_gpui::app::actions::app_key_bindings(
+            AppConfig::default().mod_key(),
+        ));
         cx.set_global(AppConfigStore::new_ephemeral(AppConfig::default()));
         cx.set_global(Theme::light());
         let opened = Arc::new(Mutex::new(None));

--- a/shell/gpui/tests/gpui/keyboard_shortcuts.rs
+++ b/shell/gpui/tests/gpui/keyboard_shortcuts.rs
@@ -59,3 +59,49 @@ fn mod_slash_opens_keyboard_shortcuts(cx: &mut TestAppContext) {
             .is_some()
     );
 }
+
+#[cfg(target_os = "linux")]
+#[gpui::test]
+fn super_modifier_setting_rebinds_app_shortcuts(cx: &mut TestAppContext) {
+    use gpui::Modifiers;
+    use jayjay_gpui::windows::settings::{SettingsSection, SettingsView};
+
+    let fixture = LinearFixture::build();
+    install_test_globals(cx);
+    cx.update(menus::install);
+    let (_view, cx) = cx.add_window_view(|_, cx| RepoWindow::new(fixture.path.clone(), cx));
+    let cx: &mut VisualTestContext = cx;
+    settle_visual(cx);
+    cx.cx
+        .update(|cx| SettingsView::open_section(SettingsSection::Appearance, cx));
+    let settings_window = cx.cx.windows().last().copied().expect("settings window");
+    let mut settings_cx = VisualTestContext::from_window(settings_window, &cx.cx);
+    settle_visual(&mut settings_cx);
+    let super_option = settings_cx
+        .debug_bounds("shortcut-modifier-super")
+        .expect("Super modifier option");
+    settings_cx.simulate_click(super_option.center(), Modifiers::default());
+    settle_visual(&mut settings_cx);
+    let shortcuts_windows = |cx: &TestAppContext| {
+        cx.windows()
+            .iter()
+            .filter(|window| window.downcast::<KeyboardShortcutsView>().is_some())
+            .count()
+    };
+
+    cx.simulate_keystrokes("ctrl-/");
+    settle_visual(cx);
+    assert_eq!(
+        shortcuts_windows(&cx.cx),
+        0,
+        "Ctrl should no longer open the reference"
+    );
+
+    cx.simulate_keystrokes("super-/");
+    settle_visual(cx);
+    assert_eq!(
+        shortcuts_windows(&cx.cx),
+        1,
+        "Super should open the reference"
+    );
+}


### PR DESCRIPTION
Adds a Linux-only setting to use Super instead of Ctrl for JayJay's app shortcuts, as requested for Omarchy.

- New `shortcut_modifier = "ctrl" | "super"` field in the GPUI config. Only Linux honors it; macOS keeps Cmd and Windows keeps Ctrl.
- The keymap is rebuilt in place when the setting changes, so no restart.
- Settings → Appearance gains a Keyboard subsection with a Ctrl / Super segmented control on Linux. The Theme control now shares the same segmented option helper.
- The Keyboard Shortcuts window renders the chosen modifier in its key caps.

Caveat for Omarchy: its default Hyprland bindings reserve Super+W, Super+O, Super+F, Super+V, Super+P and Super+, so most JayJay shortcuts under Super are swallowed by the compositor unless those bindings are trimmed. That is why Ctrl stays the default.

Evidence:
- `cargo test -p jayjay-gpui` (macOS): 323 passed; `cargo clippy -p jayjay-gpui --all-targets -D warnings` clean.
- `just test-linux -p jayjay-gpui` (OrbStack Ubuntu arm64): 190 unit + 324 integration passed, including the new `super_modifier_setting_rebinds_app_shortcuts` test (click Super in Settings, then `ctrl-/` no longer opens the shortcuts window and `super-/` does).
- `jj fix` no-op, `just lint` clean.
- Not verified: Windows compile (CI), and a real Hyprland session with Super bindings trimmed.
