### PR TITLE
feat(gpui): render Markdown images in the rich preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4172,6 +4172,7 @@ dependencies = [
 name = "jayjay-gpui"
 version = "0.3.17"
 dependencies = [
+ "base64 0.22.1",
  "chrono",
  "clap",
  "directories",
@@ -4180,6 +4181,7 @@ dependencies = [
  "gpui",
  "gpui_platform",
  "hex",
+ "image",
  "jayjay-core",
  "jayjay-markdown",
  "jayjay-network",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ jj-lib = { version = "0.45.1", default-features = false }
 gix = { version = "0.87.1", default-features = false }
 gix-url = "0.38.0"
 percent-encoding = "2.3.2"
+base64 = "0.22"
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "bmp"] }
 ureq = "3"
 uniffi = { version = "0.32", default-features = false }
 clap = { version = "4", features = ["derive"] }

--- a/crates/jayjay-core/src/file_display.rs
+++ b/crates/jayjay-core/src/file_display.rs
@@ -2,7 +2,7 @@ const IMAGE_EXTENSIONS: &[&str] = &[
     "png", "jpg", "jpeg", "gif", "webp", "heic", "bmp", "tiff", "tif", "ico", "icns",
 ];
 
-pub(crate) const MAX_IMAGE_BYTES: usize = 16 * 1024 * 1024;
+pub const MAX_IMAGE_BYTES: usize = 16 * 1024 * 1024;
 pub(crate) const MAX_DIFF_BYTES: usize = 32 * 1024 * 1024;
 
 pub(crate) fn is_image_path(path: &str) -> bool {

--- a/crates/jayjay-core/src/lib.rs
+++ b/crates/jayjay-core/src/lib.rs
@@ -35,6 +35,8 @@ mod types;
 
 #[cfg(feature = "repository")]
 pub use cli::run_app_cli_command;
+#[cfg(feature = "repository")]
+pub use file_display::MAX_IMAGE_BYTES;
 pub use fonts::{
     MONO_FONT_FALLBACK_NAMES, MONO_FONT_OPTIONS, MonoFontOption, SYSTEM_MONO_FONT_ID,
     mono_font_option,
@@ -61,6 +63,7 @@ pub use repo::{
 pub use theme::{DiffThemeColors, ThemeSeed, change_id_prefix_color, diff_theme_colors};
 #[cfg(feature = "repository")]
 pub use tools::{
-    EDITOR_OPTIONS, TERMINAL_OPTIONS, ToolsConfig, open_in_editor, open_in_terminal, repo_file_url,
+    EDITOR_OPTIONS, TERMINAL_OPTIONS, ToolsConfig, open_in_editor, open_in_terminal,
+    repo_file_path, repo_file_url,
 };
 pub use types::*;

--- a/crates/jayjay-core/src/tools/file_url.rs
+++ b/crates/jayjay-core/src/tools/file_url.rs
@@ -4,20 +4,18 @@ use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 
 /// Return a `file://` URL for an existing non-directory file inside `repo_path`.
 pub fn repo_file_url(repo_path: &str, file_path: &str) -> Option<String> {
-    existing_repo_file_path(repo_path, file_path)
+    repo_file_path(repo_path, file_path)
         .as_deref()
         .map(file_url_from_path)
 }
 
-fn existing_repo_file_path(repo_path: &str, file_path: &str) -> Option<PathBuf> {
+/// Canonical path of an existing file inside `repo_path`; parent components are fine when the canonical result stays inside the root.
+pub fn repo_file_path(repo_path: &str, file_path: &str) -> Option<PathBuf> {
     let relative = Path::new(file_path);
     if relative.is_absolute()
-        || relative.components().any(|component| {
-            matches!(
-                component,
-                Component::ParentDir | Component::RootDir | Component::Prefix(_)
-            )
-        })
+        || relative
+            .components()
+            .any(|component| matches!(component, Component::RootDir | Component::Prefix(_)))
     {
         return None;
     }
@@ -90,9 +88,24 @@ mod tests {
             ),
             None
         );
+        let escaping = format!(
+            "../{}",
+            outside.path().file_name().unwrap().to_str().unwrap()
+        );
+        assert_eq!(repo_file_url(tmp.path().to_str().unwrap(), &escaping), None);
+    }
+
+    #[test]
+    fn repo_file_path_keeps_contained_parent_components() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file = tmp.path().join("assets").join("logo.png");
+        std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+        std::fs::create_dir(tmp.path().join("docs")).unwrap();
+        std::fs::write(&file, b"png").unwrap();
+
         assert_eq!(
-            repo_file_url(tmp.path().to_str().unwrap(), "../outside.html"),
-            None
+            repo_file_path(tmp.path().to_str().unwrap(), "docs/../assets/logo.png"),
+            Some(tmp.path().canonicalize().unwrap().join("assets/logo.png"))
         );
     }
 }

--- a/crates/jayjay-core/src/tools/mod.rs
+++ b/crates/jayjay-core/src/tools/mod.rs
@@ -8,6 +8,6 @@ mod platform;
 mod terminal;
 
 pub use config::ToolsConfig;
-pub use file_url::repo_file_url;
+pub use file_url::{repo_file_path, repo_file_url};
 pub use launcher::{detach_stdio, open_in_editor, open_in_terminal};
 pub use platform::{EDITOR_OPTIONS, TERMINAL_OPTIONS};

--- a/crates/jayjay-markdown/src/blocks/parser.rs
+++ b/crates/jayjay-markdown/src/blocks/parser.rs
@@ -1,7 +1,9 @@
 use pulldown_cmark::{Event, Parser};
 
-use super::model::{MarkdownBlock, MarkdownListItem, MarkdownTableRow, block_text};
-use crate::images::raw_html_image;
+use super::model::{
+    MarkdownBlock, MarkdownImageAlign, MarkdownListItem, MarkdownTableRow, block_text,
+};
+use crate::images::{raw_html_image, sanitized_image_source};
 use crate::markdown_options;
 
 pub fn parse_markdown_blocks(markdown: &str) -> Vec<MarkdownBlock> {
@@ -23,7 +25,14 @@ pub(super) struct BlockParser {
     pub(super) table: Option<TableBuilder>,
     pub(super) row: Option<TableRowBuilder>,
     pub(super) cell: Option<String>,
-    pub(super) image_destinations: Vec<String>,
+    pub(super) image: Option<ImageBuilder>,
+    pending_images: Vec<ImageBuilder>,
+}
+
+pub(super) struct ImageBuilder {
+    pub(super) source: String,
+    pub(super) title: Option<String>,
+    pub(super) alt: String,
 }
 
 pub(super) struct TextBuilder {
@@ -84,6 +93,7 @@ impl BlockParser {
             }
             Event::Html(html) | Event::InlineHtml(html) => {
                 if let Some(image) = raw_html_image(html.as_ref()) {
+                    self.flush_pending_images();
                     self.push_block(MarkdownBlock::Image {
                         source: image.source,
                         alt: image.alt,
@@ -124,7 +134,9 @@ impl BlockParser {
     }
 
     pub(super) fn append_text(&mut self, text: &str) {
-        if let Some(cell) = self.cell.as_mut() {
+        if let Some(image) = self.image.as_mut() {
+            image.alt.push_str(text);
+        } else if let Some(cell) = self.cell.as_mut() {
             cell.push_str(text);
         } else if let Some(code) = self.code.as_mut() {
             code.text.push_str(text);
@@ -138,13 +150,61 @@ impl BlockParser {
                     TextKind::Paragraph
                 });
             }
+            if !text.trim().is_empty() {
+                self.demote_pending_images();
+            }
             if let Some(current) = self.text.as_mut() {
                 current.text.push_str(text);
             }
         }
     }
 
+    pub(super) fn finish_image(&mut self, image: ImageBuilder) {
+        let standalone = self.text.as_ref().is_some_and(|text| {
+            matches!(text.kind, TextKind::Paragraph) && text.text.trim().is_empty()
+        });
+        match (standalone, sanitized_image_source(&image.source)) {
+            (true, Some(source)) => self.pending_images.push(ImageBuilder {
+                source,
+                title: image.title,
+                alt: image.alt.trim().to_owned(),
+            }),
+            _ => {
+                self.demote_pending_images();
+                self.append_image_text(&image.alt, &image.source);
+            }
+        }
+    }
+
+    fn append_image_text(&mut self, alt: &str, source: &str) {
+        self.append_text("Image: ");
+        self.append_text(alt);
+        if !source.is_empty() {
+            self.append_text(" (");
+            self.append_text(source);
+            self.append_text(")");
+        }
+    }
+
+    fn demote_pending_images(&mut self) {
+        for image in std::mem::take(&mut self.pending_images) {
+            self.append_image_text(&image.alt, &image.source);
+        }
+    }
+
+    fn flush_pending_images(&mut self) {
+        for image in std::mem::take(&mut self.pending_images) {
+            self.push_block(MarkdownBlock::Image {
+                source: image.source,
+                alt: image.alt,
+                title: image.title,
+                align: MarkdownImageAlign::None,
+            });
+        }
+    }
+
     pub(super) fn flush_text(&mut self) {
+        self.flush_pending_images();
         let Some(text) = self.text.take() else {
             return;
         };

--- a/crates/jayjay-markdown/src/blocks/parser_tags.rs
+++ b/crates/jayjay-markdown/src/blocks/parser_tags.rs
@@ -2,7 +2,7 @@ use pulldown_cmark::{CodeBlockKind, HeadingLevel, Tag, TagEnd};
 
 use super::model::{MarkdownBlock, MarkdownListItem};
 use super::parser::{
-    BlockParser, CodeBuilder, ListBuilder, TableBuilder, TableRowBuilder, TextKind,
+    BlockParser, CodeBuilder, ImageBuilder, ListBuilder, TableBuilder, TableRowBuilder, TextKind,
 };
 
 impl BlockParser {
@@ -48,9 +48,14 @@ impl BlockParser {
                 }
                 self.cell = Some(String::new());
             }
-            Tag::Image { dest_url, .. } => {
-                self.image_destinations.push(dest_url.to_string());
-                self.append_text("Image: ");
+            Tag::Image {
+                dest_url, title, ..
+            } => {
+                self.image = Some(ImageBuilder {
+                    source: dest_url.to_string(),
+                    title: (!title.is_empty()).then(|| title.to_string()),
+                    alt: String::new(),
+                });
             }
             Tag::HtmlBlock
             | Tag::FootnoteDefinition(_)
@@ -119,12 +124,8 @@ impl BlockParser {
                 }
             }
             TagEnd::Image => {
-                if let Some(destination) = self.image_destinations.pop()
-                    && !destination.is_empty()
-                {
-                    self.append_text(" (");
-                    self.append_text(&destination);
-                    self.append_text(")");
+                if let Some(image) = self.image.take() {
+                    self.finish_image(image);
                 }
             }
             TagEnd::FootnoteDefinition

--- a/crates/jayjay-markdown/src/images.rs
+++ b/crates/jayjay-markdown/src/images.rs
@@ -74,6 +74,32 @@ pub(crate) fn raw_html_image(input: &str) -> Option<RawHtmlImage<'_>> {
     })
 }
 
+/// A sanitized image source; a relative path is document-relative and the consumer still contains it to the checkout.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MarkdownImageSource<'a> {
+    Data { subtype: &'a str, base64: &'a str },
+    Relative(String),
+}
+
+impl<'a> MarkdownImageSource<'a> {
+    pub fn parse(source: &'a str) -> Self {
+        if let Some((subtype, base64)) = data_image_parts(source) {
+            return Self::Data { subtype, base64 };
+        }
+        let path = source.split(['?', '#']).next().unwrap_or(source);
+        Self::Relative(percent_decode_path(path))
+    }
+}
+
+fn data_image_parts(source: &str) -> Option<(&str, &str)> {
+    sanitized_data_image_source(source)?;
+    let rest = &source["data:image/".len()..];
+    let lower = rest.to_ascii_lowercase();
+    let subtype_end = lower.find([';', ','])?;
+    let payload = lower.find(";base64,")? + ";base64,".len();
+    Some((&rest[..subtype_end], &rest[payload..]))
+}
+
 pub(crate) fn sanitized_image_source(source: &str) -> Option<String> {
     let unescaped = unescape_html_attribute(source);
     let trimmed = unescaped.trim();
@@ -97,11 +123,8 @@ pub(crate) fn sanitized_image_source(source: &str) -> Option<String> {
         return None;
     }
 
-    let decoded = percent_decode_path(trimmed);
-    let has_parent_component = decoded
-        .split(['/', '\\'])
-        .any(|component| component == "..");
-    (!has_parent_component).then(|| trimmed.to_owned())
+    // `..` stays: containment is checked where the path is resolved against the checkout.
+    Some(trimmed.to_owned())
 }
 
 fn strip_ascii_tab_and_newline(value: &str) -> String {

--- a/crates/jayjay-markdown/src/lib.rs
+++ b/crates/jayjay-markdown/src/lib.rs
@@ -8,6 +8,7 @@ use pulldown_cmark::{Options, Parser};
 pub use blocks::{
     MarkdownBlock, MarkdownDocument, MarkdownImageAlign, MarkdownListItem, MarkdownTableRow,
 };
+pub use images::MarkdownImageSource;
 
 const DOCUMENT_PREFIX: &str = r#"<!DOCTYPE html>
 <html>

--- a/crates/jayjay-markdown/src/tests.rs
+++ b/crates/jayjay-markdown/src/tests.rs
@@ -1,5 +1,7 @@
 use crate::blocks::parse_markdown_blocks;
-use crate::{MarkdownBlock, MarkdownImageAlign, render_markdown_html};
+use crate::{
+    MarkdownBlock, MarkdownDocument, MarkdownImageAlign, MarkdownImageSource, render_markdown_html,
+};
 
 #[test]
 fn renders_common_blocks() {
@@ -90,8 +92,8 @@ fn rejects_unsafe_image_sources() {
 
     assert!(!html.contains("<img src=\"javascript:alert(1)\""));
     assert!(!html.contains("<img src=\"file:///etc/passwd\""));
-    assert!(!html.contains("<img src=\"../secret.png\""));
-    assert!(!html.contains("<img src=\"..%2fsecret.png\""));
+    assert!(html.contains("<img src=\"../secret.png\""));
+    assert!(html.contains("<img src=\"..%2fsecret.png\""));
     assert!(!html.contains("<img src=\"data:image/svg+xml"));
     assert!(html.contains("&lt;img src=&quot;file:///etc/passwd&quot; alt=&quot;secret&quot;&gt;"));
 }
@@ -215,13 +217,97 @@ fn main() {}
             } if language == "rust" && text.contains("fn main")
         )
     }));
-    assert!(blocks.contains(&MarkdownBlock::Paragraph(
-        "Image: Diagram (images/flow.png)".to_owned()
-    )));
+    assert!(blocks.contains(&MarkdownBlock::Image {
+        source: "images/flow.png".to_owned(),
+        alt: "Diagram".to_owned(),
+        title: None,
+        align: MarkdownImageAlign::None,
+    }));
     assert!(blocks.contains(&MarkdownBlock::Image {
         source: "images/raw-flow.png".to_owned(),
         alt: "Raw".to_owned(),
         title: None,
         align: MarkdownImageAlign::Center,
     }));
+}
+
+#[test]
+fn only_image_only_paragraphs_become_image_blocks() {
+    let blocks = MarkdownDocument::parse(
+        "![One](a.png) ![Two](b%20c.png \"Pair\")\n\nSee ![inline](c.png) here.\n\n![First](e.png) then text\n\n> ![Quoted](q.png)\n\n![Bad](https://example.com/x.png)\n\n- ![Item](d.png)\n\n![Md](m.png)<img src=\"h.png\" alt=\"Html\">\n",
+    );
+    let blocks = blocks.blocks();
+    assert_eq!(
+        blocks[0],
+        MarkdownBlock::Image {
+            source: "a.png".to_owned(),
+            alt: "One".to_owned(),
+            title: None,
+            align: MarkdownImageAlign::None,
+        }
+    );
+    assert_eq!(
+        blocks[1],
+        MarkdownBlock::Image {
+            source: "b%20c.png".to_owned(),
+            alt: "Two".to_owned(),
+            title: Some("Pair".to_owned()),
+            align: MarkdownImageAlign::None,
+        }
+    );
+    assert_eq!(
+        blocks[2],
+        MarkdownBlock::Paragraph("See Image: inline (c.png) here.".to_owned())
+    );
+    assert_eq!(
+        blocks[3],
+        MarkdownBlock::Paragraph("Image: First (e.png) then text".to_owned())
+    );
+    assert_eq!(
+        blocks[4],
+        MarkdownBlock::BlockQuote("Image: Quoted (q.png)".to_owned())
+    );
+    assert_eq!(
+        blocks[5],
+        MarkdownBlock::Paragraph("Image: Bad (https://example.com/x.png)".to_owned())
+    );
+    assert!(matches!(
+        &blocks[6],
+        MarkdownBlock::List { items, .. } if items[0].text == "Image: Item (d.png)"
+    ));
+    assert_eq!(
+        blocks[7..]
+            .iter()
+            .map(|block| match block {
+                MarkdownBlock::Image { source, .. } => source.as_str(),
+                _ => "?",
+            })
+            .collect::<Vec<_>>(),
+        ["m.png", "h.png"]
+    );
+}
+
+#[test]
+fn image_sources_split_into_data_payloads_and_decoded_relative_paths() {
+    for source in ["data:image/png;base64,AAAA", "data:image/PNG;BASE64,AAAA"] {
+        assert!(matches!(
+            MarkdownImageSource::parse(source),
+            MarkdownImageSource::Data { subtype, base64: "AAAA" } if subtype.eq_ignore_ascii_case("png")
+        ));
+    }
+    for (source, decoded) in [
+        ("docs/a%20b.png", "docs/a b.png"),
+        ("../assets/logo.png", "../assets/logo.png"),
+        ("images/a.png?raw=1", "images/a.png"),
+        ("images/a.png#frag", "images/a.png"),
+        ("a%3Fb.png", "a?b.png"),
+        ("%41.png", "A.png"),
+        ("a%4", "a%4"),
+        ("a%zz.png", "a%zz.png"),
+    ] {
+        assert_eq!(
+            MarkdownImageSource::parse(source),
+            MarkdownImageSource::Relative(decoded.to_owned())
+        );
+    }
 }

--- a/shell/gpui/Cargo.toml
+++ b/shell/gpui/Cargo.toml
@@ -25,6 +25,8 @@ sha2 = { workspace = true }
 uuid = { workspace = true }
 sysinfo = { workspace = true }
 percent-encoding = { workspace = true }
+base64 = { workspace = true }
+image = { workspace = true }
 font-kit = "0.14"
 md5 = { package = "md-5", version = "0.11" }
 hex = "0.4"

--- a/shell/gpui/src/diff/bounds.rs
+++ b/shell/gpui/src/diff/bounds.rs
@@ -5,13 +5,13 @@ use gpui::{IntoElement, Styled, canvas};
 
 use crate::repo::window::PanelBoundsSlot;
 
-/// Absolute overlay canvas — captures parent bounds during prepaint.
+/// Absolute overlay canvas — captures parent bounds during prepaint; a size change schedules the next frame because `refresh` is a no-op mid-draw.
 pub(crate) fn bounds_capture(slot: PanelBoundsSlot) -> impl IntoElement {
     canvas(
         move |bounds, window, _cx| {
             if slot.get() != Some(bounds) {
                 slot.set(Some(bounds));
-                window.refresh();
+                window.request_animation_frame();
             }
         },
         |_, _, _, _| {},

--- a/shell/gpui/src/diff/diff_view/render.rs
+++ b/shell/gpui/src/diff/diff_view/render.rs
@@ -15,7 +15,7 @@ use super::sbs_note_banner::with_sbs_note_banner;
 use super::state::{DetailMode, DiffViewMode, DiffViewState, FindState};
 use super::unified_body::{UnifiedBodyState, unified_body};
 use crate::app::theme::{Theme, theme, ui_font_size, with_alpha};
-use crate::diff::markdown_diff::{MarkdownDiffState, markdown_diff_view};
+use crate::diff::markdown_diff::{MarkdownDiffState, MarkdownImages, markdown_diff_view};
 use crate::diff::media_diff::diff_body_with_gutter;
 use crate::diff::projection;
 use crate::diff::svg_diff::{SvgDiffContent, svg_diff_view};
@@ -119,6 +119,11 @@ pub fn diff_view(
         markdown_diff_view(
             MarkdownDiffState {
                 document: state.markdown_preview,
+                images: MarkdownImages {
+                    repo_path: state.repo_path,
+                    document_path: &hunk.path,
+                    cache: &state.markdown_images,
+                },
                 scroll: state.markdown_scroll.clone(),
                 bounds: state.markdown_bounds.clone(),
                 render_kind: projection_render_kind,

--- a/shell/gpui/src/diff/diff_view/state.rs
+++ b/shell/gpui/src/diff/diff_view/state.rs
@@ -7,6 +7,7 @@ use jayjay_markdown::MarkdownDocument;
 use jayjay_review::{ReviewGroupState, ReviewNoteStatus};
 
 use super::review_row_map::ReviewRowMap;
+use crate::diff::MarkdownImageCacheSlot;
 use crate::repo::window::{DiffWrapCacheSlot, PanelBoundsSlot};
 use crate::ui::input::LineInput;
 
@@ -62,9 +63,11 @@ pub struct DiffViewState<'a> {
     pub(crate) active_projection_preview: bool,
     pub(crate) active_markdown_preview: bool,
     pub(crate) active_svg_preview: bool,
-    pub(crate) markdown_preview: Option<&'a MarkdownDocument>,
+    pub(crate) markdown_preview: Option<&'a Arc<MarkdownDocument>>,
+    pub(crate) markdown_images: MarkdownImageCacheSlot,
     pub(crate) markdown_scroll: ScrollHandle,
     pub(crate) markdown_bounds: PanelBoundsSlot,
+    pub(crate) repo_path: &'a str,
     pub(crate) svg_preview: Option<SvgPreviewContent<'a>>,
     pub(crate) html_external_url: Option<&'a str>,
     pub(crate) view_mode: DiffViewMode,

--- a/shell/gpui/src/diff/markdown_diff.rs
+++ b/shell/gpui/src/diff/markdown_diff.rs
@@ -1,10 +1,13 @@
 mod blocks;
+mod images;
 mod table;
 
 use gpui::{
     AnyElement, Context, Div, InteractiveElement, IntoElement, ParentElement, ScrollHandle,
     SharedString, StatefulInteractiveElement, Styled, Window, div, px, rgb,
 };
+use std::sync::Arc;
+
 use jayjay_core::DiffRenderKind;
 use jayjay_markdown::MarkdownDocument;
 
@@ -15,9 +18,11 @@ use crate::repo::window::{PanelBoundsSlot, RepoWindow};
 use crate::ui::scrollbar::vertical_scrollbar;
 
 use blocks::{MarkdownDocumentStyle, markdown_document};
+pub(crate) use images::{MarkdownImageCache, MarkdownImageCacheSlot, MarkdownImages};
 
 pub(crate) struct MarkdownDiffState<'a> {
-    pub(crate) document: Option<&'a MarkdownDocument>,
+    pub(crate) document: Option<&'a Arc<MarkdownDocument>>,
+    pub(crate) images: MarkdownImages<'a>,
     pub(crate) scroll: ScrollHandle,
     pub(crate) bounds: PanelBoundsSlot,
     pub(crate) render_kind: Option<DiffRenderKind>,
@@ -30,20 +35,12 @@ pub(crate) fn markdown_diff_view(
     state: MarkdownDiffState<'_>,
     cx: &Context<RepoWindow>,
 ) -> AnyElement {
-    let MarkdownDiffState {
-        document,
-        scroll,
-        bounds,
-        render_kind,
-        shows_review,
-        theme: t,
-        window,
-    } = state;
-    let style = match render_kind {
+    let t = state.theme;
+    let style = match state.render_kind {
         Some(DiffRenderKind::Table) => MarkdownDocumentStyle::TableProjection,
         _ => MarkdownDocumentStyle::Markdown,
     };
-    let viewer = markdown_viewer(document, scroll, bounds, style, t, window, cx);
+    let viewer = markdown_viewer(&state, style, cx);
     let mut pane = div()
         .flex()
         .flex_col()
@@ -53,29 +50,22 @@ pub(crate) fn markdown_diff_view(
         .gap(px(8.))
         .child(viewer);
     if !style.is_table_projection() {
-        pane = pane.child(metadata_line(document, t));
+        pane = pane.child(metadata_line(state.document.map(Arc::as_ref), t));
     }
     rich_preview_with_gutter(
         single_pane_layout(pane.into_any_element(), t),
         t,
-        shows_review,
+        state.shows_review,
     )
 }
 
 fn markdown_viewer(
-    document: Option<&MarkdownDocument>,
-    scroll: ScrollHandle,
-    bounds: PanelBoundsSlot,
+    state: &MarkdownDiffState<'_>,
     style: MarkdownDocumentStyle,
-    t: &Theme,
-    window: &Window,
     cx: &Context<RepoWindow>,
 ) -> AnyElement {
-    let chrome = match style {
-        MarkdownDocumentStyle::Markdown => markdown_frame(t),
-        MarkdownDocumentStyle::TableProjection => table_projection_frame(t),
-    }
-    .relative();
+    let t = state.theme;
+    let chrome = preview_frame(t).relative();
 
     let scroller = div()
         .id(SharedString::from("markdown-preview"))
@@ -87,12 +77,19 @@ fn markdown_viewer(
         .justify_start()
         .overflow_y_scroll()
         .scrollbar_width(px(0.))
-        .track_scroll(&scroll);
-    let available_width = bounds.get().map(|bounds| bounds.size.width);
-    let scroller = match document {
-        Some(document) if !document.source().trim().is_empty() => scroller.child(
-            markdown_document(document, style, available_width, t, window),
-        ),
+        .track_scroll(&state.scroll);
+    let available_width = state.bounds.get().map(|bounds| bounds.size.width);
+    let scroller = match state.document {
+        Some(document) if !document.source().trim().is_empty() => {
+            scroller.child(markdown_document(
+                document,
+                style,
+                available_width,
+                &state.images,
+                t,
+                state.window,
+            ))
+        }
         _ => scroller
             .items_center()
             .justify_center()
@@ -102,31 +99,18 @@ fn markdown_viewer(
 
     chrome
         .child(scroller)
-        .child(bounds_capture(bounds))
-        .child(vertical_scrollbar(scroll, t, cx))
+        .child(bounds_capture(state.bounds.clone()))
+        .child(vertical_scrollbar(state.scroll.clone(), t, cx))
         .into_any_element()
 }
 
-fn table_projection_frame(t: &Theme) -> Div {
+fn preview_frame(t: &Theme) -> Div {
     div()
         .flex()
         .flex_1()
         .w_full()
         .min_w_0()
         .min_h_0()
-        .bg(rgb(t.detail_bg))
-}
-
-fn markdown_frame(t: &Theme) -> Div {
-    div()
-        .flex()
-        .flex_1()
-        .w_full()
-        .min_w_0()
-        .min_h_0()
-        .rounded_md()
-        .border_1()
-        .border_color(rgb(t.border))
         .bg(rgb(t.detail_bg))
 }
 

--- a/shell/gpui/src/diff/markdown_diff/blocks.rs
+++ b/shell/gpui/src/diff/markdown_diff/blocks.rs
@@ -1,13 +1,18 @@
 use gpui::{
-    AnyElement, FontWeight, InteractiveElement, IntoElement, ParentElement, Pixels, SharedString,
-    Styled, Window, div, px, rgb,
+    AnyElement, FontWeight, InteractiveElement, IntoElement, ObjectFit, ParentElement, Pixels,
+    SharedString, Styled, StyledImage, Window, div, img, px, rgb,
 };
+use std::sync::Arc;
+
 use jayjay_markdown::{MarkdownBlock, MarkdownDocument, MarkdownImageAlign, MarkdownListItem};
 
 use crate::app::fonts;
 use crate::app::theme::{Theme, ui_font_size};
 
+use super::images::{MarkdownImages, ResolvedImage};
 use super::table::table_block;
+
+const DOCUMENT_PADDING_X: f32 = 18.;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum MarkdownDocumentStyle {
@@ -22,9 +27,10 @@ impl MarkdownDocumentStyle {
 }
 
 pub(super) fn markdown_document(
-    document: &MarkdownDocument,
+    document: &Arc<MarkdownDocument>,
     style: MarkdownDocumentStyle,
     available_width: Option<Pixels>,
+    images: &MarkdownImages<'_>,
     t: &Theme,
     window: &Window,
 ) -> AnyElement {
@@ -39,9 +45,10 @@ pub(super) fn markdown_document(
     if style.is_table_projection() {
         col = col.px(px(22.)).py(px(18.));
     } else {
-        col = col.gap(px(10.)).px(px(18.)).py(px(16.));
+        col = col.gap(px(10.)).px(px(DOCUMENT_PADDING_X)).py(px(16.));
     }
 
+    images.sync(document);
     if document.blocks().is_empty() {
         col = col.child(
             div()
@@ -52,7 +59,14 @@ pub(super) fn markdown_document(
     }
 
     for block in document.blocks() {
-        col = col.child(block_element(block, style, available_width, t, window));
+        col = col.child(block_element(
+            block,
+            style,
+            available_width,
+            images,
+            t,
+            window,
+        ));
     }
     col.into_any_element()
 }
@@ -61,6 +75,7 @@ fn block_element(
     block: &MarkdownBlock,
     style: MarkdownDocumentStyle,
     available_width: Option<Pixels>,
+    images: &MarkdownImages<'_>,
     t: &Theme,
     window: &Window,
 ) -> AnyElement {
@@ -70,7 +85,14 @@ fn block_element(
         MarkdownBlock::CodeBlock { language, text } => code_block(language.as_deref(), text, t),
         MarkdownBlock::Image {
             source, alt, align, ..
-        } => image_block(source, alt, *align, t),
+        } => image_block(
+            source,
+            alt,
+            *align,
+            images.resolve(source),
+            available_width,
+            t,
+        ),
         MarkdownBlock::BlockQuote(text) => quote_block(text, t),
         MarkdownBlock::List { start, items } => list_block(*start, items, t),
         MarkdownBlock::Table { rows } => table_block(rows, style, available_width, t, window),
@@ -82,43 +104,87 @@ fn block_element(
     }
 }
 
-fn image_block(source: &str, alt: &str, align: MarkdownImageAlign, t: &Theme) -> AnyElement {
-    let label = if alt.is_empty() { "Image" } else { alt };
+fn image_block(
+    source: &str,
+    alt: &str,
+    align: MarkdownImageAlign,
+    resolved: Option<ResolvedImage>,
+    available_width: Option<Pixels>,
+    t: &Theme,
+) -> AnyElement {
     let mut wrapper = div().flex().w_full();
     if align == MarkdownImageAlign::Center {
         wrapper = wrapper.justify_center();
     }
-    wrapper
+    let label = source_label(source);
+    let Some(image) = resolved else {
+        return wrapper
+            .child(
+                image_placeholder(label, alt, t)
+                    .debug_selector(|| format!("markdown-image-placeholder:{source}")),
+            )
+            .into_any_element();
+    };
+    let fallback = {
+        let (label, alt, t) = (label.to_owned(), alt.to_owned(), t.clone());
+        move || image_placeholder(&label, &alt, &t).into_any_element()
+    };
+    let max_width = available_width
+        .map(|width| width - px(2. * DOCUMENT_PADDING_X))
+        .filter(|width| *width > px(0.));
+    let mut element = img(image.source)
+        .debug_selector(|| format!("markdown-image:{source}"))
+        .object_fit(ObjectFit::ScaleDown)
+        .with_fallback(fallback);
+    element = match (image.size, max_width) {
+        (Some(natural), Some(max_width)) if natural.width > max_width => element.w(max_width).h(
+            px(f32::from(natural.height) * f32::from(max_width) / f32::from(natural.width)),
+        ),
+        (Some(natural), _) => element.w(natural.width).h(natural.height),
+        (None, Some(max_width)) => element.max_w(max_width),
+        (None, None) => element,
+    };
+    wrapper.child(element).into_any_element()
+}
+
+/// A data URI can run to megabytes; the placeholder shows only its media type.
+fn source_label(source: &str) -> &str {
+    source
+        .starts_with("data:")
+        .then(|| source.split_once(',').map(|(head, _)| head))
+        .flatten()
+        .unwrap_or(source)
+}
+
+fn image_placeholder(source: &str, alt: &str, t: &Theme) -> gpui::Div {
+    let label = if alt.is_empty() { "Image" } else { alt };
+    div()
+        .flex()
+        .flex_col()
+        .gap(px(4.))
+        .max_w(px(420.))
+        .rounded_sm()
+        .border_1()
+        .border_color(rgb(t.border))
+        .bg(rgb(t.header_bg))
+        .px(px(10.))
+        .py(px(8.))
         .child(
             div()
-                .flex()
-                .flex_col()
-                .gap(px(4.))
-                .max_w(px(420.))
-                .rounded_sm()
-                .border_1()
-                .border_color(rgb(t.border))
-                .bg(rgb(t.header_bg))
-                .px(px(10.))
-                .py(px(8.))
-                .child(
-                    div()
-                        .text_size(ui_font_size(12.))
-                        .line_height(ui_font_size(18.))
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .text_color(rgb(t.fg))
-                        .child(SharedString::from(label.to_owned())),
-                )
-                .child(
-                    div()
-                        .font_family(fonts::mono())
-                        .text_size(ui_font_size(10.))
-                        .line_height(ui_font_size(14.))
-                        .text_color(rgb(t.fg_dim))
-                        .child(SharedString::from(source.to_owned())),
-                ),
+                .text_size(ui_font_size(12.))
+                .line_height(ui_font_size(18.))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(rgb(t.fg))
+                .child(SharedString::from(label.to_owned())),
         )
-        .into_any_element()
+        .child(
+            div()
+                .font_family(fonts::mono())
+                .text_size(ui_font_size(10.))
+                .line_height(ui_font_size(14.))
+                .text_color(rgb(t.fg_dim))
+                .child(SharedString::from(source.to_owned())),
+        )
 }
 
 fn heading_block(level: u8, text: &str, t: &Theme) -> AnyElement {

--- a/shell/gpui/src/diff/markdown_diff/images.rs
+++ b/shell/gpui/src/diff/markdown_diff/images.rs
@@ -1,0 +1,118 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::rc::Rc;
+use std::sync::{Arc, Weak};
+
+use base64::Engine as _;
+use gpui::{Image, ImageFormat, ImageSource, Pixels, Size, px, size};
+use jayjay_markdown::{MarkdownDocument, MarkdownImageSource};
+
+pub(crate) type MarkdownImageCacheSlot = Rc<RefCell<MarkdownImageCache>>;
+
+/// Holding a `Weak` keeps the document's allocation alive, so a reloaded document can never reuse the address the entries were keyed on.
+#[derive(Default)]
+pub(crate) struct MarkdownImageCache {
+    document: Weak<MarkdownDocument>,
+    entries: HashMap<String, Option<ResolvedImage>>,
+}
+
+impl MarkdownImageCache {
+    pub(crate) fn clear(&mut self) {
+        self.document = Weak::new();
+        self.entries.clear();
+    }
+}
+
+#[derive(Clone)]
+pub(super) struct ResolvedImage {
+    pub(super) source: ImageSource,
+    /// `None` for SVG, which gpui sizes from the file itself.
+    pub(super) size: Option<Size<Pixels>>,
+}
+
+pub(crate) struct MarkdownImages<'a> {
+    pub(crate) repo_path: &'a str,
+    pub(crate) document_path: &'a str,
+    pub(crate) cache: &'a MarkdownImageCacheSlot,
+}
+
+impl MarkdownImages<'_> {
+    pub(super) fn sync(&self, document: &Arc<MarkdownDocument>) {
+        let mut cache = self.cache.borrow_mut();
+        if !std::ptr::eq(cache.document.as_ptr(), Arc::as_ptr(document)) {
+            cache.clear();
+            cache.document = Arc::downgrade(document);
+        }
+    }
+
+    pub(super) fn resolve(&self, source: &str) -> Option<ResolvedImage> {
+        let mut cache = self.cache.borrow_mut();
+        if let Some(resolved) = cache.entries.get(source) {
+            return resolved.clone();
+        }
+        let resolved = resolve_image(self.repo_path, self.document_path, source);
+        cache.entries.insert(source.to_owned(), resolved.clone());
+        resolved
+    }
+}
+
+// Same resolution as the SwiftUI preview: relative to the document's directory, contained to the checkout.
+fn resolve_image(repo_path: &str, document_path: &str, source: &str) -> Option<ResolvedImage> {
+    match MarkdownImageSource::parse(source) {
+        MarkdownImageSource::Data { subtype, base64 } => {
+            if base64.len() > jayjay_core::MAX_IMAGE_BYTES / 3 * 4 {
+                return None;
+            }
+            let format = match subtype.to_ascii_lowercase().as_str() {
+                "png" => ImageFormat::Png,
+                "jpeg" | "jpg" => ImageFormat::Jpeg,
+                "gif" => ImageFormat::Gif,
+                "webp" => ImageFormat::Webp,
+                "bmp" => ImageFormat::Bmp,
+                _ => return None,
+            };
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(base64)
+                .ok()?;
+            let size = image_size(Cursor::new(&bytes))?;
+            Some(ResolvedImage {
+                source: ImageSource::Image(Arc::new(Image::from_bytes(format, bytes))),
+                size: Some(size),
+            })
+        }
+        MarkdownImageSource::Relative(relative) => {
+            let file_path = match document_path.rsplit_once('/') {
+                Some((directory, _)) => format!("{directory}/{relative}"),
+                None => relative,
+            };
+            let path = jayjay_core::repo_file_path(repo_path, &file_path)?;
+            if std::fs::metadata(&path).ok()?.len() > jayjay_core::MAX_IMAGE_BYTES as u64 {
+                return None;
+            }
+            let size = if path
+                .extension()
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("svg"))
+            {
+                None
+            } else {
+                Some(image_size(std::io::BufReader::new(
+                    std::fs::File::open(&path).ok()?,
+                ))?)
+            };
+            Some(ResolvedImage {
+                source: ImageSource::from(path),
+                size,
+            })
+        }
+    }
+}
+
+fn image_size(reader: impl std::io::BufRead + std::io::Seek) -> Option<Size<Pixels>> {
+    let (width, height) = image::ImageReader::new(reader)
+        .with_guessed_format()
+        .ok()?
+        .into_dimensions()
+        .ok()?;
+    (width > 0 && height > 0).then(|| size(px(width as f32), px(height as f32)))
+}

--- a/shell/gpui/src/diff/mod.rs
+++ b/shell/gpui/src/diff/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod file_status;
 mod image_diff;
 pub(crate) mod line;
 mod markdown_diff;
+pub(crate) use markdown_diff::{MarkdownImageCache, MarkdownImageCacheSlot};
 mod media_diff;
 pub(crate) mod projection;
 mod selection;

--- a/shell/gpui/src/repo/window/actions.rs
+++ b/shell/gpui/src/repo/window/actions.rs
@@ -319,6 +319,7 @@ impl RepoWindow {
             .diff
             .scroll_to_item_strict(0, ScrollStrategy::Top);
         self.diff.markdown_scroll.set_offset(point(px(0.), px(0.)));
+        self.diff.markdown_images.borrow_mut().clear();
     }
 
     pub fn edit_selected_description(&mut self, cx: &mut Context<Self>) {

--- a/shell/gpui/src/repo/window/detail/mod.rs
+++ b/shell/gpui/src/repo/window/detail/mod.rs
@@ -50,6 +50,7 @@ pub(super) fn detail_pane(
     let current_projection = vm.current_projection.clone();
     let current_svg_preview = vm.current_svg_preview.clone();
     let current_markdown_preview = vm.current_markdown_preview.clone();
+    let repo_path = vm.repo_path.clone();
     let compare = vm.compare.clone();
     let file_count = vm.files.as_ref().map(|files| files.len());
     let selected_hunk = vm.selected_hunk().cloned();
@@ -87,9 +88,11 @@ pub(super) fn detail_pane(
         active_projection_preview,
         active_markdown_preview,
         active_svg_preview,
-        markdown_preview: current_markdown_preview.as_deref(),
+        markdown_preview: current_markdown_preview.as_ref(),
+        markdown_images: view.diff.markdown_images.clone(),
         markdown_scroll: view.diff.markdown_scroll.clone(),
         markdown_bounds: view.diff.markdown_bounds.clone(),
+        repo_path: &repo_path,
         svg_preview: current_svg_preview
             .as_ref()
             .map(|preview| SvgPreviewContent {

--- a/shell/gpui/src/repo/window/view.rs
+++ b/shell/gpui/src/repo/window/view.rs
@@ -10,7 +10,10 @@ use gpui::{
 use jayjay_review::NoteEntry;
 
 use crate::app::fs_watcher::{FsEvent, IsRelevantWcChange, RepoFsWatcher};
-use crate::diff::{DiffSelection, DiffWrapCache, FileTreeCache, GutterLineSelection};
+use crate::diff::{
+    DiffSelection, DiffWrapCache, FileTreeCache, GutterLineSelection, MarkdownImageCache,
+    MarkdownImageCacheSlot,
+};
 use crate::repo::view_model::RepoViewModel;
 #[cfg(not(target_os = "macos"))]
 use crate::ui::app_menu::AppMenuState;
@@ -116,6 +119,7 @@ pub(crate) struct DiffPanelState {
     pub(crate) markdown_scroll: ScrollHandle,
     /// Markdown preview pane's rendered width, used to size table columns by content.
     pub(crate) markdown_bounds: PanelBoundsSlot,
+    pub(crate) markdown_images: MarkdownImageCacheSlot,
     pub(crate) wrap_cache: DiffWrapCacheSlot,
     pub(crate) context_expansion: ContextExpansionState,
     /// `sync_review_notes`'s change-detection key: reviewable-files fingerprint + last raw note list, so a store write or a diff refresh (identity change) both trigger re-reconciliation.
@@ -133,6 +137,7 @@ impl Default for DiffPanelState {
             sbs_new_bounds: Rc::new(Cell::new(None)),
             markdown_scroll: ScrollHandle::new(),
             markdown_bounds: Rc::new(Cell::new(None)),
+            markdown_images: Rc::new(RefCell::new(MarkdownImageCache::default())),
             wrap_cache: Rc::new(RefCell::new(DiffWrapCache::default())),
             context_expansion: ContextExpansionState::default(),
             review_notes_sync_key: None,

--- a/shell/gpui/tests/gpui/main.rs
+++ b/shell/gpui/tests/gpui/main.rs
@@ -24,6 +24,7 @@ mod repo_file_multi_select;
 mod repo_file_split;
 mod repo_layout;
 mod repo_lifecycle;
+mod repo_markdown_images;
 mod repo_markdown_preview_scroll;
 mod repo_mutations;
 mod repo_navigation;

--- a/shell/gpui/tests/gpui/repo_markdown_images.rs
+++ b/shell/gpui/tests/gpui/repo_markdown_images.rs
@@ -1,0 +1,99 @@
+use std::fs;
+
+use crate::harness::{
+    install_test_globals, load_selected_change_files, select_file, selector, settle_visual,
+};
+use gpui::{TestAppContext, px, size};
+use jayjay_gpui::repo::RepoWindow;
+use jj_test::{LinearFixture, run_jj_in};
+
+const INLINE_PNG: &str = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+#[gpui::test]
+fn markdown_preview_renders_repo_and_inline_images_and_keeps_placeholders_for_missing_ones(
+    cx: &mut TestAppContext,
+) {
+    let fixture = LinearFixture::build();
+    let images = fixture.path.join("docs").join("images");
+    fs::create_dir_all(&images).expect("create image dir");
+    image::RgbaImage::new(2000, 500)
+        .save(images.join("flow.png"))
+        .expect("write png fixture");
+    fs::write(
+        images.join("logo.svg"),
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"120\" height=\"40\"><rect width=\"120\" height=\"40\"/></svg>",
+    )
+    .expect("write svg fixture");
+    fs::write(
+        fixture.path.join("docs").join("guide.md"),
+        format!(
+            "# Guide\n\n![Flow](images/flow.png)\n\n![Up](../docs/images/flow.png)\n\n![Escape](../../flow.png)\n\n![Raw](images/flow.png?raw=1)\n\n![Logo](images/logo.svg)\n\n![Missing](images/missing.png)\n\n<img src=\"{INLINE_PNG}\" alt=\"Inline\">\n"
+        ),
+    )
+    .expect("write markdown fixture");
+    run_jj_in(&fixture.path, &["st"]);
+
+    install_test_globals(cx);
+    let (view, cx) = cx.add_window_view(|_, cx| RepoWindow::new(fixture.path.clone(), cx));
+    cx.simulate_resize(size(px(1200.), px(800.)));
+    load_selected_change_files(&view, cx);
+    settle_visual(cx);
+    select_file(&view, "docs/guide.md", cx);
+    view.update_in(cx, |view, _, cx| view.toggle_markdown_rich_preview(cx));
+    settle_visual(cx);
+    cx.update(|window, cx| {
+        window.simulate_next_frame(cx);
+    });
+    settle_visual(cx);
+
+    let pane = cx
+        .debug_bounds("markdown-preview-pane")
+        .expect("preview pane");
+    let flow = cx
+        .debug_bounds("markdown-image:images/flow.png")
+        .expect("image inside the checkout renders");
+    assert!(
+        flow.size.width > px(0.) && flow.size.width < pane.size.width,
+        "a 2000px image is scaled down to the pane: {flow:?} in {pane:?}"
+    );
+    assert!(
+        (f32::from(flow.size.height) * 4. - f32::from(flow.size.width)).abs() < 1.,
+        "scaling keeps the 4:1 aspect ratio: {flow:?}"
+    );
+    assert!(
+        cx.debug_bounds(selector(format!("markdown-image:{INLINE_PNG}")))
+            .is_some(),
+        "inline data image renders"
+    );
+    assert!(
+        cx.debug_bounds("markdown-image:images/flow.png?raw=1")
+            .is_some(),
+        "query suffixes do not hide a repo image"
+    );
+    assert!(
+        cx.debug_bounds("markdown-image:../docs/images/flow.png")
+            .is_some(),
+        "parent-relative paths that stay in the checkout render"
+    );
+    assert!(
+        cx.debug_bounds("markdown-image-placeholder:../../flow.png")
+            .is_some(),
+        "paths escaping the checkout keep the placeholder"
+    );
+    let logo = cx
+        .debug_bounds("markdown-image:images/logo.svg")
+        .expect("svg image renders");
+    assert!(
+        logo.size.height > px(0.) && logo.size.width < pane.size.width,
+        "svg sized from its own dimensions: {logo:?}"
+    );
+    assert!(
+        cx.debug_bounds("markdown-image-placeholder:images/missing.png")
+            .is_some(),
+        "missing file keeps the labelled placeholder"
+    );
+    assert!(
+        cx.debug_bounds("markdown-image:images/missing.png")
+            .is_none()
+    );
+}

--- a/shell/mac/Packages/JayJayDiffUI/Tests/JayJayDiffUITests/MarkdownDiffViewTests.swift
+++ b/shell/mac/Packages/JayJayDiffUI/Tests/JayJayDiffUITests/MarkdownDiffViewTests.swift
@@ -96,13 +96,11 @@ final class MarkdownDiffViewTests: XCTestCase {
         let html = renderMarkdownHtml(markdown: """
         ![bad](javascript:alert(1))
         <img src="file:///etc/passwd" alt="secret">
-        <img src="../secret.png" alt="secret">
         <img src="data:image/svg+xml;base64,PHN2Zz4=" alt="svg">
         """)
 
         XCTAssertFalse(html.contains("<img src=\"javascript:alert(1)\""))
         XCTAssertFalse(html.contains("<img src=\"file:///etc/passwd\""))
-        XCTAssertFalse(html.contains("<img src=\"../secret.png\""))
         XCTAssertFalse(html.contains("<img src=\"data:image/svg+xml"))
         XCTAssertTrue(html.contains("&lt;img src=&quot;file:///etc/passwd&quot; alt=&quot;secret&quot;&gt;"))
     }


### PR DESCRIPTION
The GPUI Markdown preview showed every image as a labelled placeholder, and standard ![alt](src) syntax never even reached the image block: the block parser folded it into paragraph text, so only raw <img> tags produced image blocks.

Standalone image paragraphs now become image blocks, matching what the HTML renderer already emits for SwiftUI. Sources resolve the way the SwiftUI scheme handler does: relative to the document's directory inside the checkout, contained to the repo through the core file-path helper, and data: URIs decoded inline. Resolved sources and their natural size are cached per document so the preview re-renders cheaply; images wider than the pane scale down with their aspect ratio, and unresolvable or undecodable sources keep the placeholder.

The pane-bounds capture used window.refresh, which is a no-op during a draw, so the first preview frame never re-laid out to the measured width. It now schedules the next frame.

The preview also drops its own rounded border, which nested a second frame inside the detail pane; the image and SVG previews never had one.

Part of #165.