### PR TITLE
fix(markdown): center multi-line raw images, close the table head row, and cover renderer gaps

### DIFF
--- a/crates/jayjay-markdown/src/blocks/parser.rs
+++ b/crates/jayjay-markdown/src/blocks/parser.rs
@@ -3,7 +3,7 @@ use pulldown_cmark::{Event, Parser};
 use super::model::{
     MarkdownBlock, MarkdownImageAlign, MarkdownListItem, MarkdownTableRow, block_text,
 };
-use crate::images::{raw_html_image, sanitized_image_source};
+use crate::images::{RawHtml, RawImageParagraphs, keeps_raw_image_wrapper, sanitized_image_source};
 use crate::markdown_options;
 
 pub fn parse_markdown_blocks(markdown: &str) -> Vec<MarkdownBlock> {
@@ -27,6 +27,7 @@ pub(super) struct BlockParser {
     pub(super) cell: Option<String>,
     pub(super) image: Option<ImageBuilder>,
     pending_images: Vec<ImageBuilder>,
+    raw_images: RawImageParagraphs,
 }
 
 pub(super) struct ImageBuilder {
@@ -70,6 +71,11 @@ pub(super) struct TableRowBuilder {
 
 impl BlockParser {
     fn handle(&mut self, event: Event<'_>) {
+        if !keeps_raw_image_wrapper(&event)
+            && let Some(opening) = self.raw_images.take_unmatched()
+        {
+            self.append_text(&opening);
+        }
         match event {
             Event::Start(tag) => self.start(tag),
             Event::End(tag) => self.end(tag),
@@ -91,19 +97,22 @@ impl BlockParser {
                     text: math.to_string(),
                 });
             }
-            Event::Html(html) | Event::InlineHtml(html) => {
-                if let Some(image) = raw_html_image(html.as_ref()) {
-                    self.flush_pending_images();
+            Event::Html(html) | Event::InlineHtml(html) => match self.raw_images.classify(&html) {
+                RawHtml::Image { image, align, rest } => {
+                    self.flush_text();
                     self.push_block(MarkdownBlock::Image {
                         source: image.source,
                         alt: image.alt,
                         title: image.title,
-                        align: image.align,
+                        align,
                     });
-                } else {
-                    self.append_text(html.as_ref());
+                    if let Some(rest) = rest {
+                        self.append_text(rest);
+                    }
                 }
-            }
+                RawHtml::Skip => {}
+                RawHtml::Text(text) => self.append_text(&text),
+            },
             Event::FootnoteReference(label) => {
                 self.append_text("[^");
                 self.append_text(label.as_ref());

--- a/crates/jayjay-markdown/src/html.rs
+++ b/crates/jayjay-markdown/src/html.rs
@@ -3,10 +3,9 @@ mod tags;
 use pulldown_cmark::{Event, HeadingLevel, Tag, TagEnd};
 
 use self::tags::heading_tag;
-use crate::MarkdownImageAlign;
 use crate::images::{
-    image_html, image_html_with_align, raw_html_image, raw_html_image_markup,
-    raw_html_image_paragraph_end, raw_html_image_paragraph_start, sanitized_image_source,
+    RawHtml, RawImageParagraphs, image_html, image_html_with_align, keeps_raw_image_wrapper,
+    sanitized_image_source,
 };
 use crate::text::{escape_html, render_text_with_bare_autolinks};
 
@@ -26,9 +25,7 @@ struct HtmlRenderer<'a> {
     link_stack: Vec<bool>,
     pending_item_starts: usize,
     table_head_depth: usize,
-    table_depth: usize,
-    pending_raw_image_paragraph_align: Option<MarkdownImageAlign>,
-    skip_raw_image_paragraph_end: bool,
+    raw_images: RawImageParagraphs,
 }
 
 impl<'a> HtmlRenderer<'a> {
@@ -41,9 +38,7 @@ impl<'a> HtmlRenderer<'a> {
             link_stack: Vec::new(),
             pending_item_starts: 0,
             table_head_depth: 0,
-            table_depth: 0,
-            pending_raw_image_paragraph_align: None,
-            skip_raw_image_paragraph_end: false,
+            raw_images: RawImageParagraphs::default(),
         }
     }
 
@@ -57,6 +52,11 @@ impl<'a> HtmlRenderer<'a> {
 
     fn render_current_event(&mut self) {
         let event = self.events[self.index].clone();
+        if !keeps_raw_image_wrapper(&event)
+            && let Some(opening) = self.raw_images.take_unmatched()
+        {
+            self.output.push_str(&escape_html(&opening));
+        }
         match event {
             Event::Start(Tag::Heading { level, .. }) => {
                 self.flush_pending_items();
@@ -144,50 +144,20 @@ impl<'a> HtmlRenderer<'a> {
     }
 
     fn render_raw_html(&mut self, html: &str) {
-        if self.skip_raw_image_paragraph_end && raw_html_image_paragraph_end(html) {
-            self.skip_raw_image_paragraph_end = false;
-            return;
-        }
-
-        if let Some((image, rest)) = raw_html_image_markup(html) {
-            self.output.push_str(&image);
-            self.render_raw_html_rest(rest);
-            return;
-        }
-
-        if let Some(align) = raw_html_image_paragraph_start(html) {
-            self.pending_raw_image_paragraph_align = Some(align);
-            return;
-        }
-
-        if let Some(align) = self.pending_raw_image_paragraph_align {
-            if let Some(image) = raw_html_image(html) {
+        match self.raw_images.classify(html) {
+            RawHtml::Image { image, align, rest } => {
                 self.output.push_str(&image_html_with_align(
                     &image.source,
                     &image.alt,
                     image.title.as_deref(),
                     align,
                 ));
-                self.pending_raw_image_paragraph_align = None;
-                self.skip_raw_image_paragraph_end = true;
-                self.render_raw_html_rest(image.rest);
-                return;
+                if let Some(rest) = rest {
+                    self.output.push_str(&escape_html(rest));
+                }
             }
-            self.pending_raw_image_paragraph_align = None;
-        }
-
-        self.output.push_str(&escape_html(html));
-    }
-
-    fn render_raw_html_rest(&mut self, rest: &str) {
-        let rest = rest.trim();
-        if rest.is_empty() {
-            return;
-        }
-        if self.skip_raw_image_paragraph_end && raw_html_image_paragraph_end(rest) {
-            self.skip_raw_image_paragraph_end = false;
-        } else {
-            self.output.push_str(&escape_html(rest));
+            RawHtml::Skip => {}
+            RawHtml::Text(text) => self.output.push_str(&escape_html(&text)),
         }
     }
 

--- a/crates/jayjay-markdown/src/html/tags.rs
+++ b/crates/jayjay-markdown/src/html/tags.rs
@@ -31,13 +31,12 @@ impl<'a> HtmlRenderer<'a> {
             } => self.render_link_start(dest_url.as_ref(), title.as_ref()),
             Tag::Table(_) => {
                 self.flush_pending_items();
-                self.table_depth += 1;
                 self.output.push_str("<table>");
             }
             Tag::TableHead => {
                 self.flush_pending_items();
                 self.table_head_depth += 1;
-                self.output.push_str("<thead>");
+                self.output.push_str("<thead><tr>");
             }
             Tag::TableRow => {
                 self.flush_pending_items();
@@ -85,12 +84,11 @@ impl<'a> HtmlRenderer<'a> {
             }
             TagEnd::Image => {}
             TagEnd::Table => {
-                self.table_depth = self.table_depth.saturating_sub(1);
                 self.output.push_str("</tbody></table>");
             }
             TagEnd::TableHead => {
                 self.table_head_depth = self.table_head_depth.saturating_sub(1);
-                self.output.push_str("</thead><tbody>");
+                self.output.push_str("</tr></thead><tbody>");
             }
             TagEnd::TableRow => self.output.push_str("</tr>"),
             TagEnd::TableCell => self.output.push_str(if self.table_head_depth > 0 {

--- a/crates/jayjay-markdown/src/images.rs
+++ b/crates/jayjay-markdown/src/images.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::MarkdownImageAlign;
 use crate::text::{escape_html, url_scheme};
 
@@ -9,20 +11,90 @@ pub(crate) struct RawHtmlImage<'a> {
     pub(crate) rest: &'a str,
 }
 
-pub(crate) fn raw_html_image_markup(input: &str) -> Option<(String, &str)> {
-    let image = raw_html_image(input)?;
-    Some((
-        image_html_with_align(
-            &image.source,
-            &image.alt,
-            image.title.as_deref(),
-            image.align,
-        ),
-        image.rest,
-    ))
+/// A `<p align>` wrapper that pulldown splits across raw HTML events: images inside keep its alignment until the swallowed `</p>`; a wrapper that never held an image is replayed as text.
+#[derive(Default)]
+pub(crate) struct RawImageParagraphs {
+    wrapper: Option<Wrapper>,
 }
 
-pub(crate) fn raw_html_image_paragraph_start(input: &str) -> Option<MarkdownImageAlign> {
+struct Wrapper {
+    align: MarkdownImageAlign,
+    opening: String,
+    matched: bool,
+}
+
+pub(crate) fn keeps_raw_image_wrapper(event: &pulldown_cmark::Event<'_>) -> bool {
+    use pulldown_cmark::Event;
+    match event {
+        Event::Html(_) | Event::InlineHtml(_) | Event::SoftBreak => true,
+        Event::Text(text) => text.trim().is_empty(),
+        _ => false,
+    }
+}
+
+pub(crate) enum RawHtml<'a> {
+    Image {
+        image: RawHtmlImage<'a>,
+        align: MarkdownImageAlign,
+        rest: Option<&'a str>,
+    },
+    Skip,
+    Text(Cow<'a, str>),
+}
+
+impl RawImageParagraphs {
+    pub(crate) fn classify<'a>(&mut self, html: &'a str) -> RawHtml<'a> {
+        if self.consume_paragraph_end(html) {
+            return RawHtml::Skip;
+        }
+        if let Some(image) = raw_html_image(html) {
+            let align = match self.wrapper.as_mut() {
+                Some(wrapper) if image.align == MarkdownImageAlign::None => {
+                    wrapper.matched = true;
+                    wrapper.align
+                }
+                _ => image.align,
+            };
+            let rest = image.rest.trim();
+            let rest = (!rest.is_empty() && !self.consume_paragraph_end(rest)).then_some(rest);
+            return RawHtml::Image { image, align, rest };
+        }
+        let unmatched = self.take_unmatched();
+        if let Some(align) = raw_html_image_paragraph_start(html) {
+            self.wrapper = Some(Wrapper {
+                align,
+                opening: html.to_owned(),
+                matched: false,
+            });
+            return match unmatched {
+                Some(opening) => RawHtml::Text(opening.into()),
+                None => RawHtml::Skip,
+            };
+        }
+        RawHtml::Text(match unmatched {
+            Some(opening) => (opening + html).into(),
+            None => html.into(),
+        })
+    }
+
+    pub(crate) fn take_unmatched(&mut self) -> Option<String> {
+        self.wrapper
+            .take_if(|wrapper| !wrapper.matched)
+            .map(|wrapper| wrapper.opening)
+    }
+
+    fn consume_paragraph_end(&mut self, html: &str) -> bool {
+        if self.wrapper.as_ref().is_some_and(|wrapper| wrapper.matched)
+            && raw_html_image_paragraph_end(html)
+        {
+            self.wrapper = None;
+            return true;
+        }
+        false
+    }
+}
+
+fn raw_html_image_paragraph_start(input: &str) -> Option<MarkdownImageAlign> {
     let input = input.trim();
     let after_paragraph = raw_html_tag_end("p", input)?;
     input[after_paragraph..]
@@ -31,7 +103,7 @@ pub(crate) fn raw_html_image_paragraph_start(input: &str) -> Option<MarkdownImag
         .then(|| paragraph_alignment(&html_attributes(&input[..after_paragraph])))
 }
 
-pub(crate) fn raw_html_image_paragraph_end(input: &str) -> bool {
+fn raw_html_image_paragraph_end(input: &str) -> bool {
     input.trim().eq_ignore_ascii_case("</p>")
 }
 

--- a/crates/jayjay-markdown/src/tests.rs
+++ b/crates/jayjay-markdown/src/tests.rs
@@ -22,10 +22,176 @@ print("hi")
     );
 
     assert!(html.contains("<h1 id=\"title\">Title</h1>"));
-    assert!(html.contains("<ul>"));
-    assert!(html.contains("<strong>Two</strong>"));
-    assert!(html.contains("<table>"));
+    assert!(html.contains("<ul><li>One</li><li><strong>Two</strong></li></ul>"));
+    assert!(html.contains("<table><thead><tr><th>Name</th><th>Value</th></tr></thead><tbody><tr><td>Code</td><td><code>ok</code></td></tr></tbody></table>"));
     assert!(html.contains("<code class=\"language-swift\">print(&quot;hi&quot;)"));
+}
+
+#[test]
+fn heading_ids_links_and_code_classes_are_sanitized() {
+    let html = render_markdown_html(
+        "# Hello, World!\n\n# Hello, World!\n\n[plain](https://example.com) [titled](https://example.com \"Site\")\n\n```c++\nint x;\n```\n\n```shell_session-2\n$ ls\n```\n",
+    );
+
+    assert!(html.contains("<h1 id=\"hello-world\">"));
+    assert!(html.contains("<h1 id=\"hello-world-2\">"));
+    assert!(html.contains("<a href=\"https://example.com\">plain</a>"));
+    assert!(html.contains("<a href=\"https://example.com\" title=\"Site\">titled</a>"));
+    assert!(html.contains("<code class=\"language-c\">"));
+    assert!(html.contains("<code class=\"language-shell_session-2\">"));
+}
+
+#[test]
+fn task_list_classes_apply_per_list_including_loose_and_nested_items() {
+    let html = render_markdown_html(
+        "- plain\n\n1. one\n\n- a\n  - b\n- [ ] c\n\n* [ ] loose\n\n* [x] second\n",
+    );
+
+    assert!(html.contains("<ul><li>plain</li></ul>"));
+    assert!(html.contains("<ol start=\"1\"><li>one</li></ol>"));
+    assert!(html.contains("<ul class=\"contains-task-list\"><li>a<ul><li>b</li></ul></li><li class=\"task-list-item\"><input type=\"checkbox\" disabled> c</li></ul>"), "{html}");
+    assert!(html.contains("<ul class=\"contains-task-list\"><li><p><input type=\"checkbox\" disabled> loose</p></li><li><p><input type=\"checkbox\" disabled checked> second</p></li></ul>"), "{html}");
+}
+
+#[test]
+fn image_alt_text_flattens_inline_markup_and_skips_inner_events() {
+    let html = render_markdown_html("![**bold** `code`\nalt](a.png) after\n\n# Title `code`\n");
+
+    assert!(html.contains(
+        "<img src=\"a.png\" alt=\"bold code alt\" loading=\"lazy\" decoding=\"async\"> after"
+    ));
+    assert!(!html.contains("<strong>"));
+    assert!(html.contains("<h1 id=\"title-code\">Title <code>code</code></h1>"));
+}
+
+#[test]
+fn raw_image_tags_tolerate_attribute_syntax_variants() {
+    let cases = [
+        (
+            "<IMG SRC='a.png' ALT='caps' />",
+            "<img src=\"a.png\" alt=\"caps\"",
+        ),
+        ("<img src=a.png/>", "<img src=\"a.png\" alt=\"\""),
+        (
+            "<img src=\"a>b.png\" alt=\"q\">",
+            "<img src=\"a&gt;b.png\" alt=\"q\"",
+        ),
+        (
+            "<img  src = \"a.png\"  alt=\"sp\" >",
+            "<img src=\"a.png\" alt=\"sp\"",
+        ),
+        ("<img src=\"a.png\" alt>", "<img src=\"a.png\" alt=\"\""),
+        (
+            "<img src=\"ü.png\" alt=\"ü\">",
+            "<img src=\"ü.png\" alt=\"ü\"",
+        ),
+        ("<img src=a.png alt=x> tail", "decoding=\"async\"> tail"),
+        ("<img src=a.png alt=x></p>", "decoding=\"async\">&lt;/p&gt;"),
+        (
+            "<p align=\"center\">\n<img src=\"a.png\" alt=\"c\">\n<span>x</span>\n</p>\n",
+            "</p>&lt;span&gt;x&lt;/span&gt;\n\n",
+        ),
+        (
+            "<p align=\"left\"><img src=\"a.png\" alt=\"l\"></p>",
+            "\n<img src=\"a.png\" alt=\"l\"",
+        ),
+        (
+            "<p align=\"center\"><img src=\"a.png\" alt=\"c\"><span>x</span></p>",
+            "</p>&lt;span&gt;x&lt;/span&gt;&lt;/p&gt;",
+        ),
+    ];
+    for (markdown, expected) in cases {
+        let html = render_markdown_html(markdown);
+        assert!(html.contains(expected), "{markdown:?} -> {html}");
+    }
+    let rejected = [
+        "<imgx src=\"a.png\">",
+        "<img>",
+        "<img src=\"a.png\" alt=\"unterminated>",
+        "<img src=\"/etc/x.png\" alt=\"abs\">",
+        "<img src=\"\\\\x.png\" alt=\"unc\">",
+    ];
+    for markdown in rejected {
+        let html = render_markdown_html(markdown);
+        assert!(!html.contains("<img "), "{markdown:?} -> {html}");
+    }
+    let html = render_markdown_html("<p>\nplain\n</p>\n");
+    assert!(html.contains("&lt;/p&gt;"), "{html}");
+}
+
+#[test]
+fn wrapper_alignment_spans_every_image_and_unmatched_openings_stay_text() {
+    let centered = "<p align=\"center\">\n<img src=\"a.png\" alt=\"A\">\n<img src=\"b.png\" alt=\"B\">\n</p>\n";
+    let html = render_markdown_html(centered);
+    assert_eq!(
+        html.matches("<p class=\"image-align-center\">").count(),
+        2,
+        "{html}"
+    );
+    assert!(!html.contains("&lt;/p&gt;"), "{html}");
+    let blocks = MarkdownDocument::parse(centered);
+    assert!(blocks.blocks().iter().all(|block| matches!(
+        block,
+        MarkdownBlock::Image {
+            align: MarkdownImageAlign::Center,
+            ..
+        }
+    )));
+
+    let inline = "- <p align=\"center\">text</p>\n- <p align=\"center\"> <img src=\"a.png\" alt=\"A\"> </p>\n";
+    let html = render_markdown_html(inline);
+    assert!(
+        html.contains("<li>&lt;p align=&quot;center&quot;&gt;text&lt;/p&gt;"),
+        "{html}"
+    );
+    assert!(
+        html.contains("<li><p class=\"image-align-center\"><img src=\"a.png\" alt=\"A\""),
+        "{html}"
+    );
+    assert!(matches!(
+        &MarkdownDocument::parse(inline).blocks()[0],
+        MarkdownBlock::List { items, .. }
+            if items[0].text == "<p align=\"center\">text</p>" && items[1].text == "Image: A (a.png)"
+    ));
+
+    let captioned = "<img src=\"a.png\" alt=\"A\"> caption\n<img src=\"b.png\" alt=\"B\">\n";
+    assert!(matches!(
+        MarkdownDocument::parse(captioned).blocks(),
+        [
+            MarkdownBlock::Image { source: a, .. },
+            MarkdownBlock::Paragraph(caption),
+            MarkdownBlock::Image { source: b, .. },
+        ] if a == "a.png" && caption == "caption" && b == "b.png"
+    ));
+
+    let unmatched = "<p align=\"center\">\ntext only\n</p>\n";
+    let html = render_markdown_html(unmatched);
+    assert!(
+        html.contains("&lt;p align=&quot;center&quot;&gt;\ntext only\n&lt;/p&gt;"),
+        "{html}"
+    );
+    assert_eq!(
+        MarkdownDocument::parse(unmatched).blocks(),
+        [MarkdownBlock::Paragraph(
+            "<p align=\"center\">\ntext only\n</p>".to_owned()
+        )]
+    );
+}
+
+#[test]
+fn bare_autolinks_need_boundaries_and_valid_domains() {
+    let linked = render_markdown_html("(https://example.com now, [x]user@example.com\n");
+    assert!(linked.contains("(<a href=\"https://example.com\">https://example.com</a> now"));
+    assert!(linked.contains("<a href=\"mailto:user@example.com\">"));
+    for text in [
+        "xhttps://example.com",
+        "user@.example.com",
+        "user@localhost",
+        "user@exa_mple.com",
+    ] {
+        let html = render_markdown_html(text);
+        assert!(!html.contains("<a "), "{text:?} -> {html}");
+    }
 }
 
 #[test]
@@ -72,11 +238,12 @@ fn renders_image_syntax_and_raw_image_tags() {
     assert!(html.contains("<p class=\"image-align-center\">"));
     assert!(html.contains("<img src=\"images/raw-flow.png\" alt=\"Raw\""));
     assert!(html.contains(
-        "<img src=\"docs/imgs/home.webp\" alt=\"JayJay - DAG graph and side-by-side diff\""
+        "<p class=\"image-align-center\"><img src=\"docs/imgs/home.webp\" alt=\"JayJay - DAG graph and side-by-side diff\""
     ));
     assert!(html.contains("<img src=\"data:image/png;base64,abc123\" alt=\"Data\""));
     assert!(!html.contains("onerror"));
     assert!(!html.contains("&lt;p align=&quot;center&quot;&gt;"));
+    assert!(!html.contains("&lt;/p&gt;"));
 }
 
 #[test]
@@ -167,6 +334,8 @@ fn parses_blocks_for_native_renderers() {
     let blocks = parse_markdown_blocks(
         r#"# Title
 
+### Sub
+
 Intro `code`.
 
 - [x] Done
@@ -182,10 +351,17 @@ fn main() {}
 
 ![Diagram](images/flow.png)
 
-<p align="center"> <img src=images/raw-flow.png alt=Raw></p>
+<p align="center">
+  <img src=images/raw-flow.png alt=Raw>
+</p>
 "#,
     );
 
+    assert!(
+        !blocks
+            .iter()
+            .any(|block| matches!(block, MarkdownBlock::Paragraph(text) if text.contains("<p")))
+    );
     assert_eq!(
         blocks.first(),
         Some(&MarkdownBlock::Heading {
@@ -193,6 +369,10 @@ fn main() {}
             text: "Title".to_owned(),
         })
     );
+    assert!(blocks.contains(&MarkdownBlock::Heading {
+        level: 3,
+        text: "Sub".to_owned(),
+    }));
     assert!(blocks.contains(&MarkdownBlock::Paragraph("Intro `code`.".to_owned())));
     let list = blocks
         .iter()
@@ -229,6 +409,28 @@ fn main() {}
         title: None,
         align: MarkdownImageAlign::Center,
     }));
+}
+
+#[test]
+fn nested_blocks_and_raw_html_fold_into_item_and_quote_text() {
+    let document = MarkdownDocument::parse(
+        "- item\n\n  ```\n  code\n  ```\n- <img src=\"a.png\" alt=\"A\">\n\n<div>top</div>\n\n> <div>quoted</div>\n",
+    );
+    assert_eq!(document.source().lines().next(), Some("- item"));
+    let blocks = document.blocks();
+    assert!(matches!(
+        &blocks[0],
+        MarkdownBlock::List { items, .. }
+            if items[0].text == "item\ncode" && items[1].text == "Image: A (a.png)"
+    ));
+    assert_eq!(
+        blocks[1],
+        MarkdownBlock::Paragraph("<div>top</div>".to_owned())
+    );
+    assert_eq!(
+        blocks[2],
+        MarkdownBlock::BlockQuote("<div>quoted</div>".to_owned())
+    );
 }
 
 #[test]


### PR DESCRIPTION
A mutation pass over jayjay-markdown left 100 of 374 mutants alive with 9 tests. Writing tests for the survivors exposed two renderer bugs. A centered image wrapped in a <p align="center"> block across several lines, the README's own format, lost its alignment and leaked an escaped </p> because the renderer matched the bare image before the pending paragraph, and the GPUI block parser had no handling for that form at all. Table heads also rendered their cells without a <tr>.

The paragraph state now lives in one classifier in the images module used by both the HTML renderer and the block parser. The write-only table depth counter is gone. New tests cover heading ids, link titles, code-class sanitization, per-list task classes including loose and nested items, image alt flattening, raw <img> attribute syntax variants, bare autolink boundaries, nested blocks inside list items, and percent decoding. Mutants: 239 caught / 100 missed before, 315 caught / 26 missed after; the rest are index arithmetic in the attribute scanner and defensive guards.