### PR TITLE
fix(diff): group removed and added rows in unified view

### DIFF
--- a/crates/jj-diff/src/conflicts.rs
+++ b/crates/jj-diff/src/conflicts.rs
@@ -106,7 +106,19 @@ pub fn build_diff_display_lines(lines: &[DiffLine]) -> Vec<DiffLine> {
             DiffDisplayItem::Lines {
                 line_start,
                 line_end,
-            } => display_lines.extend_from_slice(&lines[line_start as usize..line_end as usize]),
+            } => {
+                let start = display_lines.len();
+                display_lines.extend_from_slice(&lines[line_start as usize..line_end as usize]);
+                // Keep raw ordering for word pairs and persisted review fingerprints; group only display rows.
+                for group in display_lines[start..].chunk_by_mut(|left, right| {
+                    left.is_changed()
+                        && right.is_changed()
+                        && left.conflict_kind == ConflictLineKind::None
+                        && right.conflict_kind == ConflictLineKind::None
+                }) {
+                    group.sort_by_key(|line| line.style == DiffSpanStyle::Added);
+                }
+            }
             DiffDisplayItem::ConflictBlock { block } => {
                 display_lines.push(conflict_summary_line(lines, &block));
                 for section in &block.sections {

--- a/crates/jj-diff/src/tests/basic.rs
+++ b/crates/jj-diff/src/tests/basic.rs
@@ -224,3 +224,71 @@ fn skip_highlight_for_lock_files() {
     assert_eq!(diff.lines[0].style, DiffSpanStyle::Removed);
     assert_eq!(diff.lines[1].style, DiffSpanStyle::Added);
 }
+
+#[test]
+fn unified_replacements_group_sides_without_changing_pairs_or_anchors() {
+    let diff = compute_file_diff_full(
+        "sample.rs",
+        "head\nlet a = 1;\nlet b = 2;\nmiddle\nold one\nold two\nold three\ntail\n",
+        "head\nlet a = 10;\nlet b = 20;\nlet c = 30;\nmiddle\nnew one\ntail\n",
+        false,
+    );
+    let display = build_diff_display_lines(&diff.lines);
+    assert_eq!(
+        display.iter().map(DiffLine::text).collect::<Vec<_>>(),
+        [
+            "head",
+            "let a = 1;",
+            "let b = 2;",
+            "let a = 10;",
+            "let b = 20;",
+            "let c = 30;",
+            "middle",
+            "old one",
+            "old two",
+            "old three",
+            "new one",
+            "tail"
+        ],
+    );
+    for line in &display {
+        let original = diff
+            .lines
+            .iter()
+            .find(|original| {
+                original.old_line_no == line.old_line_no && original.new_line_no == line.new_line_no
+            })
+            .unwrap();
+        assert_eq!(span_info(line), span_info(original));
+        if let Some((side, number)) = anchor_side_and_number(line) {
+            let before = change_group_for_anchor(&diff.lines, side, number, &line.text()).unwrap();
+            let after = change_group_for_anchor(&display, side, number, &line.text()).unwrap();
+            assert_eq!(
+                (before.index, before.start_line, before.end_line),
+                (after.index, after.start_line, after.end_line)
+            );
+        }
+    }
+    assert_eq!(
+        sbs_line_to_row(&diff.lines),
+        vec![0, 1, 2, 1, 2, 3, 4, 5, 6, 7, 5, 8]
+    );
+    let rows = build_side_by_side_rows(&diff.lines);
+    assert_eq!(
+        rows.iter()
+            .map(|row| (row.old.text(), row.new.text()))
+            .collect::<Vec<_>>(),
+        [
+            ("head", "head"),
+            ("let a = 1;", "let a = 10;"),
+            ("let b = 2;", "let b = 20;"),
+            ("", "let c = 30;"),
+            ("middle", "middle"),
+            ("old one", "new one"),
+            ("old two", ""),
+            ("old three", ""),
+            ("tail", "tail")
+        ]
+        .map(|(old, new)| (old.to_owned(), new.to_owned())),
+    );
+}


### PR DESCRIPTION
Group contiguous replacement rows by side at display projection time, so a unified diff shows all removed lines of a group before its added lines instead of interleaved pairs.

Raw diff ordering is preserved for word highlights, review fingerprints, conflict rendering, side-by-side pairing, and note anchors: the reorder happens only inside `build_diff_display_lines`, and both shells map display rows back to raw lines by (style, old line, new line), never by index.

Evidence: `cargo test` for jj-diff (270), jayjay-core (140 + 191), jayjay-review (45 + 95), and jayjay-gpui (327) pass on macOS. Swift tests not run.
