### PR TITLE
fix(dag): correct merge continuations and cap missing ancestry

### DIFF
--- a/crates/jayjay-core/src/dag.rs
+++ b/crates/jayjay-core/src/dag.rs
@@ -22,6 +22,8 @@ pub struct DagLayout {
     pub active_lane_indices_per_row: Vec<Vec<usize>>,
     /// Lane indices that were active both above and below each row.
     pub pass_through_lane_indices_per_row: Vec<Vec<usize>>,
+    /// True when one or more parent edges leave the rendered graph at this row.
+    pub missing_ancestry_rows: Vec<bool>,
     /// True when this row references lanes collapsed into the compact overflow lane.
     pub overflow_rows: Vec<bool>,
 }
@@ -33,9 +35,16 @@ impl DagLayout {
         let mut active_counts: Vec<usize> = Vec::with_capacity(entries.len());
         let mut active_indices: Vec<Vec<usize>> = Vec::with_capacity(entries.len());
         let mut pass_through_indices: Vec<Vec<usize>> = Vec::with_capacity(entries.len());
+        let mut missing_ancestry_rows = Vec::with_capacity(entries.len());
 
         for entry in entries {
             let cid = &entry.change.commit_id.id;
+            missing_ancestry_rows.push(
+                entry
+                    .edges
+                    .iter()
+                    .any(|edge| edge.edge_type == EdgeType::Missing),
+            );
 
             if !lanes.contains_key(cid) {
                 let lane = match active
@@ -86,6 +95,7 @@ impl DagLayout {
             active_lanes_per_row: active_counts,
             active_lane_indices_per_row: active_indices,
             pass_through_lane_indices_per_row: pass_through_indices,
+            missing_ancestry_rows,
             overflow_rows: Vec::new(),
         };
         layout.overflow_rows = compute_overflow_rows(entries, &layout);
@@ -133,6 +143,13 @@ impl DagLayout {
             .get(row)
             .map(Vec::as_slice)
             .unwrap_or(&[])
+    }
+
+    pub fn row_has_missing_ancestry(&self, row: usize) -> bool {
+        self.missing_ancestry_rows
+            .get(row)
+            .copied()
+            .unwrap_or(false)
     }
 
     pub fn row_has_overflow(&self, row: usize) -> bool {
@@ -352,14 +369,18 @@ mod tests {
     }
 
     #[test]
-    fn missing_edges_dont_assign_lanes() {
+    fn missing_edges_share_one_termination_without_assigning_lanes() {
         let mut e = entry("A", &[]);
-        e.edges.push(GraphEdge {
-            target: "missing-parent".to_owned(),
-            edge_type: EdgeType::Missing,
-        });
+        for parent in ["missing-parent", "another-missing-parent"] {
+            e.edges.push(GraphEdge {
+                target: parent.to_owned(),
+                edge_type: EdgeType::Missing,
+            });
+        }
         let layout = DagLayout::compute(&[e]);
         assert!(!layout.lanes.contains_key("missing-parent"));
+        assert!(!layout.lanes.contains_key("another-missing-parent"));
+        assert!(layout.row_has_missing_ancestry(0));
         assert_eq!(layout.lane("A"), 0);
     }
 }

--- a/crates/jayjay-core/src/dag.rs
+++ b/crates/jayjay-core/src/dag.rs
@@ -18,8 +18,10 @@ pub struct DagLayout {
     pub lanes: HashMap<String, usize>,
     /// Total active lanes at each row index.
     pub active_lanes_per_row: Vec<usize>,
-    /// Lane indices that continue through each row.
+    /// Lane indices active below each row.
     pub active_lane_indices_per_row: Vec<Vec<usize>>,
+    /// Lane indices that were active both above and below each row.
+    pub pass_through_lane_indices_per_row: Vec<Vec<usize>>,
     /// True when this row references lanes collapsed into the compact overflow lane.
     pub overflow_rows: Vec<bool>,
 }
@@ -30,6 +32,7 @@ impl DagLayout {
         let mut active: Vec<Option<String>> = Vec::new();
         let mut active_counts: Vec<usize> = Vec::with_capacity(entries.len());
         let mut active_indices: Vec<Vec<usize>> = Vec::with_capacity(entries.len());
+        let mut pass_through_indices: Vec<Vec<usize>> = Vec::with_capacity(entries.len());
 
         for entry in entries {
             let cid = &entry.change.commit_id.id;
@@ -46,6 +49,15 @@ impl DagLayout {
             }
 
             let my_lane = lanes[cid];
+            pass_through_indices.push(
+                active
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(lane, commit)| {
+                        (lane != my_lane && commit.is_some()).then_some(lane)
+                    })
+                    .collect(),
+            );
             if my_lane < active.len() {
                 active[my_lane] = None;
             }
@@ -73,6 +85,7 @@ impl DagLayout {
             lanes,
             active_lanes_per_row: active_counts,
             active_lane_indices_per_row: active_indices,
+            pass_through_lane_indices_per_row: pass_through_indices,
             overflow_rows: Vec::new(),
         };
         layout.overflow_rows = compute_overflow_rows(entries, &layout);
@@ -112,6 +125,13 @@ impl DagLayout {
         self.active_lane_indices_per_row
             .get(row)
             .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    pub fn pass_through_lane_indices(&self, row: usize) -> &[usize] {
+        self.pass_through_lane_indices_per_row
+            .get(row)
+            .map(Vec::as_slice)
             .unwrap_or(&[])
     }
 
@@ -266,6 +286,8 @@ mod tests {
         assert_eq!(layout.lane("B"), 0); // fork's first edge stays on parent's lane
         assert_eq!(layout.lane("C"), 1); // second edge spawns new lane
         assert_eq!(layout.lane("A"), 0); // merged back into B's lane
+        assert!(layout.pass_through_lane_indices(0).is_empty());
+        assert_eq!(layout.pass_through_lane_indices(1), &[1]);
         assert!(layout.max_lanes() >= 2);
         assert_eq!(layout.display_lane_count(), layout.max_lanes());
     }

--- a/crates/jayjay-uniffi/src/dag.rs
+++ b/crates/jayjay-uniffi/src/dag.rs
@@ -4,6 +4,7 @@ pub struct DagLayoutData {
     active_lanes_per_row: Vec<u32>,
     active_lane_indices_per_row: Vec<Vec<u32>>,
     pass_through_lane_indices_per_row: Vec<Vec<u32>>,
+    missing_ancestry_rows: Vec<bool>,
     overflow_rows: Vec<bool>,
     display_lane_count: u32,
 }
@@ -33,6 +34,7 @@ fn compute_dag_layout(entries: Vec<jayjay_core::GraphEntry>) -> DagLayoutData {
             .iter()
             .map(|row| row.iter().map(|&v| v as u32).collect())
             .collect(),
+        missing_ancestry_rows: layout.missing_ancestry_rows,
         overflow_rows: layout.overflow_rows.to_vec(),
         display_lane_count: display_lane_count as u32,
     }

--- a/crates/jayjay-uniffi/src/dag.rs
+++ b/crates/jayjay-uniffi/src/dag.rs
@@ -3,6 +3,7 @@ pub struct DagLayoutData {
     lanes: std::collections::HashMap<String, u32>,
     active_lanes_per_row: Vec<u32>,
     active_lane_indices_per_row: Vec<Vec<u32>>,
+    pass_through_lane_indices_per_row: Vec<Vec<u32>>,
     overflow_rows: Vec<bool>,
     display_lane_count: u32,
 }
@@ -24,6 +25,11 @@ fn compute_dag_layout(entries: Vec<jayjay_core::GraphEntry>) -> DagLayoutData {
             .collect(),
         active_lane_indices_per_row: layout
             .active_lane_indices_per_row
+            .iter()
+            .map(|row| row.iter().map(|&v| v as u32).collect())
+            .collect(),
+        pass_through_lane_indices_per_row: layout
+            .pass_through_lane_indices_per_row
             .iter()
             .map(|row| row.iter().map(|&v| v as u32).collect())
             .collect(),

--- a/shell/gpui/src/repo/window/dag/mod.rs
+++ b/shell/gpui/src/repo/window/dag/mod.rs
@@ -19,6 +19,7 @@ const TRAILING_PAD: f32 = 6.0;
 const NODE_TOP_OFFSET: f32 = 15.0;
 const OVERFLOW_DASH_PATTERN: &[f32] = &[10.0, 4.0, 10.0, 12.0];
 const INDIRECT_EDGE_DASH_PATTERN: &[f32] = &[3.0, 3.0];
+const MISSING_EDGE_DASH_PATTERN: &[f32] = &[2.0, 2.0];
 
 fn lane_column_width(display_lane_count: usize) -> f32 {
     let lanes = display_lane_count.max(1);
@@ -30,8 +31,8 @@ pub(super) struct DagRowLanes {
     pub row_lane: usize,
     pub pass_through_lanes: Vec<usize>,
     pub prev_active_lanes: Vec<usize>,
-    pub next_active_lanes: Vec<usize>,
     pub has_overflow: bool,
+    pub has_missing_ancestry: bool,
 }
 
 pub(super) fn dag_column(
@@ -44,11 +45,12 @@ pub(super) fn dag_column(
         row_lane,
         pass_through_lanes,
         prev_active_lanes,
-        next_active_lanes,
         has_overflow,
+        has_missing_ancestry,
     } = lanes;
-    let total_w = lane_column_width(layout.display_lane_count());
-    let overflow_display_lane = layout.display_lane_count().max(1) - 1;
+    let display_lane_count = layout.display_lane_count();
+    let total_w = lane_column_width(display_lane_count);
+    let overflow_display_lane = display_lane_count.max(1) - 1;
     let style = DagNodeStyle::resolve(&entry.change, theme);
     let line_color = theme.dag_line;
     let edge_color = theme.dag_edge;
@@ -56,14 +58,11 @@ pub(super) fn dag_column(
     let node_top_offset = NODE_TOP_OFFSET + (theme.scaled_font_size(10.) - 10.) / 2.;
 
     // Resolve targets up front — `layout` can't move into the canvas closure.
-    let edge_targets: Vec<(usize, usize, EdgeType)> = entry
+    let edge_targets: Vec<(usize, EdgeType)> = entry
         .edges
         .iter()
         .filter(|e| !matches!(e.edge_type, EdgeType::Missing))
-        .map(|e| {
-            let target_lane = layout.lane(&e.target);
-            (target_lane, layout.display_lane(target_lane), e.edge_type)
-        })
+        .map(|e| (layout.display_lane(layout.lane(&e.target)), e.edge_type))
         .collect();
 
     let mut pass_through_display_lanes: Vec<usize> = pass_through_lanes
@@ -75,10 +74,6 @@ pub(super) fn dag_column(
     pass_through_display_lanes.dedup();
 
     let has_above = prev_active_lanes.contains(&row_lane);
-    let has_same_lane_parent = edge_targets
-        .iter()
-        .any(|&(target_lane, _, _)| target_lane == row_lane);
-    let has_below = has_same_lane_parent || next_active_lanes.contains(&row_lane);
 
     let overflow_pattern = LinePattern::Dashed(OVERFLOW_DASH_PATTERN);
     let line_pattern = move |display_lane| {
@@ -133,7 +128,7 @@ pub(super) fn dag_column(
 
                 // 3. Edges to parents — straight for same lane, quadratic curve otherwise.
                 let start_y = node_y + radius_px;
-                for &(_, target_display_lane, edge_type) in &edge_targets {
+                for &(target_display_lane, edge_type) in &edge_targets {
                     let target_x = display_lane_center_x(target_display_lane);
                     let edge_pattern = if edge_type == EdgeType::Indirect {
                         LinePattern::Dashed(INDIRECT_EDGE_DASH_PATTERN)
@@ -168,16 +163,34 @@ pub(super) fn dag_column(
                     }
                 }
 
-                // 3b. Bottom stub for non-tail nodes on a forking lane.
-                if !has_same_lane_parent && has_below {
+                if has_missing_ancestry {
+                    let has_visible_parent = !edge_targets.is_empty();
+                    let terminal_x = my_x
+                        + px(if has_visible_parent {
+                            LANE_WIDTH * 0.35
+                        } else {
+                            0.0
+                        });
+                    // End the side cap before the parent curves fan out at 40% of the remaining height.
+                    let terminal_y = start_y
+                        + (row_bottom - start_y) * if has_visible_parent { 0.25 } else { 0.55 };
                     stroke_line_pattern(
                         window,
                         my_x,
                         start_y,
-                        my_x,
-                        row_bottom,
-                        line_color,
-                        line_pattern(row_display_lane),
+                        terminal_x,
+                        terminal_y,
+                        edge_color,
+                        LinePattern::Dashed(MISSING_EDGE_DASH_PATTERN),
+                    );
+                    stroke_line_pattern(
+                        window,
+                        terminal_x - px(2.0),
+                        terminal_y,
+                        terminal_x + px(2.0),
+                        terminal_y,
+                        edge_color,
+                        LinePattern::Solid,
                     );
                 }
 

--- a/shell/gpui/src/repo/window/dag/mod.rs
+++ b/shell/gpui/src/repo/window/dag/mod.rs
@@ -28,7 +28,7 @@ fn lane_column_width(display_lane_count: usize) -> f32 {
 /// Lane geometry for a single DAG row — used to decide what lines to draw.
 pub(super) struct DagRowLanes {
     pub row_lane: usize,
-    pub active_lanes: Vec<usize>,
+    pub pass_through_lanes: Vec<usize>,
     pub prev_active_lanes: Vec<usize>,
     pub next_active_lanes: Vec<usize>,
     pub has_overflow: bool,
@@ -42,7 +42,7 @@ pub(super) fn dag_column(
 ) -> AnyElement {
     let DagRowLanes {
         row_lane,
-        active_lanes,
+        pass_through_lanes,
         prev_active_lanes,
         next_active_lanes,
         has_overflow,
@@ -66,13 +66,13 @@ pub(super) fn dag_column(
         })
         .collect();
 
-    let mut active_other: Vec<usize> = active_lanes
+    let mut pass_through_display_lanes: Vec<usize> = pass_through_lanes
         .into_iter()
         .map(|lane| layout.display_lane(lane))
         .filter(|&lane| lane != row_display_lane)
         .collect();
-    active_other.sort();
-    active_other.dedup();
+    pass_through_display_lanes.sort();
+    pass_through_display_lanes.dedup();
 
     let has_above = prev_active_lanes.contains(&row_lane);
     let has_same_lane_parent = edge_targets
@@ -105,8 +105,8 @@ pub(super) fn dag_column(
             let row_bottom = oy + h;
 
             window.with_content_mask(Some(ContentMask { bounds }), |window| {
-                // 1. Non-current active lane continuations: full top → bottom.
-                for &display_lane in &active_other {
+                // 1. Lanes that pass through this row: full top → bottom.
+                for &display_lane in &pass_through_display_lanes {
                     stroke_line_pattern(
                         window,
                         display_lane_center_x(display_lane),

--- a/shell/gpui/src/repo/window/sidebar.rs
+++ b/shell/gpui/src/repo/window/sidebar.rs
@@ -126,7 +126,7 @@ pub(super) fn sidebar(
                                 });
                             });
                         let row_lane = dag_layout.lane(&change.commit_id);
-                        let active_lanes = dag_layout.active_lane_indices(ix).to_vec();
+                        let pass_through_lanes = dag_layout.pass_through_lane_indices(ix).to_vec();
                         let prev_active_lanes = if ix > 0 {
                             dag_layout.active_lane_indices(ix - 1).to_vec()
                         } else {
@@ -143,7 +143,7 @@ pub(super) fn sidebar(
                                 entry,
                                 DagRowLanes {
                                     row_lane,
-                                    active_lanes,
+                                    pass_through_lanes,
                                     prev_active_lanes,
                                     next_active_lanes,
                                     has_overflow,

--- a/shell/gpui/src/repo/window/sidebar.rs
+++ b/shell/gpui/src/repo/window/sidebar.rs
@@ -132,12 +132,8 @@ pub(super) fn sidebar(
                         } else {
                             Vec::new()
                         };
-                        let next_active_lanes = if ix + 1 < change_count {
-                            dag_layout.active_lane_indices(ix + 1).to_vec()
-                        } else {
-                            Vec::new()
-                        };
                         let has_overflow = dag_layout.row_has_overflow(ix);
+                        let has_missing_ancestry = dag_layout.row_has_missing_ancestry(ix);
                         let dag_col = entries.get(ix).map(|entry| {
                             dag_column(
                                 entry,
@@ -145,8 +141,8 @@ pub(super) fn sidebar(
                                     row_lane,
                                     pass_through_lanes,
                                     prev_active_lanes,
-                                    next_active_lanes,
                                     has_overflow,
+                                    has_missing_ancestry,
                                 },
                                 &dag_layout,
                                 &t,

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGLayout.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGLayout.swift
@@ -9,6 +9,7 @@ let dagNodeCenterY: CGFloat = 12
 let dagCompactVisibleLanes = 4
 let dagOverflowStroke = StrokeStyle(lineWidth: 1, dash: [10, 4, 10, 12])
 let dagIndirectEdgeStroke = StrokeStyle(lineWidth: 1, dash: [3, 3])
+let dagMissingEdgeStroke = StrokeStyle(lineWidth: 1, lineCap: .round, dash: [2, 2])
 let dagSolidStroke = StrokeStyle(lineWidth: 1)
 
 /// Thin Swift wrapper over `jayjay_core::dag::DagLayout` (via uniffi).
@@ -17,6 +18,7 @@ struct DAGLayout {
     private let maxLaneCount: Int
     private let activeLaneIndicesPerRow: [[UInt32]]
     private let passThroughLaneIndicesPerRow: [[UInt32]]
+    private let missingAncestryRows: [Bool]
     private let overflowRows: [Bool]
     private let displayLaneCountValue: UInt32
 
@@ -26,6 +28,7 @@ struct DAGLayout {
         maxLaneCount = Int(data.activeLanesPerRow.max() ?? 1)
         activeLaneIndicesPerRow = data.activeLaneIndicesPerRow
         passThroughLaneIndicesPerRow = data.passThroughLaneIndicesPerRow
+        missingAncestryRows = data.missingAncestryRows
         overflowRows = data.overflowRows
         displayLaneCountValue = data.displayLaneCount
     }
@@ -59,6 +62,11 @@ struct DAGLayout {
     func passThroughLaneIndices(at row: Int) -> [Int] {
         guard passThroughLaneIndicesPerRow.indices.contains(row) else { return [] }
         return passThroughLaneIndicesPerRow[row].map(Int.init)
+    }
+
+    func hasMissingAncestry(at row: Int) -> Bool {
+        guard missingAncestryRows.indices.contains(row) else { return false }
+        return missingAncestryRows[row]
     }
 
     func hasLaneOverflow(at row: Int) -> Bool {

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGLayout.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGLayout.swift
@@ -16,6 +16,7 @@ struct DAGLayout {
     private let lanes: [String: UInt32]
     private let maxLaneCount: Int
     private let activeLaneIndicesPerRow: [[UInt32]]
+    private let passThroughLaneIndicesPerRow: [[UInt32]]
     private let overflowRows: [Bool]
     private let displayLaneCountValue: UInt32
 
@@ -24,6 +25,7 @@ struct DAGLayout {
         lanes = data.lanes
         maxLaneCount = Int(data.activeLanesPerRow.max() ?? 1)
         activeLaneIndicesPerRow = data.activeLaneIndicesPerRow
+        passThroughLaneIndicesPerRow = data.passThroughLaneIndicesPerRow
         overflowRows = data.overflowRows
         displayLaneCountValue = data.displayLaneCount
     }
@@ -52,6 +54,11 @@ struct DAGLayout {
     func activeLaneIndices(at row: Int) -> [Int] {
         guard activeLaneIndicesPerRow.indices.contains(row) else { return [] }
         return activeLaneIndicesPerRow[row].map(Int.init)
+    }
+
+    func passThroughLaneIndices(at row: Int) -> [Int] {
+        guard passThroughLaneIndicesPerRow.indices.contains(row) else { return [] }
+        return passThroughLaneIndicesPerRow[row].map(Int.init)
     }
 
     func hasLaneOverflow(at row: Int) -> Bool {

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGRow+GraphColumn.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGRow+GraphColumn.swift
@@ -9,8 +9,10 @@ extension DAGRow {
             let myX = viewModel.layout.xPosition(forDisplayLane: myDisplayLane)
             let hasOverflow = viewModel.layout.hasLaneOverflow(at: viewModel.index)
             let overflowDisplayLane = viewModel.layout.displayLaneCount() - 1
-            let activeDisplayLanes = Set(
-                viewModel.layout.activeLaneIndices(at: viewModel.index).map { viewModel.layout.displayLane(for: $0) }
+            let passThroughDisplayLanes = Set(
+                viewModel.layout.passThroughLaneIndices(at: viewModel.index).map {
+                    viewModel.layout.displayLane(for: $0)
+                }
             ).sorted()
             let nodeY = dagNodeCenterY
             let height = geo.size.height
@@ -24,7 +26,7 @@ extension DAGRow {
                         : dagSolidStroke
                 }
 
-                for displayLane in activeDisplayLanes where displayLane != myDisplayLane {
+                for displayLane in passThroughDisplayLanes where displayLane != myDisplayLane {
                     let laneX = viewModel.layout.xPosition(forDisplayLane: displayLane)
                     let path = Path { p in
                         p.move(to: CGPoint(x: laneX, y: 0))
@@ -61,7 +63,9 @@ extension DAGRow {
                 }
 
                 for edge in viewModel.entry.edges {
-                    if edge.edgeType == .missing { continue }
+                    if edge.edgeType == .missing {
+                        continue
+                    }
                     let targetLane = viewModel.layout.lane(for: edge.target)
                     let targetDisplayLane = viewModel.layout.displayLane(for: targetLane)
                     let targetX = viewModel.layout.xPosition(forDisplayLane: targetDisplayLane)

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGRow+GraphColumn.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGRow+GraphColumn.swift
@@ -14,6 +14,7 @@ extension DAGRow {
                     viewModel.layout.displayLane(for: $0)
                 }
             ).sorted()
+            let hasVisibleParent = viewModel.entry.edges.contains { $0.edgeType != .missing }
             let nodeY = dagNodeCenterY
             let height = geo.size.height
 
@@ -42,21 +43,6 @@ extension DAGRow {
                         let path = Path { p in
                             p.move(to: CGPoint(x: myX, y: 0))
                             p.addLine(to: CGPoint(x: myX, y: nodeY - nodeRadius))
-                        }
-                        ctx.stroke(path, with: .color(lineColor), style: laneStroke(myDisplayLane))
-                    }
-                }
-
-                // Bottom stub for non-tail nodes on a forking lane.
-                let hasSameLaneParent = viewModel.entry.edges.contains { edge in
-                    edge.edgeType != .missing && viewModel.layout.lane(for: edge.target) == myLane
-                }
-                if !hasSameLaneParent {
-                    let nextActive = viewModel.layout.activeLaneIndices(at: viewModel.index + 1)
-                    if nextActive.contains(myLane) {
-                        let path = Path { p in
-                            p.move(to: CGPoint(x: myX, y: nodeY + nodeRadius))
-                            p.addLine(to: CGPoint(x: myX, y: height))
                         }
                         ctx.stroke(path, with: .color(lineColor), style: laneStroke(myDisplayLane))
                     }
@@ -91,6 +77,23 @@ extension DAGRow {
                         dagSolidStroke
                     }
                     ctx.stroke(path, with: .color(edgeColor), style: style)
+                }
+
+                if viewModel.layout.hasMissingAncestry(at: viewModel.index) {
+                    let terminalX = myX + (hasVisibleParent ? laneWidth * 0.35 : 0)
+                    let startY = nodeY + nodeRadius
+                    // End the side cap before the parent curves fan out at 40% of the remaining height.
+                    let endY = startY + (height - startY) * (hasVisibleParent ? 0.25 : 0.55)
+                    let stem = Path { path in
+                        path.move(to: CGPoint(x: myX, y: startY))
+                        path.addLine(to: CGPoint(x: terminalX, y: endY))
+                    }
+                    let cap = Path { path in
+                        path.move(to: CGPoint(x: terminalX - 2, y: endY))
+                        path.addLine(to: CGPoint(x: terminalX + 2, y: endY))
+                    }
+                    ctx.stroke(stem, with: .color(edgeColor), style: dagMissingEdgeStroke)
+                    ctx.stroke(cap, with: .color(edgeColor), style: dagSolidStroke)
                 }
 
                 let style = DAGNodeStyle.resolve(change: change)

--- a/shell/mac/Tests/JayJayTests/DAGRowGraphTests.swift
+++ b/shell/mac/Tests/JayJayTests/DAGRowGraphTests.swift
@@ -1,0 +1,67 @@
+import AppKit
+@testable import JayJay
+import JayJayCore
+import SwiftUI
+import XCTest
+
+@MainActor
+final class DAGRowGraphTests: XCTestCase {
+    func testMissingAncestryStopsBeforeAReusedLane() throws {
+        let entries = [
+            entry("A", edges: [GraphEdge(target: "hidden", edgeType: .missing)]),
+            entry("B", edges: [GraphEdge(target: "C", edgeType: .direct)]),
+            entry("C")
+        ]
+        let image = try renderGraph(entries, row: 0)
+
+        XCTAssertTrue(alphaValues(image).contains { $0 > 0 })
+        XCTAssertTrue(alphaValues(image, fromY: 60).allSatisfy { $0 == 0 })
+    }
+
+    func testMixedAncestryCapEndsBeforeParentCurvesFanOut() throws {
+        let parent = GraphEdge(target: "P", edgeType: .direct)
+        var entries = [entry("H", edges: [parent]), entry("A", edges: [parent]), entry("P")]
+        let withoutCap = try renderGraph(entries, row: 1)
+        entries[1] = entry("A", edges: [parent, GraphEdge(target: "hidden", edgeType: .missing)])
+        let withCap = try renderGraph(entries, row: 1)
+
+        XCTAssertNotEqual(alphaValues(withCap), alphaValues(withoutCap))
+        XCTAssertTrue(alphaValues(withCap, fromY: 41) == alphaValues(withoutCap, fromY: 41))
+    }
+
+    private func entry(_ id: String, edges: [GraphEdge] = []) -> GraphEntry {
+        GraphEntry(
+            change: mockChangeInfo(changeId: id, commitId: id, parents: edges.map(\.target)),
+            edges: edges
+        )
+    }
+
+    private func renderGraph(_ entries: [GraphEntry], row: Int) throws -> NSBitmapImageRep {
+        let layout = DAGLayout(entries: entries)
+        let viewModel = DAGRowViewModel(
+            entry: entries[row],
+            layout: layout,
+            index: row,
+            selectedId: nil,
+            compareFromId: nil,
+            contextTargetId: nil,
+            rebaseDrag: nil,
+            rebasePreviewText: nil,
+            bookmarkDrag: nil,
+            bookmarkPreviewText: nil,
+            colorScheme: .light
+        )
+        let renderer = ImageRenderer(content: DAGRow(viewModel: viewModel).graphColumn
+            .frame(width: layout.graphWidth, height: 76)
+            .environment(\.colorScheme, .light))
+        return try NSBitmapImageRep(cgImage: XCTUnwrap(renderer.cgImage))
+    }
+
+    private func alphaValues(_ image: NSBitmapImageRep, fromY: Int = 0) -> [CGFloat] {
+        (fromY ..< image.pixelsHigh).flatMap { y in
+            (0 ..< image.pixelsWide).map { x in
+                image.colorAt(x: x, y: y)!.alphaComponent
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #193 with two focused changes:

1. Track pass-through lanes separately from lanes introduced by a merge row, so new parent lanes start at the node instead of sticking up above it.
2. Draw one short dashed stem with a flat cap for missing ancestry, and remove bottom stubs inferred from later lane reuse. When visible and missing parents coexist, the cap ends before the parent curves fan out.

Both SwiftUI and GPUI consume the shared Rust layout metadata. Existing lane assignment, compact overflow lanes, default revsets, and the caching improvements from #222 are preserved. No Sapling dependency or pagination changes.

## Validation

- `cargo test -p jayjay-core -p jayjay-uniffi -p jayjay-gpui`: 948 tests passed on macOS. The optional live Cursor Origin fixture was absent; no live Origin coverage is claimed.
- `just test-app`: 257 app tests and 99 JayJayDiffUI package tests passed, including the canvas regressions and 12k-row DAG performance checks.
- `just ffi`, `jj fix`, and `just lint` passed on the rebased stack.
- No live XCUITest scene was run for this publication. Linux and Windows execution is left to CI.
