### PR TITLE
fix(gpui): show conflict banner for submodule conflicts

### DIFF
--- a/shell/gpui/src/diff/diff_view/render.rs
+++ b/shell/gpui/src/diff/diff_view/render.rs
@@ -2,7 +2,7 @@ use gpui::{
     AnyElement, Context, InteractiveElement, IntoElement, ParentElement,
     StatefulInteractiveElement, Styled, UniformListScrollHandle, Window, div, px, rgb, rgba,
 };
-use jayjay_core::{DiffProjection, diff::ConflictLineKind};
+use jayjay_core::DiffProjection;
 
 use super::find_bar::render_find_bar;
 use super::header::{
@@ -196,13 +196,7 @@ pub fn diff_view(
     let find_bar = find
         .query
         .map(|q| render_find_bar(q, find.match_count, find.match_current, &t, cx));
-    let show_conflict_bar = state.can_resolve_conflict
-        && (state.selected_file_has_conflict
-            || state.file_diff.is_some_and(|fd| {
-                fd.lines
-                    .iter()
-                    .any(|line| line.conflict_kind != ConflictLineKind::None)
-            }));
+    let show_conflict_bar = state.can_resolve_conflict && state.selected_file_has_conflict;
     let projection_banner = state.effective_projection().and_then(|projection| {
         projection::shows_banner(projection, state.active_projection_preview)
             .then(|| render_projection_banner(projection, &t))
@@ -326,18 +320,18 @@ fn conflict_banner(
         )
         .child(div().flex_1())
         .child(
-            button("conflict-use-ours", "Use Ours", t, false).on_click(cx.listener(
-                |view, _, _, cx| {
+            button("conflict-use-ours", "Use Ours", t, false)
+                .debug_selector(|| "conflict-use-ours".to_owned())
+                .on_click(cx.listener(|view, _, _, cx| {
                     view.resolve_selected_file_with_tool(":ours".to_owned(), cx);
-                },
-            )),
+                })),
         )
         .child(
-            button("conflict-use-theirs", "Use Theirs", t, false).on_click(cx.listener(
-                |view, _, _, cx| {
+            button("conflict-use-theirs", "Use Theirs", t, false)
+                .debug_selector(|| "conflict-use-theirs".to_owned())
+                .on_click(cx.listener(|view, _, _, cx| {
                     view.resolve_selected_file_with_tool(":theirs".to_owned(), cx);
-                },
-            )),
+                })),
         );
 
     if supports_conflict_editor {

--- a/shell/gpui/src/repo/view_model/mod.rs
+++ b/shell/gpui/src/repo/view_model/mod.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use gpui::{Context, SharedString};
 use jayjay_core::dag::DagLayout;
-use jayjay_core::diff::FileDiff;
+use jayjay_core::diff::{ConflictLineKind, FileDiff};
 use jayjay_core::{
     AnnotationLine, BookmarkInfo, ChangeInfo, DEFAULT_REVSET_DEPTH, DiffHunk, DiffProjection,
     DiffStats, GraphEntry, PrInfo, Repo, WorkspaceInfo, build_default_revset,
@@ -98,6 +98,7 @@ pub struct RepoViewModel {
     pub selected: Option<usize>,
     selected_changes: OrderedSelection<usize>,
     pub files: Option<Arc<Vec<DiffHunk>>>,
+    conflicted_paths: HashSet<String>,
     pub selected_file_ix: Option<usize>,
     pub current_diff: Option<Arc<FileDiff>>,
     pub current_projection: Option<DiffProjection>,
@@ -271,6 +272,7 @@ impl RepoViewModel {
             selected,
             selected_changes,
             files: None,
+            conflicted_paths: HashSet::new(),
             selected_file_ix: None,
             current_diff: None,
             current_projection: None,
@@ -322,6 +324,7 @@ impl RepoViewModel {
             selected: None,
             selected_changes: OrderedSelection::default(),
             files: None,
+            conflicted_paths: HashSet::new(),
             selected_file_ix: None,
             current_diff: None,
             current_projection: None,
@@ -408,6 +411,16 @@ impl RepoViewModel {
         self.files
             .as_ref()
             .and_then(|f| self.selected_file_ix.and_then(|ix| f.get(ix)))
+    }
+
+    pub(crate) fn selected_file_has_conflict(&self) -> bool {
+        self.selected_hunk().is_some_and(|hunk| {
+            self.conflicted_paths.contains(&hunk.path) || hunk.is_conflict_only_placeholder()
+        }) || self.current_diff.as_ref().is_some_and(|diff| {
+            diff.lines
+                .iter()
+                .any(|line| line.conflict_kind != ConflictLineKind::None)
+        })
     }
 
     fn clear_diff_cache_state(&mut self) {

--- a/shell/gpui/src/repo/view_model/selection.rs
+++ b/shell/gpui/src/repo/view_model/selection.rs
@@ -61,16 +61,22 @@ impl RepoViewModel {
                 async move {
                     let detail = repo.show_summary(&rev);
                     let stats = repo.diff_stats(&rev).ok();
-                    (detail, stats)
+                    let conflicted_paths = repo
+                        .resolve_list(&rev)
+                        .unwrap_or_default()
+                        .into_iter()
+                        .collect();
+                    (detail, stats, conflicted_paths)
                 }
             },
-            move |vm, (detail, stats), cx| {
+            move |vm, (detail, stats, conflicted_paths), cx| {
                 // Drop stale results from a superseded select_change.
                 if vm.loading.change_gen != generation {
                     return;
                 }
                 vm.loading.files = false;
                 vm.change_stats = stats;
+                vm.conflicted_paths = conflicted_paths;
                 match detail {
                     Ok(detail) => {
                         let files = Arc::new(detail.diff);
@@ -451,6 +457,7 @@ impl RepoViewModel {
         self.loading.diff_gen = self.loading.diff_gen.wrapping_add(1);
         self.selected_file_ix = None;
         self.files = None;
+        self.conflicted_paths.clear();
         self.current_diff = None;
         self.current_projection = None;
         self.current_svg_preview = None;

--- a/shell/gpui/src/repo/window/detail/mod.rs
+++ b/shell/gpui/src/repo/window/detail/mod.rs
@@ -53,10 +53,7 @@ pub(super) fn detail_pane(
     let compare = vm.compare.clone();
     let file_count = vm.files.as_ref().map(|files| files.len());
     let selected_hunk = vm.selected_hunk().cloned();
-    let selected_file_has_conflict = change.has_conflict
-        && selected_hunk
-            .as_ref()
-            .is_some_and(|hunk| hunk.is_conflict_only_placeholder());
+    let selected_file_has_conflict = vm.selected_file_has_conflict();
     let active_projection_preview = selected_hunk.as_ref().is_some_and(|hunk| {
         view.diff.rich_preview.as_ref().is_some_and(|selection| {
             selection.is_active(super::DiffRichPreviewKind::Projection, hunk.path.as_str())

--- a/shell/gpui/src/repo/window/file_editor/actions.rs
+++ b/shell/gpui/src/repo/window/file_editor/actions.rs
@@ -1,5 +1,5 @@
 use gpui::{AppContext as _, Context};
-use jayjay_core::diff::{ConflictLineKind, highlight_file};
+use jayjay_core::diff::highlight_file;
 use jayjay_core::{DiffHunk, HunkType};
 
 use crate::ui::text_area::TextArea;
@@ -40,7 +40,7 @@ impl RepoWindow {
             && vm.compare.is_none()
             && vm.selected_hunk().is_some_and(hunk_supports_file_editor)
             && vm.current_diff_supports_file_editor
-            && !selected_file_has_conflict(vm)
+            && !vm.selected_file_has_conflict()
     }
 
     pub(crate) fn enter_selected_file_editor(&mut self, cx: &mut Context<Self>) {
@@ -187,14 +187,4 @@ fn hunk_supports_file_editor(hunk: &DiffHunk) -> bool {
         && hunk.projection.is_none()
         && hunk.new.preview.is_none()
         && !hunk.is_conflict_only_placeholder()
-}
-
-fn selected_file_has_conflict(vm: &crate::repo::view_model::RepoViewModel) -> bool {
-    vm.selected_hunk()
-        .is_some_and(DiffHunk::is_conflict_only_placeholder)
-        || vm.current_diff.as_ref().is_some_and(|diff| {
-            diff.lines
-                .iter()
-                .any(|line| line.conflict_kind != ConflictLineKind::None)
-        })
 }

--- a/shell/gpui/tests/gpui/repo_conflict_editor.rs
+++ b/shell/gpui/tests/gpui/repo_conflict_editor.rs
@@ -35,6 +35,27 @@ fn conflicted_repo() -> tempfile::TempDir {
     temp_dir
 }
 
+fn rebased_binary_conflict_repo() -> tempfile::TempDir {
+    let temp_dir = init_jj_repo();
+    let path = temp_dir.path().join("repo");
+    let file = path.join("data.bin");
+
+    fs::write(&file, b"base\0bytes").expect("write base binary");
+    run_jj_in(&path, &["describe", "-m", "binary base"]);
+    run_jj_in(&path, &["new", "@"]);
+    fs::write(&file, b"left\0bytes").expect("write left binary");
+    run_jj_in(&path, &["describe", "-m", "left binary"]);
+    run_jj_in(&path, &["bookmark", "create", "left-binary", "-r", "@"]);
+
+    run_jj_in(&path, &["new", "@-"]);
+    fs::write(&file, b"right\0bytes").expect("write right binary");
+    run_jj_in(&path, &["describe", "-m", "right binary"]);
+    run_jj_in(&path, &["rebase", "-s", "left-binary", "-d", "@"]);
+    run_jj_in(&path, &["edit", "left-binary"]);
+
+    temp_dir
+}
+
 #[gpui::test]
 fn conflict_only_file_row_hides_unusable_review_controls(cx: &mut TestAppContext) {
     let fixture = conflicted_repo();
@@ -126,6 +147,31 @@ fn conflict_banner_edits_and_saves_inside_the_repository_window(cx: &mut TestApp
         fs::read_to_string(path.join("greeting.rs")).expect("read resolved file"),
         "combined in JayJay\n"
     );
+}
+
+#[gpui::test]
+fn rebased_non_text_conflict_shows_banner_without_in_app_editor(cx: &mut TestAppContext) {
+    let fixture = rebased_binary_conflict_repo();
+    let path = fixture.path().join("repo");
+    let repo = Repo::open(&path).expect("open binary conflict");
+    let detail = repo.show_summary("@").expect("show binary conflict");
+    let hunk = detail
+        .diff
+        .iter()
+        .find(|hunk| hunk.path == "data.bin")
+        .expect("binary conflict hunk");
+    assert_eq!(
+        repo.resolve_list("@").expect("list conflicts"),
+        ["data.bin"]
+    );
+    assert!(!hunk.is_conflict_only_placeholder());
+    assert!(!hunk.supports_conflict_editor);
+
+    let (_view, cx) = open_repo(path, cx);
+
+    assert!(cx.debug_bounds("conflict-use-ours").is_some());
+    assert!(cx.debug_bounds("conflict-use-theirs").is_some());
+    assert!(cx.debug_bounds("conflict-resolve-jayjay").is_none());
 }
 
 #[gpui::test]


### PR DESCRIPTION
## Summary

- load conflicted paths for the selected revision instead of relying only on rendered conflict markers
- show Use Ours and Use Theirs for submodule and other non-text conflicts
- keep Edit in JayJay limited to supported text conflicts and block the regular file editor for conflicted files

## Testing

- `cargo test -p jayjay-gpui --test gpui repo_conflict_editor::`
- `cargo clippy -p jayjay-gpui --all-targets -- -D warnings`
- `just test-gpui`
- `just lint`