### PR TITLE
fix: keep large repository browsing responsive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 DerivedData/
 JayJayCore.swift
 .DS_Store
+/.wrangler/
 shell/mac/Resources/app.icon/Assets/jaybird.svg
 shell/mac/Resources/DockIcon/jayjay-dock-dark.png
 shell/mac/Resources/DockIcon/jayjay-dock-light.png

--- a/agents/code-review.md
+++ b/agents/code-review.md
@@ -31,6 +31,7 @@ The focused docs remain the source of truth. This guide points review attention 
 - Keep business logic in Rust core, UniFFI bindings thin, and SwiftUI/GPUI shells focused on rendering state and dispatching actions.
 - Preserve review-state invariants: content-based identity, per-file invalidation, hunk/file promotion, and local persistence.
 - Keep UI changes native, keyboard-friendly, quiet, and jj-native in wording. Use repo-level presentation types instead of ad hoc alerts or booleans.
+- Check repeated UI work for per-row whole-collection scans, stale render caches, and geometry-driven invalidation loops; apply the [SwiftUI rendering performance rules](swiftui.md#rendering-performance) or [GPUI render-cache conventions](gpui.md#conventions) for the affected shell.
 - Match nearby patterns. Keep patches focused, avoid speculative abstractions, prefer structured parsers/APIs, and comment only non-obvious why.
 - Look for what the `AGENTS.md` cleanup rounds should have removed: once-used helpers, unused parameters/flags/imports, forwarding wrappers, copy-pasted blocks, restating comments, and tests that only mirror wiring.
 

--- a/agents/swiftui.md
+++ b/agents/swiftui.md
@@ -55,6 +55,12 @@ The ViewModel owns `JayJayRepo`; all jj operations go through it. `Core/` holds 
 - **Diff caching**: `Diff/DiffStore.swift` (`@Observable`) fronts an `actor DiffCache`, an LRU bounded by content bytes. Keys are content-addressed on the immutable commit id (never the mutable rev) plus compare side, whitespace mode, and path, so amends/rebases cannot serve stale diffs. `preload()` cancels the prior preload task.
 - **Refresh pipeline** (`ViewModel/Core/RepoViewModel+Refresh.swift`): one cancel-and-replace `refreshTask`; FS-triggered refreshes are dropped while one is in flight; snapshots (e.g. `StatusBarSnapshot`) load off-thread and apply atomically. Commit-box drafts reseed only when the working-copy change id actually changes; `jj split` gives the remainder (the new `@`) a fresh change id while diff-edit extract keeps it, so in-app split must preserve the draft explicitly, and divergent siblings share one id, so detect `@` moving between them by description.
 
+## Rendering Performance
+
+- Keep row rendering and menu eligibility cheap: compute whole-graph indexes, lane aggregates, and selection ancestry once per input snapshot, not per row. Computed properties do not cache automatically, and context-menu builders may run before the menu opens. Invalidate cached results when any of their inputs change.
+- Store geometry used only for drag hit-testing in a non-observable reference such as `DAGRowFrameCache`; publishing those measurements back into view state can create layout feedback. Use observable state only when the measurement must change rendered output.
+- Verify DAG hot-path changes with `DAGPerformanceTests` (12k-change fixture) and frame-measurement changes with `DAGRowFrameCacheTests`, both in `shell/mac/Tests/JayJayTests/`. These cover computation cost and view invalidation, not end-to-end keyboard or scrolling latency; measure the affected interaction separately when claiming a responsiveness improvement.
+
 ## Window Lifecycle
 
 - Scene restoration is disabled everywhere: `.restorationBehavior(.disabled)` on every scene and `ApplePersistenceIgnoreState` registered in `JayJayApp.init`. Restoration opens the wrong scene at launch and resurrects blank repo windows.

--- a/crates/jayjay-core/src/repo/bookmarks.rs
+++ b/crates/jayjay-core/src/repo/bookmarks.rs
@@ -86,7 +86,10 @@ impl Repo {
         let mut orphans: BTreeMap<String, Vec<(String, RefTarget, bool)>> = BTreeMap::new();
         for (sym, remote_ref) in repo.view().all_remote_bookmarks() {
             let name = sym.name.as_str();
-            if local_names.contains(name) || remote_ref.target.is_absent() {
+            if local_names.contains(name)
+                || remote_ref.target.is_absent()
+                || sym.remote == REMOTE_NAME_FOR_LOCAL_GIT_REPO
+            {
                 continue;
             }
             orphans.entry(name.to_owned()).or_default().push((
@@ -98,7 +101,11 @@ impl Repo {
         for (name, mut refs) in orphans {
             refs.sort_by(|a, b| a.0.cmp(&b.0));
             let remotes: Vec<String> = refs.iter().map(|(r, _, _)| r.clone()).collect();
-            let is_deleted = refs.iter().any(|(_, _, tracked)| *tracked);
+            let tracked_remotes: Vec<String> = refs
+                .iter()
+                .filter(|(_, _, tracked)| *tracked)
+                .map(|(remote, _, _)| remote.clone())
+                .collect();
             let first_target = &refs
                 .iter()
                 .find(|(remote, _, _)| remote == "origin")
@@ -110,9 +117,9 @@ impl Repo {
                 change_id,
                 description,
                 is_tracking_remote: false,
-                is_deleted,
+                is_deleted: !tracked_remotes.is_empty(),
                 is_conflicted: first_target.has_conflict(),
-                tracked_remotes: Vec::new(),
+                tracked_remotes,
                 available_remotes: remotes,
                 has_local_target: false,
                 remote_targets: Vec::new(),

--- a/crates/jayjay-core/src/repo/git/sync.rs
+++ b/crates/jayjay-core/src/repo/git/sync.rs
@@ -5,12 +5,10 @@ use crate::types::*;
 
 impl Repo {
     /// Returns a message describing what happened (warnings, errors, or success).
-    /// Auto-tracks untracked bookmarks before pushing.
+    /// Tracks only an explicitly requested bookmark before pushing.
     pub fn git_push(&self, bookmark: &str, sync: &SyncToken) -> CoreResult<String> {
         let _enter = sync.enter();
-        if bookmark.is_empty() {
-            self.run_jj_quiet(&["bookmark", "track", "glob:*"]);
-        } else {
+        if !bookmark.is_empty() {
             self.run_jj_quiet(&["bookmark", "track", "--remote=origin", "--", bookmark]);
         }
 
@@ -22,12 +20,10 @@ impl Repo {
         self.ensure_success(&output, "git push failed")?;
         self.reload()?;
         sync.check()?;
-        let result = combine_output(&Self::stdout_text(&output), &Self::stderr_text(&output));
-        if result.contains("No bookmarks found") || result.contains("Nothing changed") {
-            Ok("Nothing to push — create a bookmark first".to_owned())
-        } else {
-            Ok(result)
-        }
+        Ok(combine_output(
+            &Self::stdout_text(&output),
+            &Self::stderr_text(&output),
+        ))
     }
 
     /// Track and push several bookmarks in one `jj git push`, with a single
@@ -54,13 +50,9 @@ impl Repo {
         ))
     }
 
-    /// Fetch all remotes, auto-track, rebase, and clean up merged bookmarks.
+    /// Fetch without changing bookmark tracking, rebase, and clean up merged bookmarks.
     pub fn git_fetch(&self, remote: &str, sync: &SyncToken) -> CoreResult<FetchResult> {
-        self.pull(
-            sync,
-            |repo| repo.git_fetch_raw(remote, ""),
-            &["bookmark", "track", "glob:*"],
-        )
+        self.pull(sync, |repo| repo.git_fetch_raw(remote, ""), None)
     }
 
     /// Fetch a specific bookmark, auto-track it, rebase, and clean up.
@@ -68,7 +60,7 @@ impl Repo {
         self.pull(
             sync,
             |repo| repo.git_fetch_raw("", bookmark),
-            &["bookmark", "track", "--remote=origin", "--", bookmark],
+            Some(&["bookmark", "track", "--remote=origin", "--", bookmark]),
         )
     }
 
@@ -76,12 +68,14 @@ impl Repo {
         &self,
         sync: &SyncToken,
         fetch: impl FnOnce(&Self) -> CoreResult<String>,
-        track_args: &[&str],
+        track_args: Option<&[&str]>,
     ) -> CoreResult<FetchResult> {
         let _enter = sync.enter();
         let tracking_before = self.tracking_bookmark_names();
         let msg = fetch(self)?;
-        let _ = self.run_jj_reload(track_args);
+        if let Some(track_args) = track_args {
+            let _ = self.run_jj_reload(track_args);
+        }
         self.rebase_to_trunk();
         let _ = self.reload();
         sync.check()?;

--- a/crates/jayjay-core/tests/integration/bookmarks.rs
+++ b/crates/jayjay-core/tests/integration/bookmarks.rs
@@ -9,74 +9,49 @@ use jj_test::{
 };
 
 #[test]
-fn list_bookmarks_includes_untracked_remote_branch() {
-    // Alice pushes a branch to origin; bob clones and sees it as `name@origin` with no local target.
+fn sync_only_tracks_explicitly_requested_bookmarks() {
     let work_dir = tempfile::tempdir().expect("create work dir");
     let bare_path = work_dir.path().join("origin.git");
     let alice_path = work_dir.path().join("alice");
     let bob_path = work_dir.path().join("bob");
 
     let bare_str = bare_path.to_str().expect("bare path utf-8");
-    let alice_str = alice_path.to_str().expect("alice path utf-8");
     let bob_str = bob_path.to_str().expect("bob path utf-8");
 
-    // Bare origin
     run_command(
         "git",
         &["init".into(), "--bare".into(), bare_str.into()],
         Command::new("git").args(["init", "--bare", bare_str]),
     );
 
-    // Alice: colocated jj+git repo, two commits, push main and feature
-    run_jj(&["git", "init", "--colocate", alice_str]);
-    run_jj(&[
-        "-R",
-        alice_str,
-        "config",
-        "set",
-        "--repo",
-        "user.name",
-        "Alice",
-    ]);
-    run_jj(&[
-        "-R",
-        alice_str,
-        "config",
-        "set",
-        "--repo",
-        "user.email",
-        "alice@example.com",
-    ]);
+    init_colocated(&alice_path);
+    configure_test_user(&alice_path);
     fs::write(alice_path.join("a.txt"), "alice initial\n").expect("write a.txt");
-    run_jj(&["-R", alice_str, "describe", "-m", "initial"]);
-    run_jj(&["-R", alice_str, "bookmark", "create", "main", "-r", "@"]);
-    run_jj(&["-R", alice_str, "new", "-m", "alice feature work"]);
+    run_jj_in(&alice_path, &["describe", "-m", "initial"]);
+    run_jj_in(&alice_path, &["bookmark", "create", "main", "-r", "@"]);
+    run_jj_in(&alice_path, &["new", "-m", "alice feature work"]);
     fs::write(alice_path.join("b.txt"), "alice feature\n").expect("write b.txt");
-    run_jj(&[
-        "-R",
-        alice_str,
-        "bookmark",
-        "create",
-        "alice-feature",
-        "-r",
-        "@",
-    ]);
+    run_jj_in(
+        &alice_path,
+        &["bookmark", "create", "alice-feature", "-r", "@"],
+    );
     run_git(&alice_path, &["remote", "add", "origin", bare_str]);
-    run_jj(&[
-        "-R",
-        alice_str,
-        "git",
-        "push",
-        "--bookmark",
-        "main",
-        "--bookmark",
-        "alice-feature",
-        "--remote",
-        "origin",
-    ]);
+    run_jj_in(
+        &alice_path,
+        &[
+            "git",
+            "push",
+            "--bookmark",
+            "main",
+            "--bookmark",
+            "alice-feature",
+            "--remote",
+            "origin",
+        ],
+    );
 
-    // Bob: clone via jj; alice-feature should arrive as an untracked remote bookmark
     run_jj(&["git", "clone", "--colocate", bare_str, bob_str]);
+    configure_test_user(&bob_path);
 
     let repo = Repo::open(&bob_path).expect("open bob's repo");
     let bookmarks = repo.list_bookmarks().expect("list bookmarks");
@@ -85,23 +60,121 @@ fn list_bookmarks_includes_untracked_remote_branch() {
         .iter()
         .find(|b| b.name == "alice-feature")
         .expect("alice-feature should appear in list_bookmarks");
-    assert!(
-        !orphan.has_local_target,
-        "alice-feature has no local target in bob's repo"
+    assert!(!orphan.has_local_target);
+    assert!(!orphan.is_tracking_remote);
+    assert_eq!(orphan.available_remotes, ["origin"]);
+    assert!(!orphan.change_id.is_empty());
+
+    repo.track_bookmark("main", "origin").expect("track main");
+    run_jj_in(
+        &alice_path,
+        &["new", "-r", "alice-feature", "-m", "updated feature"],
     );
-    assert!(
-        !orphan.is_tracking_remote,
-        "alice-feature is not tracked in bob's repo"
+    run_jj_in(
+        &alice_path,
+        &["bookmark", "set", "alice-feature", "-r", "@"],
     );
+    run_jj_in(&alice_path, &["git", "push", "--bookmark", "alice-feature"]);
+
+    repo.git_fetch("origin", &repo.sync_token()).expect("pull");
+    let after = repo.list_bookmarks().expect("bookmarks after pull");
+    let remote = after
+        .iter()
+        .find(|b| b.name == "alice-feature")
+        .expect("remote bookmark");
+    assert!(!remote.has_local_target);
+    assert!(!remote.is_tracking_remote);
+    assert_ne!(remote.change_id, orphan.change_id);
+    assert!(
+        repo.log("mutable() & ::remote_bookmarks(exact:\"alice-feature\", exact:\"origin\")")
+            .unwrap()
+            .is_empty()
+    );
+
+    run_jj_in(&bob_path, &["new", "-r", "main", "-m", "bob main update"]);
+    fs::write(bob_path.join("bob.txt"), "bob update\n").expect("write bob update");
+    run_jj_in(&bob_path, &["bookmark", "set", "main", "-r", "@"]);
+    repo.git_push("", &repo.sync_token())
+        .expect("ordinary push");
     assert_eq!(
-        orphan.available_remotes,
-        vec!["origin".to_string()],
-        "alice-feature is available only on origin"
+        run_git(&bare_path, &["rev-parse", "refs/heads/main"]).stdout,
+        format!("{}\n", repo.log("main").unwrap()[0].commit_id.id).into_bytes()
     );
     assert!(
-        !orphan.change_id.is_empty(),
-        "orphan entry should carry the change id from the remote target"
+        repo.list_bookmarks()
+            .unwrap()
+            .iter()
+            .any(|b| b.name == "alice-feature" && !b.has_local_target)
     );
+
+    run_jj_in(&bob_path, &["new", "-r", "main", "-m", "bob feature work"]);
+    run_jj_in(&bob_path, &["bookmark", "create", "bob-feature", "-r", "@"]);
+    let message = repo.git_push("", &repo.sync_token()).expect("default push");
+    assert!(
+        message.contains("bob-feature") && message.contains("track"),
+        "{message}"
+    );
+    repo.git_push("bob-feature", &repo.sync_token())
+        .expect("explicit bookmark push");
+    let message = repo
+        .git_push("bob-feature", &repo.sync_token())
+        .expect("up-to-date push");
+    assert!(
+        message.contains("Nothing changed") && !message.contains("create a bookmark"),
+        "{message}"
+    );
+    let mut tracked: Vec<_> = repo
+        .list_bookmarks()
+        .unwrap()
+        .into_iter()
+        .filter(|b| b.is_tracking_remote)
+        .map(|b| b.name)
+        .collect();
+    tracked.sort();
+    assert_eq!(tracked, ["bob-feature", "main"]);
+
+    repo.git_pull_bookmark("alice-feature", &repo.sync_token())
+        .expect("explicit bookmark pull");
+    assert!(
+        repo.list_bookmarks()
+            .unwrap()
+            .iter()
+            .any(|b| b.name == "alice-feature" && b.has_local_target && b.is_tracking_remote)
+    );
+}
+
+#[test]
+fn deleted_bookmark_preserves_tracking_per_remote() {
+    let fixture = LinearFixture::build();
+    for (remote, target) in [("origin", "HEAD"), ("upstream", "HEAD~1")] {
+        run_git(
+            &fixture.path,
+            &[
+                "remote",
+                "add",
+                remote,
+                &format!("https://example.invalid/{remote}.git"),
+            ],
+        );
+        run_git(
+            &fixture.path,
+            &[
+                "update-ref",
+                &format!("refs/remotes/{remote}/feature"),
+                target,
+            ],
+        );
+    }
+    run_jj_in(&fixture.path, &["status"]);
+    let repo = Repo::open(&fixture.path).expect("open repo");
+    repo.track_bookmark("feature", "origin")
+        .expect("track origin bookmark");
+    repo.delete_bookmark("feature")
+        .expect("delete local bookmark");
+    let deleted = listed_feature(&repo);
+    assert!(deleted.is_deleted && !deleted.has_local_target);
+    assert_eq!(deleted.available_remotes, ["origin", "upstream"]);
+    assert_eq!(deleted.tracked_remotes, ["origin"]);
 }
 
 struct ConflictedFeatureFixture {

--- a/crates/jayjay-primitives/src/bookmark.rs
+++ b/crates/jayjay-primitives/src/bookmark.rs
@@ -10,7 +10,7 @@ pub struct BookmarkInfo {
     pub is_conflicted: bool,
     pub tracked_remotes: Vec<String>,
     pub available_remotes: Vec<String>,
-    /// False for synthesized entries from an untracked remote bookmark (e.g. `feature@origin`).
+    /// False for synthesized remote entries, including locally deleted bookmarks still tracked on a remote.
     pub has_local_target: bool,
     /// Empty for remote-only (orphan) entries.
     pub remote_targets: Vec<RemoteBookmarkTarget>,

--- a/scripts/ui-test-fixtures.sh
+++ b/scripts/ui-test-fixtures.sh
@@ -102,6 +102,22 @@ fixture_bookmark_diff() {
   )
 }
 
+fixture_remote_bookmarks() {
+  copy_fixture simple remote-bookmarks
+  (
+    cd "$fixtures/remote-bookmarks"
+    git remote add origin https://example.invalid/origin.git
+    git remote add upstream https://example.invalid/upstream.git
+    git update-ref 'refs/remotes/origin/other-work' HEAD~1
+    git update-ref 'refs/remotes/upstream/other-work' HEAD~2
+    git update-ref 'refs/remotes/origin/deleted-work' HEAD~1
+    git update-ref 'refs/remotes/upstream/deleted-work' HEAD~2
+    jj status
+    jj bookmark track deleted-work@origin
+    jj bookmark delete deleted-work
+  )
+}
+
 # Simple plus structured files for projection/rendering checks.
 fixture_formats() {
   copy_fixture simple formats
@@ -349,6 +365,7 @@ fixture_mutating_scenes
 fixture_external_tools
 fixture_sync_cancel
 fixture_bookmark_diff
+fixture_remote_bookmarks
 fixture_formats
 fixture_review_notes
 fixture_evolog_hide_snapshots

--- a/shell/gpui/src/repo/window/bookmark_picker.rs
+++ b/shell/gpui/src/repo/window/bookmark_picker.rs
@@ -1,12 +1,12 @@
 use gpui::{AnyElement, Context, Entity, KeyDownEvent, MouseDownEvent, Pixels, Point};
 use jayjay_core::BookmarkInfo;
 
+mod entry;
 mod rows;
 
 use super::RepoWindow;
 use super::picker::{self, PickerOutcome, PickerQuery, picker_actions, render_sections};
 use crate::app::theme::Theme;
-use crate::repo::revset;
 use crate::ui::icons::glyph;
 use crate::ui::input::LineInput;
 use rows::{bookmark_row, bookmark_sections};
@@ -48,18 +48,12 @@ impl RepoWindow {
         }
     }
 
-    pub(super) fn filter_by_bookmark(&mut self, name: &str, cx: &mut Context<Self>) {
+    pub(super) fn filter_bookmark_revset(&mut self, revset: &str, cx: &mut Context<Self>) {
         self.close_bookmark_picker(cx);
-        let symbol = revset::quoted_symbol(name);
-        let revset = if self.bookmark_is_conflicted(name, cx) {
-            format!("bookmarks(exact:{symbol})")
-        } else {
-            symbol
-        };
         if let Some(input) = self.revset_filter.as_mut() {
-            input.set_text(revset.clone());
+            input.set_text(revset.to_owned());
         }
-        self.vm.update(cx, |vm, cx| vm.apply_revset(&revset, cx));
+        self.vm.update(cx, |vm, cx| vm.apply_revset(revset, cx));
     }
 
     pub(super) fn handle_bookmark_picker_key(
@@ -79,7 +73,7 @@ impl RepoWindow {
         match outcome {
             PickerOutcome::Handled => {}
             PickerOutcome::Dismiss => self.close_bookmark_picker(cx),
-            PickerOutcome::Activate(name) => self.filter_by_bookmark(&name, cx),
+            PickerOutcome::Activate(revset) => self.filter_bookmark_revset(&revset, cx),
         }
         true
     }
@@ -136,9 +130,7 @@ fn menu_panel(
     );
 
     let sections = bookmark_sections(state, bookmarks);
-    let has_any_bookmarks = bookmarks
-        .iter()
-        .any(|bookmark| !bookmark.is_deleted && bookmark.has_local_target);
+    let has_any_bookmarks = bookmarks.iter().any(|bookmark| !bookmark.is_deleted);
     let rows = if sections.is_empty() {
         vec![picker::empty(
             if has_any_bookmarks {

--- a/shell/gpui/src/repo/window/bookmark_picker/entry.rs
+++ b/shell/gpui/src/repo/window/bookmark_picker/entry.rs
@@ -1,0 +1,47 @@
+use jayjay_core::{BookmarkInfo, DEFAULT_REVSET_DEPTH};
+
+use crate::repo::revset::quoted_symbol;
+use crate::repo::window::picker::PickerRow;
+
+#[derive(Clone)]
+pub(super) struct BookmarkPickerEntry {
+    pub bookmark: BookmarkInfo,
+    pub remote: Option<String>,
+}
+
+impl BookmarkPickerEntry {
+    pub fn id(&self) -> String {
+        let name = &self.bookmark.name;
+        match &self.remote {
+            Some(remote) => format!("bookmark-picker-remote-row-{}:{name}{remote}", name.len()),
+            None => format!("bookmark-picker-row-{name}"),
+        }
+    }
+
+    pub fn label(&self) -> String {
+        match &self.remote {
+            Some(remote) => format!("{}@{remote}", self.bookmark.name),
+            None => self.bookmark.name.clone(),
+        }
+    }
+
+    pub fn revset(&self) -> String {
+        let name = quoted_symbol(&self.bookmark.name);
+        match &self.remote {
+            Some(remote) => format!(
+                "ancestors(remote_bookmarks(exact:{name}, exact:{}), {DEFAULT_REVSET_DEPTH})",
+                quoted_symbol(remote)
+            ),
+            None if self.bookmark.is_conflicted => format!("bookmarks(exact:{name})"),
+            None => name,
+        }
+    }
+}
+
+impl PickerRow for BookmarkPickerEntry {
+    type Action = String;
+
+    fn action(&self) -> Option<String> {
+        Some(self.revset())
+    }
+}

--- a/shell/gpui/src/repo/window/bookmark_picker/rows.rs
+++ b/shell/gpui/src/repo/window/bookmark_picker/rows.rs
@@ -5,74 +5,91 @@ use gpui::{
 use jayjay_core::BookmarkInfo;
 
 use super::BookmarkPickerState;
+use super::entry::BookmarkPickerEntry;
 use crate::app::theme::{Theme, ui_font_size};
 use crate::repo::window::RepoWindow;
-use crate::repo::window::picker::{PickerRow, PickerSection, row, sections_by_best_match};
+use crate::repo::window::picker::{PickerSection, row, sections_by_best_match};
 use crate::ui::context_menu::{ContextAction, ContextMenuItem};
 use crate::ui::icons::{self, glyph};
-
-impl PickerRow for BookmarkInfo {
-    type Action = String;
-
-    fn action(&self) -> Option<String> {
-        Some(self.name.clone())
-    }
-}
 
 pub(super) fn bookmark_sections(
     state: &BookmarkPickerState,
     bookmarks: &[BookmarkInfo],
-) -> Vec<PickerSection<BookmarkInfo>> {
+) -> Vec<PickerSection<BookmarkPickerEntry>> {
     let (mut tracked, mut local): (Vec<_>, Vec<_>) = bookmarks
         .iter()
         .filter(|bookmark| !bookmark.is_deleted && bookmark.has_local_target)
-        .cloned()
-        .partition(|bookmark| bookmark.is_tracking_remote);
-    tracked.sort_by_cached_key(|bookmark| bookmark.name.to_lowercase());
-    local.sort_by_cached_key(|bookmark| bookmark.name.to_lowercase());
+        .map(|bookmark| BookmarkPickerEntry {
+            bookmark: bookmark.clone(),
+            remote: None,
+        })
+        .partition(|entry| entry.bookmark.is_tracking_remote);
+    let mut remote: Vec<_> = bookmarks
+        .iter()
+        .filter(|bookmark| !bookmark.has_local_target)
+        .flat_map(|bookmark| {
+            bookmark
+                .available_remotes
+                .iter()
+                .filter(|remote| !bookmark.tracked_remotes.contains(remote))
+                .map(|remote| BookmarkPickerEntry {
+                    bookmark: bookmark.clone(),
+                    remote: Some(remote.clone()),
+                })
+        })
+        .collect();
+    for entries in [&mut tracked, &mut local, &mut remote] {
+        entries.sort_by_cached_key(|entry| entry.label().to_lowercase());
+    }
     sections_by_best_match(
         [
             ("bookmark-picker-tracked", "Tracked", tracked),
             ("bookmark-picker-local", "Local Only", local),
+            ("bookmark-picker-remote", "Remote Only", remote),
         ]
         .into_iter()
         .filter_map(|(id, title, rows)| {
-            PickerSection::filtered(
-                id,
-                Some(title),
-                rows,
-                state.query.input.text(),
-                |bookmark| {
-                    format!(
-                        "{} {} {}",
-                        bookmark.name,
-                        bookmark.tracked_remotes.join(" "),
-                        bookmark.available_remotes.join(" ")
-                    )
-                },
-            )
+            PickerSection::filtered(id, Some(title), rows, state.query.input.text(), |entry| {
+                let bookmark = &entry.bookmark;
+                if entry.remote.is_some() {
+                    return entry.label();
+                }
+                format!(
+                    "{} {} {}",
+                    bookmark.name,
+                    bookmark.tracked_remotes.join(" "),
+                    bookmark.available_remotes.join(" ")
+                )
+            })
         }),
     )
 }
 
 pub(super) fn bookmark_row(
-    bookmark: BookmarkInfo,
+    entry: BookmarkPickerEntry,
     selected: bool,
     t: &Theme,
     view: &Entity<RepoWindow>,
 ) -> AnyElement {
-    let caption = bookmark_caption(&bookmark);
+    let bookmark = &entry.bookmark;
+    let caption = if entry.remote.is_some() {
+        None
+    } else {
+        bookmark_caption(bookmark)
+    };
     let height = if caption.is_some() { 38. } else { 28. };
-    let id = format!("bookmark-picker-row-{}", bookmark.name);
-    let name = bookmark.name.clone();
+    let label = entry.label();
+    let revset = entry.revset();
+    let context_revset = revset.clone();
     let click_view = view.clone();
     let context_view = view.clone();
     let context_bookmark = bookmark.clone();
-    row(id, selected, height, t)
+    let remote = entry.remote.clone();
+    row(entry.id(), selected, height, t)
         .cursor_pointer()
         .on_mouse_down(MouseButton::Left, move |_: &MouseDownEvent, _, cx| {
             cx.stop_propagation();
-            click_view.update(cx, |view, cx| view.filter_by_bookmark(&name, cx));
+            click_view.update(cx, |view, cx| view.filter_bookmark_revset(&revset, cx));
         })
         .on_mouse_down(MouseButton::Right, move |event: &MouseDownEvent, _, cx| {
             let anchor = event.position;
@@ -81,9 +98,20 @@ pub(super) fn bookmark_row(
                 let mut items = vec![ContextMenuItem::new(
                     "Filter by this bookmark",
                     glyph::FILTER,
-                    ContextAction::FilterByBookmark(bookmark.name.clone().into()),
+                    ContextAction::FilterBookmarkRevset(context_revset.clone().into()),
                 )];
-                items.extend(view.build_bookmark_menu(&bookmark.name, None, cx));
+                if let Some(remote) = &remote {
+                    items.push(ContextMenuItem::new(
+                        format!("Track {}@{remote}", bookmark.name),
+                        glyph::GIT_BRANCH,
+                        ContextAction::TrackBookmark {
+                            name: bookmark.name.clone(),
+                            remote: remote.clone(),
+                        },
+                    ));
+                } else {
+                    items.extend(view.build_bookmark_menu(&bookmark.name, None, cx));
+                }
                 view.open_context_menu(anchor, items, cx);
             });
         })
@@ -105,9 +133,9 @@ pub(super) fn bookmark_row(
                                 .min_w_0()
                                 .truncate()
                                 .text_size(ui_font_size(13.))
-                                .child(SharedString::from(bookmark.name)),
+                                .child(SharedString::from(label)),
                         )
-                        .child(if bookmark.is_tracking_remote {
+                        .child(if bookmark.is_tracking_remote || entry.remote.is_some() {
                             icons::icon(glyph::CLOUD, 11., t.fg_dim)
                         } else {
                             icons::icon(glyph::CLOUD_OFF, 11., t.fg_faint)
@@ -184,12 +212,81 @@ mod tests {
 
         assert_eq!(sections.len(), 2);
         assert_eq!(sections[0].title, Some("Tracked"));
-        assert_eq!(sections[0].rows[0].name, "tracked");
+        assert_eq!(sections[0].rows[0].bookmark.name, "tracked");
         assert_eq!(sections[1].title, Some("Local Only"));
-        assert_eq!(sections[1].rows[0].name, "local");
+        assert_eq!(sections[1].rows[0].bookmark.name, "local");
         assert_eq!(
             picker_actions(&sections),
-            vec![("tracked".to_owned(), 1), ("local".to_owned(), 3)]
+            vec![("\"tracked\"".to_owned(), 1), ("\"local\"".to_owned(), 3)]
         );
+    }
+
+    #[test]
+    fn remote_rows_browse_each_remote_and_filter_by_qualified_name() {
+        let mut state = BookmarkPickerState {
+            anchor: gpui::point(gpui::px(0.), gpui::px(0.)),
+            query: PickerQuery::new(),
+        };
+        let mut remote = bookmark("odd&name", false);
+        remote.has_local_target = false;
+        remote.available_remotes = vec!["upstream".to_owned(), "origin".to_owned()];
+        let bookmarks = [bookmark("local", false), remote];
+        let sections = bookmark_sections(&state, &bookmarks);
+        assert_eq!(sections[1].title, Some("Remote Only"));
+        assert_eq!(
+            sections[1]
+                .rows
+                .iter()
+                .map(|row| row.label())
+                .collect::<Vec<_>>(),
+            ["odd&name@origin", "odd&name@upstream"]
+        );
+        state.query.input.set_text("upstream".to_owned());
+        let sections = bookmark_sections(&state, &bookmarks);
+        assert_eq!(
+            picker_actions(&sections),
+            [(
+                "ancestors(remote_bookmarks(exact:\"odd&name\", exact:\"upstream\"), 20)"
+                    .to_owned(),
+                1
+            )]
+        );
+    }
+
+    #[test]
+    fn deleted_bookmark_keeps_its_untracked_remote() {
+        let state = BookmarkPickerState {
+            anchor: gpui::point(gpui::px(0.), gpui::px(0.)),
+            query: PickerQuery::new(),
+        };
+        let mut remote = bookmark("feature", true);
+        remote.has_local_target = false;
+        remote.is_deleted = true;
+        remote.available_remotes = vec!["origin".to_owned(), "upstream".to_owned()];
+        let sections = bookmark_sections(&state, &[remote.clone()]);
+        let labels: Vec<_> = sections
+            .iter()
+            .flat_map(|section| &section.rows)
+            .map(|row| row.label())
+            .collect();
+        assert_eq!(labels, ["feature@upstream"]);
+
+        remote.tracked_remotes.push("upstream".to_owned());
+        assert!(bookmark_sections(&state, &[remote]).is_empty());
+    }
+
+    #[test]
+    fn remote_row_identity_does_not_depend_on_its_display_label() {
+        let first = super::BookmarkPickerEntry {
+            bookmark: bookmark("a@b", false),
+            remote: Some("c".to_owned()),
+        };
+        let second = super::BookmarkPickerEntry {
+            bookmark: bookmark("a", false),
+            remote: Some("b@c".to_owned()),
+        };
+        assert_eq!(first.label(), second.label());
+        assert_ne!(first.id(), second.id());
+        assert_ne!(first.revset(), second.revset());
     }
 }

--- a/shell/gpui/src/repo/window/menu.rs
+++ b/shell/gpui/src/repo/window/menu.rs
@@ -172,7 +172,21 @@ impl RepoWindow {
                 self.vm
                     .update(cx, |vm, cx| vm.compare_bookmark_diff(request, cx));
             }
-            ContextAction::FilterByBookmark(name) => self.filter_by_bookmark(&name, cx),
+            ContextAction::FilterBookmarkRevset(revset) => self.filter_bookmark_revset(&revset, cx),
+            ContextAction::TrackBookmark { name, remote } => {
+                self.close_bookmark_picker(cx);
+                let task = self.vm.update(cx, |vm, cx| {
+                    vm.bookmark_write(move |repo| repo.track_bookmark(&name, &remote), cx)
+                });
+                cx.spawn(async move |this, cx| {
+                    if let Err(error) = task.await {
+                        let _ = this.update(cx, |view, cx| {
+                            view.show_toast(error.to_string(), cx);
+                        });
+                    }
+                })
+                .detach();
+            }
             ContextAction::RevealChange(change_id) => {
                 self.reveal_change_id(change_id.as_ref(), cx);
             }

--- a/shell/gpui/src/repo/window/render/view.rs
+++ b/shell/gpui/src/repo/window/render/view.rs
@@ -36,7 +36,16 @@ impl Render for RepoWindow {
                 .filter(|bookmark| !bookmark.is_deleted && bookmark.has_local_target)
                 .collect::<Vec<_>>();
             let bookmark_counts = BookmarkCounts {
-                total: local_bookmarks.len(),
+                total: bookmarks
+                    .iter()
+                    .filter(|bookmark| {
+                        !bookmark.is_deleted
+                            || bookmark
+                                .available_remotes
+                                .iter()
+                                .any(|remote| !bookmark.tracked_remotes.contains(remote))
+                    })
+                    .count(),
                 local_only: local_bookmarks
                     .iter()
                     .filter(|bookmark| !bookmark.is_tracking_remote)

--- a/shell/gpui/src/ui/context_menu.rs
+++ b/shell/gpui/src/ui/context_menu.rs
@@ -45,7 +45,11 @@ pub enum ContextAction {
     OpenFileHistoryFor(SharedString),
     ToggleAnnotateFor(SharedString),
     ShowBookmarkDiff(BookmarkDiffRequest),
-    FilterByBookmark(SharedString),
+    FilterBookmarkRevset(SharedString),
+    TrackBookmark {
+        name: String,
+        remote: String,
+    },
     RevealChange(SharedString),
     OpenInEditor(SharedString),
     ShowInFileManager(SharedString),

--- a/shell/gpui/tests/gpui/repo_pickers.rs
+++ b/shell/gpui/tests/gpui/repo_pickers.rs
@@ -153,6 +153,93 @@ fn bookmark_picker_groups_filters_and_applies_bookmark_revsets(cx: &mut TestAppC
 }
 
 #[gpui::test]
+fn bookmark_picker_browses_remote_history_without_tracking(cx: &mut TestAppContext) {
+    let fixture = LinearFixture::build();
+    let _remote = create_tracked_bookmark(&fixture, "remote-picker");
+    run_jj_in(
+        &fixture.path,
+        &["bookmark", "untrack", "remote-picker@origin"],
+    );
+    run_jj_in(&fixture.path, &["bookmark", "delete", "remote-picker"]);
+    let (view, repo_cx) = open_fixture(&fixture, cx);
+    repo_cx.focus(&view);
+    let before = run_jj_in(
+        &fixture.path,
+        &["log", "--no-graph", "-r", "mutable()", "-T", "commit_id"],
+    );
+
+    let button = repo_cx
+        .debug_bounds("toolbar-bookmarks-2")
+        .expect("bookmark picker");
+    repo_cx.simulate_click(button.center(), Modifiers::default());
+    settle_visual(repo_cx);
+    assert!(repo_cx.debug_bounds("bookmark-picker-remote").is_some());
+    let row = repo_cx
+        .debug_bounds("bookmark-picker-remote-row-13:remote-pickerorigin")
+        .expect("remote row");
+    repo_cx.simulate_mouse_down(row.center(), MouseButton::Right, Modifiers::default());
+    settle_visual(repo_cx);
+    assert!(
+        repo_cx
+            .debug_bounds("context-menu-Track remote-picker@origin")
+            .is_some()
+    );
+    assert!(repo_cx.debug_bounds("context-menu-Push").is_none());
+    assert!(repo_cx.debug_bounds("context-menu-Move to @-").is_none());
+    repo_cx.simulate_keystrokes("escape");
+    repo_cx.simulate_input("remote-picker@origin");
+    repo_cx.simulate_keystrokes("enter");
+    settle_visual(repo_cx);
+    view.read_with(repo_cx, |view, cx| {
+        let vm = view.view_model().read(cx);
+        assert_eq!(
+            vm.revset.as_ref(),
+            "ancestors(remote_bookmarks(exact:\"remote-picker\", exact:\"origin\"), 20)"
+        );
+        assert!(vm.error.is_none(), "{:?}", vm.error);
+        assert_eq!(vm.graph.changes.len(), 3);
+    });
+    let bookmarks = jayjay_core::Repo::open(&fixture.path)
+        .unwrap()
+        .list_bookmarks()
+        .unwrap();
+    let bookmark = bookmarks
+        .iter()
+        .find(|b| b.name == "remote-picker")
+        .unwrap();
+    assert!(!bookmark.has_local_target && !bookmark.is_tracking_remote);
+    assert_eq!(
+        run_jj_in(
+            &fixture.path,
+            &["log", "--no-graph", "-r", "mutable()", "-T", "commit_id"]
+        ),
+        before
+    );
+
+    repo_cx.simulate_click(button.center(), Modifiers::default());
+    settle_visual(repo_cx);
+    let row = repo_cx
+        .debug_bounds("bookmark-picker-remote-row-13:remote-pickerorigin")
+        .unwrap();
+    repo_cx.simulate_mouse_down(row.center(), MouseButton::Right, Modifiers::default());
+    settle_visual(repo_cx);
+    let track = repo_cx
+        .debug_bounds("context-menu-Track remote-picker@origin")
+        .unwrap();
+    repo_cx.simulate_click(track.center(), Modifiers::default());
+    settle_visual(repo_cx);
+    assert!(repo_cx.debug_bounds("bookmark-picker-panel").is_none());
+    assert!(
+        jayjay_core::Repo::open(&fixture.path)
+            .unwrap()
+            .list_bookmarks()
+            .unwrap()
+            .iter()
+            .any(|b| b.name == "remote-picker" && b.has_local_target && b.is_tracking_remote)
+    );
+}
+
+#[gpui::test]
 fn bookmark_picker_menu_offers_no_removal_for_a_conflicted_bookmark(cx: &mut TestAppContext) {
     let fixture = LinearFixture::build();
     create_conflicted_bookmark(&fixture, "clash");

--- a/shell/mac/Sources/JayJay/Repo/Bookmarks/BookmarkPicker.swift
+++ b/shell/mac/Sources/JayJay/Repo/Bookmarks/BookmarkPicker.swift
@@ -7,19 +7,22 @@ struct BookmarkPicker: View {
     let onSelect: (String) -> Void
 
     private var localBookmarks: [BookmarkInfo] {
-        bookmarks.filter(\.hasLocalTarget)
+        bookmarks.filter { $0.hasLocalTarget && !$0.isDeleted }
     }
 
     private var bookmarkLabel: String {
         let local = localBookmarks
-        if local.isEmpty {
+        let total = bookmarks.filter { bookmark in
+            !bookmark.isDeleted || bookmark.availableRemotes.contains { !bookmark.trackedRemotes.contains($0) }
+        }.count
+        if total == 0 {
             return "Bookmarks"
         }
         let untrackedCount = local.filter { !$0.isTrackingRemote }.count
         if untrackedCount == 0 {
-            return "Bookmarks (\(local.count))"
+            return "Bookmarks (\(total))"
         }
-        return "Bookmarks (\(local.count), \(untrackedCount) local)"
+        return "Bookmarks (\(total), \(untrackedCount) local)"
     }
 
     private var trackedBookmarks: [BookmarkInfo] {
@@ -32,6 +35,29 @@ struct BookmarkPicker: View {
         localBookmarks
             .filter { !$0.isTrackingRemote }
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+    }
+
+    var sections: [PickerSection] {
+        var sections: [PickerSection] = []
+        if !trackedBookmarks.isEmpty {
+            sections.append(PickerSection(id: "tracked", title: "Tracked", rows: trackedBookmarks.map(bookmarkRow)))
+        }
+        if !localOnlyBookmarks.isEmpty {
+            sections.append(PickerSection(id: "local", title: "Local Only", rows: localOnlyBookmarks.map(bookmarkRow)))
+        }
+        let remoteRows = bookmarks
+            .filter { !$0.hasLocalTarget }
+            .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
+            .flatMap { bookmark in
+                bookmark.availableRemotes
+                    .filter { !bookmark.trackedRemotes.contains($0) }
+                    .sorted()
+                    .map { remoteRow(bookmark, remote: $0) }
+            }
+        if !remoteRows.isEmpty {
+            sections.append(PickerSection(id: "remote", title: "Remote Only", rows: remoteRows))
+        }
+        return sections
     }
 
     @State private var anchor = PickerAnchor()
@@ -77,13 +103,7 @@ struct BookmarkPicker: View {
             return
         }
         guard let anchorView = anchor.view else { return }
-        var sections: [PickerSection] = []
-        if !trackedBookmarks.isEmpty {
-            sections.append(PickerSection(id: "tracked", title: "Tracked", rows: trackedBookmarks.map(bookmarkRow)))
-        }
-        if !localOnlyBookmarks.isEmpty {
-            sections.append(PickerSection(id: "local", title: "Local Only", rows: localOnlyBookmarks.map(bookmarkRow)))
-        }
+        let sections = sections
         let root = PickerPanelRoot(
             placeholder: "Filter",
             actionLabel: "New",
@@ -108,6 +128,29 @@ struct BookmarkPicker: View {
             content: { _ in BookmarkRowView(bookmark: bookmark, caption: caption) }
         )
         .withContextMenu { bookmarkContextMenu(bookmark) }
+    }
+
+    private func remoteRow(_ bookmark: BookmarkInfo, remote: String) -> PickerRow {
+        let name = bookmark.name
+        let symbol = "\(name)@\(remote)"
+        let revset = "ancestors(remote_bookmarks(exact:\(RevsetExpressions.quotedSymbol(name)), exact:\(RevsetExpressions.quotedSymbol(remote))), \(RepoViewModel.defaultRevsetPageSize))"
+        return PickerRow(
+            id: "remote-bookmark-\(name.utf8.count):\(name)\(remote)",
+            searchText: symbol,
+            height: 28,
+            action: { onSelect(revset) },
+            content: { _ in BookmarkRowView(bookmark: bookmark, caption: nil, remote: remote) }
+        )
+        .withContextMenu {
+            Button("Filter by this bookmark") {
+                panel.dismiss()
+                onSelect(revset)
+            }
+            Button("Track \(symbol)") {
+                panel.dismiss()
+                actions?.trackBookmark(name: name, remote: remote)
+            }
+        }
     }
 
     @ViewBuilder

--- a/shell/mac/Sources/JayJay/Repo/Bookmarks/BookmarkRowView.swift
+++ b/shell/mac/Sources/JayJay/Repo/Bookmarks/BookmarkRowView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct BookmarkRowView: View {
     let bookmark: BookmarkInfo
     let caption: String?
+    var remote: String?
 
     static func caption(for bookmark: BookmarkInfo) -> String? {
         if !bookmark.trackedRemotes.isEmpty {
@@ -18,10 +19,10 @@ struct BookmarkRowView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
             HStack(spacing: 6) {
-                Text(bookmark.name)
+                Text(remote.map { "\(bookmark.name)@\($0)" } ?? bookmark.name)
                     .font(.system(size: 13))
                     .lineLimit(1)
-                Image(systemName: bookmark.isTrackingRemote ? "cloud.fill" : "cloud.slash")
+                Image(systemName: remote != nil ? "cloud" : bookmark.isTrackingRemote ? "cloud.fill" : "cloud.slash")
                     .imageScale(.small)
                     .foregroundStyle(bookmark.isTrackingRemote ? .secondary : .tertiary)
                 Spacer(minLength: 8)

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGLayout.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGLayout.swift
@@ -14,7 +14,7 @@ let dagSolidStroke = StrokeStyle(lineWidth: 1)
 /// Thin Swift wrapper over `jayjay_core::dag::DagLayout` (via uniffi).
 struct DAGLayout {
     private let lanes: [String: UInt32]
-    private let activeLanesPerRow: [UInt32]
+    private let maxLaneCount: Int
     private let activeLaneIndicesPerRow: [[UInt32]]
     private let overflowRows: [Bool]
     private let displayLaneCountValue: UInt32
@@ -22,7 +22,7 @@ struct DAGLayout {
     init(entries: [GraphEntry]) {
         let data = computeDagLayout(entries: entries)
         lanes = data.lanes
-        activeLanesPerRow = data.activeLanesPerRow
+        maxLaneCount = Int(data.activeLanesPerRow.max() ?? 1)
         activeLaneIndicesPerRow = data.activeLaneIndicesPerRow
         overflowRows = data.overflowRows
         displayLaneCountValue = data.displayLaneCount
@@ -33,7 +33,7 @@ struct DAGLayout {
     }
 
     func maxLanes() -> Int {
-        Int(activeLanesPerRow.max() ?? 1)
+        maxLaneCount
     }
 
     func displayLaneCount() -> Int {

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGRowFrameCache.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGRowFrameCache.swift
@@ -1,0 +1,6 @@
+import CoreGraphics
+
+/// Drag hit-testing needs current frames, but publishing layout measurements back to SwiftUI can keep the lazy stack laying itself out.
+final class DAGRowFrameCache {
+    var frames: [String: CGRect] = [:]
+}

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGView+BookmarkDrag.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGView+BookmarkDrag.swift
@@ -97,7 +97,7 @@ extension DAGView {
 
     private func updateBookmarkDrag(location: CGPoint) {
         guard var drag = bookmarkDrag else { return }
-        let hovered = rebaseRowFrames.first(where: { $0.value.contains(location) })?.key
+        let hovered = rowFrameCache.frames.first(where: { $0.value.contains(location) })?.key
         let normalized = BookmarkDragGesturePolicy.normalizedHoveredCommitId(hovered, drag: drag)
         drag.location = location
         drag.hoveredCommitId = normalized

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGView+RebaseDrag.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGView+RebaseDrag.swift
@@ -100,7 +100,6 @@ extension DAGView {
 
     private func beginRebasePress(for entry: GraphEntry, layout: DAGLayout, location: CGPoint) {
         guard rebaseDrag?.sourceCommitId != entry.change.commitId.id else { return }
-        // Row frames only mount once a drag state exists, so the first press seeds from the pointer; the ghost re-anchors from live frames on the first drag movement.
         let seedLocation = rebaseDragSeedLocation(for: entry, layout: layout) ?? location
 
         activePane = .dag
@@ -144,7 +143,7 @@ extension DAGView {
 
     private func updateRebaseDrag(location: CGPoint) {
         guard var rebaseDrag else { return }
-        let hoveredCommitId = rebaseRowFrames.first(where: { $0.value.contains(location) })?.key
+        let hoveredCommitId = rowFrameCache.frames.first(where: { $0.value.contains(location) })?.key
         let normalizedTarget = DAGRebaseGesturePolicy.normalizedTargetCommitId(
             sourceCommitId: rebaseDrag.sourceCommitId,
             hoveredCommitId: hoveredCommitId
@@ -223,7 +222,7 @@ extension DAGView {
     }
 
     private func rebaseDragSeedLocation(for entry: GraphEntry, layout: DAGLayout) -> CGPoint? {
-        guard let rowFrame = rebaseRowFrames[entry.change.commitId.id] else { return nil }
+        guard let rowFrame = rowFrameCache.frames[entry.change.commitId.id] else { return nil }
         guard let rowIndex = entries.firstIndex(where: { $0.change.commitId.id == entry.change.commitId.id }) else { return nil }
         let lane = layout.lane(for: entry.change.commitId.id)
         return CGPoint(

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGView.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGView.swift
@@ -28,7 +28,7 @@ struct DAGView: View {
     @State private var contextTargetId: String?
     @State private var dagLayout: DAGLayout
     @State private var dagLayoutEntries: [GraphEntry]
-    @State var rebaseRowFrames: [String: CGRect] = [:]
+    @State var rowFrameCache = DAGRowFrameCache()
     @State var rebaseDrag: DAGRebaseDragState?
     @State var rebaseArmTask: Task<Void, Never>?
     @State var rebasePreviewTargetId: String?
@@ -188,7 +188,7 @@ struct DAGView: View {
                     )
                     .overlay(alignment: .topLeading) { rebaseDragOverlay }
                     .overlay(alignment: .topLeading) { bookmarkDragOverlay }
-                    .onPreferenceChange(DAGRebaseRowFramePreferenceKey.self) { rebaseRowFrames = $0 }
+                    .onPreferenceChange(DAGRebaseRowFramePreferenceKey.self) { rowFrameCache.frames = $0 }
                     .onChange(of: entries.map(\.change.commitId)) { _, _ in
                         if viewModel.shouldCancelRebaseDrag(for: rebaseDrag?.hoveredCommitId) {
                             cancelRebaseDrag()

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGViewModel.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGViewModel.swift
@@ -1,9 +1,10 @@
 import JayJayCore
 import SwiftUI
 
+@MainActor
 struct DAGViewModel {
-    private static let downArrowKeyCode: UInt16 = 125
-    private static let upArrowKeyCode: UInt16 = 126
+    nonisolated private static let downArrowKeyCode: UInt16 = 125
+    nonisolated private static let upArrowKeyCode: UInt16 = 126
 
     let entries: [GraphEntry]
     let selectedId: String?
@@ -14,6 +15,7 @@ struct DAGViewModel {
     let bookmarkDrag: BookmarkDragState?
     let colorScheme: ColorScheme
     let layout: DAGLayout
+    private let cache = Cache()
 
     var isEmpty: Bool {
         entries.isEmpty
@@ -52,47 +54,41 @@ struct DAGViewModel {
 
     func canRebaseSelection(onto target: ChangeInfo) -> Bool {
         guard hasMutableSelection, !isSelected(target) else { return false }
-        return !hasSelectedAncestor(
-            startingAt: target.commitId.id,
-            parentIds: parentIdsByCommitId,
-            selectedCommitIds: selectedCommitIds
-        )
+        return !descendantCommitIds.contains(target.commitId.id)
     }
 
     var canMergeSelection: Bool {
-        canMerge(selectedChanges)
+        selectedCommitIds.count > 1 && selectedCommitIds.isDisjoint(with: ancestorCommitIds)
     }
 
     func canMergeSelectedChange(with target: ChangeInfo) -> Bool {
-        canMerge(selectedChanges + [target])
-    }
-
-    private func canMerge(_ changes: [ChangeInfo]) -> Bool {
-        let selection = Set(changes.map(\.commitId.id))
-        guard selection.count > 1 else { return false }
-        let parentIds = parentIdsByCommitId
-        return !selection.contains {
-            hasSelectedAncestor(
-                startingAt: $0,
-                parentIds: parentIds,
-                selectedCommitIds: selection
-            )
+        guard !selectedCommitIds.isEmpty else { return false }
+        if selectedCommitIds.contains(target.commitId.id) {
+            return canMergeSelection
         }
+        return selectedCommitIds.isDisjoint(with: ancestorCommitIds)
+            && !ancestorCommitIds.contains(target.commitId.id)
+            && !descendantCommitIds.contains(target.commitId.id)
     }
 
-    static func formsConsecutiveLinearRange(_ changes: [ChangeInfo]) -> Bool {
+    nonisolated static func formsConsecutiveLinearRange(_ changes: [ChangeInfo]) -> Bool {
         changes.count > 1 && zip(changes, changes.dropFirst()).allSatisfy { newer, older in
             newer.parents == [older.commitId.id]
         }
     }
 
     /// The combined diff bases on the oldest change's single parent; squashing the same range into a merge commit is still legal.
-    static func rangeHasSingleParentBase(_ changes: [ChangeInfo]) -> Bool {
+    nonisolated static func rangeHasSingleParentBase(_ changes: [ChangeInfo]) -> Bool {
         changes.last?.parents.count == 1
     }
 
     private var selectedChanges: [ChangeInfo] {
-        entries.map(\.change).filter(isSelected)
+        if let changes = cache.selectedChanges {
+            return changes
+        }
+        let changes = entries.compactMap { isSelected($0.change) ? $0.change : nil }
+        cache.selectedChanges = changes
+        return changes
     }
 
     private var selectedCommitIds: Set<String> {
@@ -106,7 +102,10 @@ struct DAGViewModel {
     }
 
     private var parentIdsByCommitId: [String: [String]] {
-        Dictionary(
+        if let parents = cache.parentIdsByCommitId {
+            return parents
+        }
+        let parents = Dictionary(
             uniqueKeysWithValues: entries.map { entry in
                 (
                     entry.change.commitId.id,
@@ -114,24 +113,43 @@ struct DAGViewModel {
                 )
             }
         )
+        cache.parentIdsByCommitId = parents
+        return parents
     }
 
-    private func hasSelectedAncestor(
-        startingAt commitId: String,
-        parentIds: [String: [String]],
-        selectedCommitIds: Set<String>
-    ) -> Bool {
-        var pending = parentIds[commitId, default: []]
-        var visited: Set<String> = []
-        while let parentId = pending.popLast() {
-            if selectedCommitIds.contains(parentId) {
-                return true
-            }
-            if visited.insert(parentId).inserted {
-                pending.append(contentsOf: parentIds[parentId, default: []])
+    private var ancestorCommitIds: Set<String> {
+        if let ancestors = cache.ancestorCommitIds {
+            return ancestors
+        }
+        let ancestors = reachableCommitIds(links: parentIdsByCommitId)
+        cache.ancestorCommitIds = ancestors
+        return ancestors
+    }
+
+    private var descendantCommitIds: Set<String> {
+        if let descendants = cache.descendantCommitIds {
+            return descendants
+        }
+        var children: [String: [String]] = [:]
+        for (commitId, parents) in parentIdsByCommitId {
+            for parent in parents {
+                children[parent, default: []].append(commitId)
             }
         }
-        return false
+        let descendants = reachableCommitIds(links: children)
+        cache.descendantCommitIds = descendants
+        return descendants
+    }
+
+    private func reachableCommitIds(links: [String: [String]]) -> Set<String> {
+        var pending = selectedCommitIds.flatMap { links[$0, default: []] }
+        var visited: Set<String> = []
+        while let commitId = pending.popLast() {
+            if visited.insert(commitId).inserted {
+                pending.append(contentsOf: links[commitId, default: []])
+            }
+        }
+        return visited
     }
 
     func rowViewModel(
@@ -196,7 +214,16 @@ struct DAGViewModel {
     }
 
     func change(for changeId: String) -> ChangeInfo? {
-        entries.first(where: { $0.change.matchesRevision(changeId) })?.change
+        if cache.changesByRevision == nil {
+            var changes: [String: ChangeInfo] = [:]
+            for entry in entries {
+                for revision in [entry.change.changeId.id, entry.change.commitId.id] where changes[revision] == nil {
+                    changes[revision] = entry.change
+                }
+            }
+            cache.changesByRevision = changes
+        }
+        return cache.changesByRevision?[changeId]
     }
 
     func canSquashIntoParent(_ target: ChangeInfo) -> Bool {
@@ -205,8 +232,8 @@ struct DAGViewModel {
     }
 
     func bookmarkDiffRequest(from selectedId: String, to target: ChangeInfo) -> BookmarkDiffRequest? {
-        guard let selectedEntry = entries.first(where: { $0.change.matchesRevision(selectedId) }),
-              let base = RevsetExpressions.primaryBaseBookmarkEndpoint(for: selectedEntry.change),
+        guard let selectedChange = change(for: selectedId),
+              let base = RevsetExpressions.primaryBaseBookmarkEndpoint(for: selectedChange),
               let head = RevsetExpressions.primaryHeadBookmarkEndpoint(for: target),
               base.label != head.label
         else {
@@ -216,7 +243,7 @@ struct DAGViewModel {
     }
 
     func scrollId(for rev: String) -> String {
-        entries.first(where: { $0.change.matchesRevision(rev) })?.change.selectionRevision ?? rev
+        change(for: rev)?.selectionRevision ?? rev
     }
 
     /// Other visible commits that share this change's id — the siblings of a divergent change. Empty unless `change` is divergent. Used to offer an interdiff between two versions of the same change so the user can see which is safer to abandon.
@@ -227,7 +254,7 @@ struct DAGViewModel {
             .filter { $0.changeId.id == change.changeId.id && $0.commitId.id != change.commitId.id }
     }
 
-    static func selectionDelta(
+    nonisolated static func selectionDelta(
         keyCode: UInt16,
         charactersIgnoringModifiers: String?,
         controlPressed: Bool
@@ -253,5 +280,14 @@ struct DAGViewModel {
             default:
                 return nil
         }
+    }
+
+    /// All inputs are immutable, so row menus can share derived data for this view-model snapshot.
+    private final class Cache {
+        var selectedChanges: [ChangeInfo]?
+        var parentIdsByCommitId: [String: [String]]?
+        var changesByRevision: [String: ChangeInfo]?
+        var ancestorCommitIds: Set<String>?
+        var descendantCommitIds: Set<String>?
     }
 }

--- a/shell/mac/Sources/JayJay/Shared/PaneLayout.swift
+++ b/shell/mac/Sources/JayJay/Shared/PaneLayout.swift
@@ -28,6 +28,6 @@ enum PaneLayout {
 
 private extension ClosedRange<CGFloat> {
     func fitted(in room: CGFloat) -> ClosedRange<CGFloat> {
-        lowerBound ... min(upperBound, max(lowerBound, room))
+        lowerBound ... Swift.min(upperBound, Swift.max(lowerBound, room))
     }
 }

--- a/shell/mac/Tests/JayJayTests/BookmarkPickerTests.swift
+++ b/shell/mac/Tests/JayJayTests/BookmarkPickerTests.swift
@@ -1,0 +1,52 @@
+@testable import JayJay
+import JayJayCore
+import XCTest
+
+@MainActor
+final class BookmarkPickerTests: XCTestCase {
+    func testRemoteRowsBrowseEachRemote() throws {
+        let remote = remoteBookmark("odd&name", remotes: ["upstream", "origin"])
+        var selected: [String] = []
+        let picker = BookmarkPicker(bookmarks: [remote], actions: nil, onSelect: { selected.append($0) })
+        let section = try XCTUnwrap(picker.sections.first)
+        XCTAssertEqual(picker.sections.count, 1)
+        XCTAssertEqual(section.title, "Remote Only")
+        XCTAssertEqual(section.rows.map(\.searchText), ["odd&name@origin", "odd&name@upstream"])
+        for row in section.rows {
+            try XCTUnwrap(row.action)()
+        }
+        XCTAssertEqual(selected, [
+            "ancestors(remote_bookmarks(exact:\"odd&name\", exact:\"origin\"), 20)",
+            "ancestors(remote_bookmarks(exact:\"odd&name\", exact:\"upstream\"), 20)"
+        ])
+    }
+
+    func testDeletedBookmarkKeepsItsUntrackedRemote() {
+        let bookmark = remoteBookmark("feature", remotes: ["origin", "upstream"], tracked: ["origin"], deleted: true)
+        let picker = BookmarkPicker(bookmarks: [bookmark], actions: nil, onSelect: { _ in })
+        XCTAssertEqual(picker.sections.flatMap(\.rows).map(\.searchText), ["feature@upstream"])
+
+        let fullyDeleted = remoteBookmark("feature", remotes: ["origin", "upstream"], tracked: ["origin", "upstream"], deleted: true)
+        let deleted = BookmarkPicker(bookmarks: [fullyDeleted], actions: nil, onSelect: { _ in })
+        XCTAssertTrue(deleted.sections.isEmpty)
+    }
+
+    func testRemoteRowIdentityDoesNotDependOnItsDisplayLabel() {
+        let bookmarks = [remoteBookmark("a@b", remotes: ["c"]), remoteBookmark("a", remotes: ["b@c"])]
+        var selected: [String] = []
+        let picker = BookmarkPicker(bookmarks: bookmarks, actions: nil, onSelect: { selected.append($0) })
+        let rows = picker.sections.flatMap(\.rows)
+        XCTAssertEqual(rows.map(\.searchText), ["a@b@c", "a@b@c"])
+        XCTAssertEqual(Set(rows.map(\.id)).count, 2)
+        rows.forEach { $0.action?() }
+        XCTAssertEqual(Set(selected).count, 2)
+    }
+
+    private func remoteBookmark(_ name: String, remotes: [String], tracked: [String] = [], deleted: Bool = false) -> BookmarkInfo {
+        BookmarkInfo(
+            name: name, changeId: ShortId(id: "abc", shortLen: 3), description: "",
+            isTrackingRemote: false, isDeleted: deleted, isConflicted: false,
+            trackedRemotes: tracked, availableRemotes: remotes, hasLocalTarget: false, remoteTargets: []
+        )
+    }
+}

--- a/shell/mac/Tests/JayJayTests/DAGPerformanceTests.swift
+++ b/shell/mac/Tests/JayJayTests/DAGPerformanceTests.swift
@@ -1,0 +1,63 @@
+@testable import JayJay
+import JayJayCore
+import XCTest
+
+@MainActor
+final class DAGPerformanceTests: XCTestCase {
+    func testLargeGraphLaneProjection() {
+        let layout = DAGLayout(entries: Self.entries)
+        let options = XCTMeasureOptions()
+        options.iterationCount = 3
+        measure(metrics: [XCTClockMetric()], options: options) {
+            let start = ContinuousClock.now
+            var total = 0
+            for _ in 0 ..< 20 {
+                for lane in 0 ..< 32 {
+                    total += layout.displayLane(for: lane)
+                }
+            }
+            XCTAssertEqual(total, 1800)
+            XCTAssertLessThan(start.duration(to: .now), .milliseconds(200))
+        }
+    }
+
+    func testLargeGraphRowMenuEligibility() {
+        let layout = DAGLayout(entries: Self.entries)
+        let options = XCTMeasureOptions()
+        options.iterationCount = 3
+        measure(metrics: [XCTClockMetric()], options: options) {
+            let start = ContinuousClock.now
+            let viewModel = DAGViewModel(
+                entries: Self.entries,
+                selectedId: "change-0",
+                selectedIds: ["change-0"],
+                compareFromId: nil,
+                contextTargetId: nil,
+                rebaseDrag: nil,
+                bookmarkDrag: nil,
+                colorScheme: .light,
+                layout: layout
+            )
+            for target in Self.entries.prefix(20) {
+                XCTAssertTrue(viewModel.canMergeSelectedChange(with: target.change))
+            }
+            XCTAssertLessThan(start.duration(to: .now), .milliseconds(200))
+        }
+    }
+
+    private static let entries: [GraphEntry] = {
+        let rowCount = 12000
+        let heads = (0 ..< 32).map { entry("head-\($0)", parents: ["commit-\(rowCount - 1 - $0)"]) }
+        let chain = (0 ..< rowCount).map { index in
+            entry("\(index)", parents: index + 1 < rowCount ? ["commit-\(index + 1)"] : [])
+        }
+        return heads + chain
+    }()
+
+    private static func entry(_ id: String, parents: [String]) -> GraphEntry {
+        GraphEntry(
+            change: mockChangeInfo(changeId: "change-\(id)", commitId: "commit-\(id)", parents: parents),
+            edges: parents.map { GraphEdge(target: $0, edgeType: .direct) }
+        )
+    }
+}

--- a/shell/mac/Tests/JayJayTests/DAGRowFrameCacheTests.swift
+++ b/shell/mac/Tests/JayJayTests/DAGRowFrameCacheTests.swift
@@ -1,0 +1,65 @@
+import AppKit
+@testable import JayJay
+import SwiftUI
+import XCTest
+
+@MainActor
+final class DAGRowFrameCacheTests: XCTestCase {
+    func testFramePreferencesReplaceDragTargetsWithoutUpdatingTheOwner() {
+        let measurements = Measurements()
+        let probe = Probe()
+        let window = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 300, height: 400),
+            styleMask: [.borderless], backing: .buffered, defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer { window.close() }
+        window.contentView = NSHostingView(rootView: FrameTrackingView(measurements: measurements, probe: probe))
+        window.layoutIfNeeded()
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        let initialBodyCount = probe.bodyCount
+
+        for count in [7, 200, 22, 0] {
+            let frames = Dictionary(uniqueKeysWithValues: (0 ..< count).map { index in
+                ("\(count)-\(index)", CGRect(x: 0, y: index * 80, width: 300, height: 80))
+            })
+            measurements.frames = frames
+            window.layoutIfNeeded()
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+
+            XCTAssertEqual(probe.cache?.frames, frames, "Drag targets must be ready before a gesture, with old rows removed")
+            XCTAssertEqual(probe.bodyCount, initialBodyCount, "Collecting row frames must not invalidate their owning view")
+        }
+    }
+
+    @Observable
+    fileprivate final class Measurements {
+        var frames: [String: CGRect] = [:]
+    }
+
+    private final class Probe {
+        var bodyCount = 0
+        var cache: DAGRowFrameCache?
+    }
+
+    private struct FrameTrackingView: View {
+        let measurements: Measurements
+        let probe: Probe
+        @State private var cache = DAGRowFrameCache()
+
+        var body: some View {
+            probe.bodyCount += 1
+            probe.cache = cache
+            return MeasuredRows(measurements: measurements)
+                .onPreferenceChange(DAGRebaseRowFramePreferenceKey.self) { cache.frames = $0 }
+        }
+    }
+
+    private struct MeasuredRows: View {
+        let measurements: Measurements
+
+        var body: some View {
+            Color.clear.preference(key: DAGRebaseRowFramePreferenceKey.self, value: measurements.frames)
+        }
+    }
+}

--- a/shell/mac/Tests/JayJayTests/DAGViewModelTests.swift
+++ b/shell/mac/Tests/JayJayTests/DAGViewModelTests.swift
@@ -3,6 +3,7 @@ import JayJayCore
 import SwiftUI
 import XCTest
 
+@MainActor
 final class DAGViewModelTests: XCTestCase {
     func testTracksHoveredContextTarget() {
         let entry = makeEntry(changeId: "hovered", commitId: "hovered-commit", isDivergent: false)
@@ -132,6 +133,44 @@ final class DAGViewModelTests: XCTestCase {
         let viewModel = makeViewModel(entries: [entry], selectedId: "selected", contextTargetId: "hovered")
 
         XCTAssertNil(viewModel.nextContextTargetId(hovering: false, entry: entry))
+    }
+
+    func testMenuProjectionPreservesFilteredAncestryAndRefreshesWithItsInputs() {
+        let first = makeEntry(changeId: "shared", commitId: "first", isDivergent: true)
+        let second = makeEntry(changeId: "shared", commitId: "second", isDivergent: true)
+        let indirect = GraphEntry(
+            change: mockChangeInfo(changeId: "descendant", commitId: "descendant", parents: ["hidden"]),
+            edges: [GraphEdge(target: "first", edgeType: .indirect)]
+        )
+        let missing = GraphEntry(
+            change: mockChangeInfo(changeId: "missing", commitId: "missing", parents: ["first"]),
+            edges: [GraphEdge(target: "first", edgeType: .missing)]
+        )
+        let entries = [indirect, missing, first, second]
+        let original = makeViewModel(entries: entries, selectedId: "first", contextTargetId: nil)
+
+        XCTAssertEqual(original.selectedRevisions, ["first"])
+        XCTAssertFalse(original.canMergeSelectedChange(with: indirect.change))
+        XCTAssertTrue(original.canMergeSelectedChange(with: missing.change))
+        XCTAssertTrue(original.canMergeSelectedChange(with: second.change))
+        XCTAssertEqual(original.change(for: "shared")?.commitId.id, "first")
+
+        let reselected = makeViewModel(entries: entries, selectedId: "second", contextTargetId: nil)
+        XCTAssertEqual(reselected.selectedRevisions, ["second"])
+        XCTAssertTrue(reselected.canMergeSelectedChange(with: indirect.change))
+
+        let refreshed = makeViewModel(entries: [first, second], selectedId: "first", contextTargetId: nil)
+        XCTAssertNil(refreshed.change(for: "descendant"))
+        XCTAssertTrue(refreshed.canMergeSelectedChange(with: indirect.change))
+        XCTAssertFalse(original.canMergeSelectedChange(with: indirect.change))
+
+        let batch = makeViewModel(
+            entries: entries, selectedId: "first", selectedIds: ["first", "second"], contextTargetId: nil
+        )
+        XCTAssertTrue(batch.canMergeSelection)
+        XCTAssertTrue(batch.canMergeSelectedChange(with: first.change))
+        XCTAssertFalse(batch.canRebaseSelection(onto: indirect.change))
+        XCTAssertTrue(batch.canRebaseSelection(onto: missing.change))
     }
 
     func testCancelsMissingHoverTarget() {

--- a/shell/mac/Tests/JayJayUITests/Scenes/RemoteBookmarkPickerScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/RemoteBookmarkPickerScene.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+final class RemoteBookmarkPickerScene: SceneBase {
+    override class var fixtureName: String {
+        "remote-bookmarks"
+    }
+
+    func testBrowseRemoteHistoryWithoutTracking() throws {
+        let app = try XCTUnwrap(app)
+        XCTAssertTrue(dagRows(of: app).firstMatch.waitForExistence(timeout: 10))
+        for (remote, count) in [("origin", 2), ("upstream", 1)] {
+            let picker = app.toolbars.buttons.matching(NSPredicate(format: "label BEGINSWITH 'Bookmarks'")).firstMatch
+            XCTAssertTrue(picker.waitForExistence(timeout: 5))
+            picker.click()
+            let row = app.buttons[AID.Picker.row("remote-bookmark-10:other-work\(remote)")]
+            XCTAssertTrue(row.waitForExistence(timeout: 5), "Browsing must leave this bookmark remote-only")
+            let filter = app.textFields["Filter"].firstMatch
+            XCTAssertTrue(filter.waitForExistence(timeout: 5))
+            filter.click()
+            paste("other-work@\(remote)")
+            keyStroke(.return)
+            XCTAssertTrue(row.waitForNonExistence(timeout: 5))
+            let rows = dagRows(of: app)
+            let expected = NSPredicate { _, _ in rows.count == count }
+            let ready = XCTNSPredicateExpectation(predicate: expected, object: nil)
+            XCTAssertEqual(XCTWaiter().wait(for: [ready], timeout: 10), .completed)
+        }
+        app.toolbars.buttons.matching(NSPredicate(format: "label BEGINSWITH 'Bookmarks'")).firstMatch.click()
+        XCTAssertTrue(app.buttons[AID.Picker.row("remote-bookmark-10:other-workorigin")].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons[AID.Picker.row("remote-bookmark-10:other-workupstream")].exists)
+        XCTAssertTrue(app.buttons[AID.Picker.row("remote-bookmark-12:deleted-workupstream")].exists)
+        XCTAssertFalse(app.buttons[AID.Picker.row("remote-bookmark-12:deleted-workorigin")].exists)
+        keyStroke(.escape)
+    }
+}


### PR DESCRIPTION
## Summary

- Cache SwiftUI DAG lane counts, selection lookups, and ancestry projections per snapshot, and keep drag-frame measurements out of observable layout state.
- Stop ordinary Pull and Push from blanket-tracking remote bookmarks. Explicit bookmark operations still track their target, and existing tracking choices are preserved.
- Add a searchable **Remote Only** section to the SwiftUI and GPUI bookmark pickers. Browse each remote's ancestry without creating a local bookmark; tracking remains an explicit action.

This keeps collaborators' work discoverable without automatically expanding local mutable history. The existing DAG algorithm and default depth of 20 are unchanged; there is no pagination or revset-policy rewrite.

Fixes #221.

## Evidence

The sampled SwiftUI context-menu hot path matches #221: repeated `canMergeSelectedChange` calls rebuilt the entire parent map. On a synthetic 12,032-change graph, a batch of 20 row-menu eligibility checks improved from about **296 ms to 16–17 ms**. These are menu-batch measurements, not end-to-end keypress latency; the reporter's exact keyboard-only scenario still merits a manual retest.

## Validation

- `cargo test -p jayjay-core -p jayjay-gpui`: 930 tests passed on macOS. The optional live Cursor Origin fixture was absent and skipped.
- `just test-app`: 253 app unit tests and 99 JayJayDiffUI package tests passed; includes the DAG performance regressions.
- `xcodebuild` with the `JayJayUITests` scheme, selecting `RemoteBookmarkPickerScene/testBrowseRemoteHistoryWithoutTracking`: passed. Keyboard selection browses the same bookmark name on two remotes while leaving both remote-only.
- After test-setup cleanup, `cargo test -p jayjay-core --test integration bookmarks::`: all 5 tests passed.
- `jj fix` made no formatting changes; `just lint` passed after simplifying the sync regression fixture.
- Linux and Windows execution is left to CI.
