### PR TITLE
fix(gpui): resolve the Linux monospace alias to an installed family

### DIFF
--- a/shell/gpui/Cargo.toml
+++ b/shell/gpui/Cargo.toml
@@ -38,6 +38,7 @@ unicode-segmentation = { workspace = true }
 unicode-width = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+font-kit = { version = "0.14", features = ["source-fontconfig-default"] }
 notify-rust = "4.18.0"
 
 [dev-dependencies]

--- a/shell/gpui/src/app/fonts.rs
+++ b/shell/gpui/src/app/fonts.rs
@@ -15,18 +15,23 @@ pub struct MonoFontChoice {
 }
 
 static MONO: OnceLock<RwLock<String>> = OnceLock::new();
+static DEFAULT_MONO: OnceLock<String> = OnceLock::new();
 
 pub(crate) fn mono() -> String {
     MONO.get_or_init(|| RwLock::new(String::new()))
         .read()
         .map(|font| {
             if font.is_empty() {
-                platform::platform_default_mono()
+                default_mono().to_owned()
             } else {
                 font.clone()
             }
         })
-        .unwrap_or_else(|_| platform::platform_default_mono())
+        .unwrap_or_else(|_| default_mono().to_owned())
+}
+
+fn default_mono() -> &'static str {
+    DEFAULT_MONO.get_or_init(platform::platform_default_mono)
 }
 
 // Falls back to ~7.2 px (SF Mono / Menlo at 12 px) on measurement failure.
@@ -82,14 +87,12 @@ pub(crate) fn mono_preference_label(preference: &str) -> String {
 
 fn resolve_preference(preference: &str) -> String {
     let Some(option) = matched_option(preference) else {
-        let fallback = platform::platform_default_mono();
-        return pick(&[preference], &fallback);
+        return pick(&[preference]).unwrap_or_else(|| default_mono().to_owned());
     };
     if option.id == SYSTEM_MONO_FONT_ID {
-        return platform::platform_default_mono();
+        return default_mono().to_owned();
     }
-    let fallback = platform::platform_default_mono();
-    pick(option.font_names, &fallback)
+    pick(option.font_names).unwrap_or_else(|| default_mono().to_owned())
 }
 
 fn matched_option(preference: &str) -> Option<&'static MonoFontOption> {
@@ -120,14 +123,12 @@ fn option_is_available(option: &MonoFontOption, source: &SystemSource) -> bool {
             .any(|name| source.select_family_by_name(name).is_ok())
 }
 
-fn pick(candidates: &[&str], fallback: &str) -> String {
+fn pick(candidates: &[&str]) -> Option<String> {
     let source = SystemSource::new();
-    for name in candidates {
-        if source.select_family_by_name(name).is_ok() {
-            return (*name).to_owned();
-        }
-    }
-    fallback.to_owned()
+    candidates
+        .iter()
+        .find(|name| source.select_family_by_name(name).is_ok())
+        .map(|name| (*name).to_owned())
 }
 
 #[cfg(test)]

--- a/shell/gpui/src/app/fonts/platform/linux.rs
+++ b/shell/gpui/src/app/fonts/platform/linux.rs
@@ -1,5 +1,41 @@
+use font_kit::family_name::FamilyName;
+use font_kit::properties::Properties;
+use font_kit::source::SystemSource;
 use jayjay_core::MONO_FONT_FALLBACK_NAMES;
 
 pub(super) fn platform_default_mono() -> String {
-    super::super::pick(MONO_FONT_FALLBACK_NAMES, "monospace")
+    default_mono_from(MONO_FONT_FALLBACK_NAMES)
+}
+
+fn default_mono_from(candidates: &[&str]) -> String {
+    super::super::pick(candidates)
+        .or_else(system_monospace)
+        .unwrap_or_else(|| "monospace".to_owned())
+}
+
+/// GPUI loads families by exact name, so the fontconfig `monospace` alias only helps once it is resolved to an installed face; otherwise text falls back to a proportional font while widths are still measured as monospace.
+fn system_monospace() -> Option<String> {
+    SystemSource::new()
+        .select_best_match(&[FamilyName::Monospace], &Properties::new())
+        .ok()?
+        .load()
+        .ok()
+        .map(|font| font.family_name())
+}
+
+#[cfg(test)]
+mod tests {
+    use font_kit::source::SystemSource;
+
+    use super::default_mono_from;
+
+    #[test]
+    fn missing_candidates_resolve_to_an_installed_family() {
+        let family = default_mono_from(&["JayJay Missing Mono"]);
+        assert_ne!(family, "monospace");
+        assert!(
+            SystemSource::new().select_family_by_name(&family).is_ok(),
+            "{family} is not an installed family"
+        );
+    }
 }


### PR DESCRIPTION
On Linux, when none of the listed mono families is installed, the picker returned the fontconfig alias `"monospace"`. GPUI loads families by exact name, so `resolve_font` fell back to the proportional UI font while `mono_advance` still measured widths as if every glyph were a mono `0`. The diff header path came out proportional and over-measured, leaving a gap before the copy button (seen on Omarchy, which ships JetBrainsMono Nerd Font and Adwaita Mono only).

- Resolve the `monospace` alias through fontconfig via font-kit's `source-fontconfig-default`, enabled for the Linux target only.
- Cache the platform default once. `mono()` runs on every render and re-queried the system font database each time.

Evidence:
- OrbStack Ubuntu (no listed family installed): `platform_default_mono()` now returns "DejaVu Sans Mono"; before, "monospace".
- macOS font unit tests, `jj fix`, `just lint` clean; Linux clippy `-D warnings` clean.
- Not verified: the visual gap on the Omarchy VM needs an aarch64 build of this branch.
