### PR TITLE
feat: make the welcome window's Recent list a collapsible side panel

### DIFF
--- a/crates/jayjay-core/src/repositories.rs
+++ b/crates/jayjay-core/src/repositories.rs
@@ -67,13 +67,19 @@ impl Store {
             return self.state.repositories.clone();
         };
         let mut next = self.state.clone();
-        let was_pinned = next.repositories.contains(&path);
-        if pinned && !was_pinned {
-            next.repositories.insert(0, path);
-        } else if !pinned && was_pinned {
-            next.repositories.retain(|entry| entry != &path);
-        } else {
+        // Stored entries may predate normalization, so match by canonical form too.
+        let is_target = |entry: &String| {
+            entry == &path
+                || stored_repository_path(Path::new(entry)).as_deref() == Some(path.as_str())
+        };
+        if pinned && next.repositories.contains(&path)
+            || !pinned && !next.repositories.iter().any(is_target)
+        {
             return self.state.repositories.clone();
+        }
+        next.repositories.retain(|entry| !is_target(entry));
+        if pinned {
+            next.repositories.insert(0, path);
         }
         if self.save(&next) {
             self.state = next;

--- a/crates/jayjay-core/src/repositories/grouping.rs
+++ b/crates/jayjay-core/src/repositories/grouping.rs
@@ -16,6 +16,54 @@ pub struct RepoListGroups {
     pub recent: Vec<RepoGroup>,
 }
 
+impl RepoListGroups {
+    /// Re-lists new entries with the nesting already known, so a list edit does not flash flat rows before group_repositories reruns.
+    pub fn with_entries(&self, pinned: &[String], recents: &[String]) -> RepoListGroups {
+        let present: HashSet<&str> = pinned.iter().chain(recents).map(String::as_str).collect();
+        let mut known: HashMap<&str, RepoGroup> = HashMap::new();
+        let mut nested: HashSet<&str> = HashSet::new();
+        for group in self.pinned.iter().chain(&self.recent) {
+            if !present.contains(group.path.as_str()) {
+                continue;
+            }
+            let workspaces: Vec<&String> = group
+                .workspaces
+                .iter()
+                .filter(|workspace| present.contains(workspace.as_str()))
+                .collect();
+            nested.extend(workspaces.iter().map(|workspace| workspace.as_str()));
+            known.insert(
+                group.path.as_str(),
+                RepoGroup {
+                    path: group.path.clone(),
+                    workspaces: workspaces.into_iter().cloned().collect(),
+                },
+            );
+        }
+        let pinned_set: HashSet<&str> = pinned.iter().map(String::as_str).collect();
+        let group = |path: &String| {
+            known.get(path.as_str()).cloned().unwrap_or(RepoGroup {
+                path: path.clone(),
+                workspaces: Vec::new(),
+            })
+        };
+        RepoListGroups {
+            pinned: pinned
+                .iter()
+                .filter(|path| !nested.contains(path.as_str()))
+                .map(group)
+                .collect(),
+            recent: recents
+                .iter()
+                .filter(|path| {
+                    !nested.contains(path.as_str()) && !pinned_set.contains(path.as_str())
+                })
+                .map(group)
+                .collect(),
+        }
+    }
+}
+
 /// Workspace checkouts nest under their listed primary repository, pinned or recent. Reads the filesystem; call off the UI thread.
 pub fn group_repositories(pinned: &[String], recents: &[String]) -> RepoListGroups {
     group_with(pinned, recents, workspace_primary_root)
@@ -110,6 +158,22 @@ mod tests {
 
     fn paths(groups: &[super::RepoGroup]) -> Vec<&str> {
         groups.iter().map(|group| group.path.as_str()).collect()
+    }
+
+    #[test]
+    fn with_entries_keeps_known_nesting_and_drops_removed_paths() {
+        let groups = group_with(
+            &strings(&["/work/main"]),
+            &strings(&["/work/agent-a", "/work/other", "/work/agent-b"]),
+            primary_root,
+        );
+        let edited = groups.with_entries(
+            &strings(&["/work/other"]),
+            &strings(&["/work/agent-a", "/work/main", "/work/new"]),
+        );
+        assert_eq!(paths(&edited.pinned), ["/work/other"]);
+        assert_eq!(paths(&edited.recent), ["/work/main", "/work/new"]);
+        assert_eq!(edited.recent[0].workspaces, ["/work/agent-a"]);
     }
 
     #[test]

--- a/crates/jayjay-core/src/repositories/tests.rs
+++ b/crates/jayjay-core/src/repositories/tests.rs
@@ -165,3 +165,26 @@ fn non_utf8_path_is_not_persisted_lossily() {
     assert!(store.set_pinned(&invalid, true).is_empty());
     assert!(!store_path.exists());
 }
+
+#[test]
+fn pinning_and_unpinning_match_a_stored_path_that_is_not_canonical() {
+    let dir = tempfile::tempdir().unwrap();
+    let repo = dir.path().join("repo");
+    std::fs::create_dir(&repo).unwrap();
+    let store_path = dir.path().join("repositories.json");
+    let stored = repo.parent().unwrap().join("repo").join("..").join("repo");
+    std::fs::write(
+        &store_path,
+        format!(
+            "{{\"repositories\":[{}]}}",
+            serde_json::to_string(&stored).unwrap()
+        ),
+    )
+    .unwrap();
+    let mut store = Store::load_from(store_path);
+    assert_eq!(store.repositories().len(), 1);
+
+    let canonical = stored_repository_path(&repo).unwrap();
+    assert_eq!(store.set_pinned(&repo, true), [canonical]);
+    assert!(store.set_pinned(&repo, false).is_empty());
+}

--- a/scripts/ui-test-fixtures.sh
+++ b/scripts/ui-test-fixtures.sh
@@ -22,6 +22,7 @@ setup_defaults() {
   defaults write "$bundle_id" jayjay.ignoreWhitespace -bool NO
   defaults write "$bundle_id" jayjay.treeFileList -bool NO
   defaults write "$bundle_id" jayjay.recentRepos -array "$fixtures/formats"
+  defaults write "$bundle_id" jayjay.showsRecentRepositoriesPanel -bool YES
   defaults delete "$bundle_id" jayjay.lastOpenedRepo 2>/dev/null || true
   defaults delete "$bundle_id" commandPalette.frameOrigin 2>/dev/null || true
   for key in jayjay.windowFrame.repo-window jayjay.windowFrame.repo-list-window jayjay.secondaryPaneWidth jayjay.fileColumnWidth; do
@@ -337,6 +338,7 @@ fixture_repository_stores() {
   printf '{"repositories":["%s"]}\n' "$fixtures/formats" > "$fixtures/repositories-pinned.json"
   printf '{"repositories":["%s"]}\n' "$(cd "$fixtures/formats" && pwd -P)" > "$fixtures/repositories-picker-pinning.json"
   printf '{"repositories":["%s"]}\n' "$fixtures/simple" > "$fixtures/repositories-simple.json"
+  printf '{"repositories":["%s"]}\n' "$fixtures/simple" > "$fixtures/repositories-recent-panel.json"
 }
 
 # Three code sections edit the same expressions so every side of the rebase collides while syntax highlighting stays testable.

--- a/shell/gpui/src/app/config/layout.rs
+++ b/shell/gpui/src/app/config/layout.rs
@@ -8,6 +8,7 @@ pub struct LayoutConfig {
     #[serde(alias = "file_column_width")]
     pub(crate) secondary_pane_width: f32,
     pub(crate) description_height: f32,
+    pub recent_repos_panel: bool,
 }
 
 impl Default for LayoutConfig {
@@ -16,6 +17,7 @@ impl Default for LayoutConfig {
             sidebar_width: 360.0,
             secondary_pane_width: SECONDARY_PANE_DEFAULT,
             description_height: DESCRIPTION_DEFAULT,
+            recent_repos_panel: false,
         }
     }
 }

--- a/shell/gpui/src/app/config/mod.rs
+++ b/shell/gpui/src/app/config/mod.rs
@@ -34,7 +34,7 @@ pub struct AppConfig {
     pub font_family: String,
     pub(crate) font_size: f32,
     pub diff: DiffConfig,
-    pub(crate) layout: LayoutConfig,
+    pub layout: LayoutConfig,
     pub(crate) tools: ToolsConfig,
     pub(crate) features: FeaturesConfig,
     pub onboarding: OnboardingConfig,
@@ -122,6 +122,16 @@ impl AppConfig {
         self.recent_repos.truncate(Self::MAX_RECENT_REPOS);
     }
 
+    /// Lists the path again without claiming recency, since the first entry doubles as the startup repository.
+    pub fn restore_recent_repo(&mut self, path: &Path) {
+        let normalized = normalize_repo_path(path);
+        if self.recent_repos.contains(&normalized) {
+            return;
+        }
+        self.recent_repos.truncate(Self::MAX_RECENT_REPOS - 1);
+        self.recent_repos.push(normalized);
+    }
+
     pub(crate) fn clear_recent_repos(&mut self) {
         self.recent_repos.clear();
     }
@@ -173,6 +183,30 @@ mod tests {
         let s = "appearance = \"dark\"\nunknown_root_key = 42\n";
         let cfg: AppConfig = toml::from_str(s).unwrap();
         assert_eq!(cfg.appearance, AppearanceMode::Dark);
+    }
+
+    #[test]
+    fn restoring_a_recent_repo_keeps_the_startup_entry_first() {
+        let mut cfg = AppConfig::default();
+        for ix in 0..AppConfig::MAX_RECENT_REPOS {
+            cfg.record_opened_repo(Path::new(&format!("/tmp/repo-{ix}")));
+        }
+        cfg.restore_recent_repo(Path::new("/tmp/repo-3"));
+        assert_eq!(
+            cfg.recent_repos.iter().position(|p| p == "/tmp/repo-3"),
+            Some(8)
+        );
+
+        cfg.restore_recent_repo(Path::new("/tmp/unpinned"));
+        assert_eq!(
+            cfg.recent_repos.first().map(String::as_str),
+            Some("/tmp/repo-11")
+        );
+        assert_eq!(
+            cfg.recent_repos.last().map(String::as_str),
+            Some("/tmp/unpinned")
+        );
+        assert_eq!(cfg.recent_repos.len(), AppConfig::MAX_RECENT_REPOS);
     }
 
     #[test]

--- a/shell/gpui/src/app/config/store.rs
+++ b/shell/gpui/src/app/config/store.rs
@@ -43,6 +43,10 @@ where
     cx.update_global::<AppConfigStore, _>(|store, _| {
         let mut next = (*store.config).clone();
         mutate(&mut next);
+        // The first recent shows the panel and the last removal hides it, whatever was chosen before.
+        if next.recent_repos.is_empty() != store.config.recent_repos.is_empty() {
+            next.layout.recent_repos_panel = !next.recent_repos.is_empty();
+        }
         if store.persist
             && let Err(err) = next.save()
         {

--- a/shell/gpui/src/app/repositories.rs
+++ b/shell/gpui/src/app/repositories.rs
@@ -36,6 +36,13 @@ pub fn set_pinned(cx: &mut App, path: &Path, pinned: bool) {
     });
 }
 
+pub fn set_pinned_keep_listed(cx: &mut App, path: &Path, pinned: bool) {
+    if !pinned {
+        super::config::update(cx, |cfg| cfg.restore_recent_repo(path));
+    }
+    set_pinned(cx, path, pinned);
+}
+
 pub fn install_in_memory(cx: &mut App) {
     cx.set_global(StoreHandle(RefCell::new(Store::in_memory())));
 }

--- a/shell/gpui/src/repo/window/menu.rs
+++ b/shell/gpui/src/repo/window/menu.rs
@@ -210,7 +210,7 @@ impl RepoWindow {
                 .detach();
             }
             ContextAction::SetRepositoryPinned { path, pinned } => {
-                crate::app::repositories::set_pinned(
+                crate::app::repositories::set_pinned_keep_listed(
                     cx,
                     std::path::Path::new(path.as_ref()),
                     pinned,

--- a/shell/gpui/src/windows/command_palette/actions.rs
+++ b/shell/gpui/src/windows/command_palette/actions.rs
@@ -6,6 +6,7 @@ use crate::app::tools;
 use crate::repo::window::RepoWindow;
 use crate::ui::icons::glyph;
 use crate::windows::keyboard_shortcuts::KeyboardShortcutsView;
+use crate::windows::repo_list::RepoListWindow;
 use crate::windows::settings::SettingsView;
 
 /// Context passed to a palette action's dispatcher.
@@ -77,6 +78,19 @@ pub(super) const ACTIONS: &[PaletteAction] = &[
                 view.update(cx, |view, cx| view.open_bookmark_manager(cx));
             }
         },
+    },
+    PaletteAction {
+        name: "Repository List",
+        keywords: &[
+            "repository",
+            "repositories",
+            "recent",
+            "pinned",
+            "welcome",
+            "open",
+        ],
+        glyph_str: glyph::HARD_DRIVE,
+        dispatch: |_, cx| RepoListWindow::open(cx),
     },
     PaletteAction {
         name: "New Workspace",

--- a/shell/gpui/src/windows/repo_list/actions.rs
+++ b/shell/gpui/src/windows/repo_list/actions.rs
@@ -29,7 +29,7 @@ pub(super) fn repository_actions(
         )
         .on_click(move |_, _, cx| {
             cx.stop_propagation();
-            repositories::set_pinned(cx, Path::new(&pin_path), !pinned);
+            repositories::set_pinned_keep_listed(cx, Path::new(&pin_path), !pinned);
         })
         .into_any_element(),
     ];

--- a/shell/gpui/src/windows/repo_list/grouping.rs
+++ b/shell/gpui/src/windows/repo_list/grouping.rs
@@ -1,7 +1,5 @@
-use std::collections::HashSet;
-
 use gpui::{AppContext, Context};
-use jayjay_core::repositories::{RepoGroup, RepoListGroups, group_repositories};
+use jayjay_core::repositories::{RepoListGroups, group_repositories};
 
 use super::window::RepoListWindow;
 
@@ -15,15 +13,7 @@ impl RepoListWindow {
         if self.pinned == pinned && self.recent == recent {
             return;
         }
-        let pinned_set = pinned.iter().collect::<HashSet<_>>();
-        self.groups = RepoListGroups {
-            pinned: pinned.iter().map(|path| flat_group(path)).collect(),
-            recent: recent
-                .iter()
-                .filter(|path| !pinned_set.contains(path))
-                .map(|path| flat_group(path))
-                .collect(),
-        };
+        self.groups = self.groups.with_entries(&pinned, &recent);
         self.pinned = pinned;
         self.recent = recent;
         self.regroup(cx);
@@ -50,12 +40,5 @@ impl RepoListWindow {
             });
         })
         .detach();
-    }
-}
-
-fn flat_group(path: &str) -> RepoGroup {
-    RepoGroup {
-        path: path.to_owned(),
-        workspaces: Vec::new(),
     }
 }

--- a/shell/gpui/src/windows/repo_list/sections.rs
+++ b/shell/gpui/src/windows/repo_list/sections.rs
@@ -1,48 +1,32 @@
 use gpui::{
-    Div, FontWeight, InteractiveElement, IntoElement, ParentElement, StatefulInteractiveElement,
-    Styled, div, px,
+    Div, FontWeight, InteractiveElement, ParentElement, StatefulInteractiveElement, Styled, div,
+    px, rgb,
 };
-use jayjay_core::repositories::{RepoGroup, RepoListGroups};
+use jayjay_core::repositories::RepoGroup;
 
 use super::card::repository_card;
 use crate::app::config;
 use crate::app::theme::{Theme, ui_font_size};
 use crate::ui::primitives::button;
 
-pub(super) fn repository_sections(
-    groups: RepoListGroups,
-    pinned_paths: &[String],
-    t: &Theme,
-) -> impl IntoElement {
-    let mut sections = div().flex().flex_col().gap(px(18.)).px(px(30.)).py(px(18.));
-    if !groups.pinned.is_empty() {
-        sections = sections.child(repository_section(
-            "Pinned",
-            groups.pinned,
-            RowKind::Pinned,
-            pinned_paths,
-            t,
-        ));
+pub(super) fn recent_section(groups: Vec<RepoGroup>, pinned_paths: &[String], t: &Theme) -> Div {
+    if groups.is_empty() {
+        return div()
+            .flex()
+            .flex_1()
+            .items_center()
+            .justify_center()
+            .text_size(ui_font_size(12.))
+            .text_color(rgb(t.fg_dim))
+            .child("No Recent Repositories");
     }
-    if !groups.recent.is_empty() {
-        sections = sections.child(repository_section(
-            "Recent Repositories",
-            groups.recent,
-            RowKind::Recent,
-            pinned_paths,
-            t,
-        ));
-    }
-
-    div()
-        .id("repo-list-scroll")
-        .flex()
-        .flex_1()
-        .min_h_0()
-        .flex_col()
-        .overflow_y_scroll()
-        .scrollbar_width(px(0.))
-        .child(sections)
+    repository_section(
+        "Recent Repositories",
+        groups,
+        RowKind::Recent,
+        pinned_paths,
+        t,
+    )
 }
 
 #[derive(Clone, Copy)]
@@ -51,7 +35,7 @@ pub(super) enum RowKind {
     Recent,
 }
 
-fn repository_section(
+pub(super) fn repository_section(
     title: &'static str,
     groups: Vec<RepoGroup>,
     kind: RowKind,

--- a/shell/gpui/src/windows/repo_list/view.rs
+++ b/shell/gpui/src/windows/repo_list/view.rs
@@ -1,49 +1,58 @@
+use std::time::{Duration, Instant};
+
 use gpui::{
-    Context, InteractiveElement, IntoElement, ParentElement, Render, Styled, Window, div, px, rgb,
+    Context, Div, InteractiveElement, IntoElement, ParentElement, Render, Stateful,
+    StatefulInteractiveElement, Styled, Window, div, ease_in_out, px, rgb,
 };
 
-use super::window::RepoListWindow;
+use super::window::{DETAIL_WIDTH, RepoListWindow};
 use super::{header, sections};
 use crate::app::actions::CloseWindow;
 use crate::app::config;
 use crate::app::repositories;
-use crate::ui::primitives::divider_h;
+use crate::app::theme::Theme;
+use crate::platform::TOOLBAR_LEADING_INSET;
+use crate::ui::icons::glyph;
+use crate::ui::primitives::{divider_h, icon_button, text_tooltip};
+
+const PANEL_WIDTH: f32 = 270.;
+const PANEL_SLIDE: Duration = Duration::from_millis(180);
+const TOP_INSET: f32 = 38.;
+
+#[derive(Clone, Copy)]
+pub(super) struct PanelSlide {
+    started: Instant,
+    from: f32,
+    to: f32,
+}
+
+impl PanelSlide {
+    fn width_at(&self, now: Instant) -> f32 {
+        let progress = (now - self.started).as_secs_f32() / PANEL_SLIDE.as_secs_f32();
+        self.from + (self.to - self.from) * ease_in_out(progress.min(1.))
+    }
+}
 
 impl Render for RepoListWindow {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let t = crate::app::theme::theme_for_window(window, cx).clone();
         let pinned = repositories::current(cx);
-        let recent = config::current(cx).recent_repos.clone();
-        let has_repositories = !pinned.is_empty() || !recent.is_empty();
-        self.show(pinned.clone(), recent, cx);
+        let cfg = config::current(cx);
+        self.show(pinned.clone(), cfg.recent_repos.clone(), cx);
         let content = if let Some(onboarding) = self.onboarding.as_ref() {
             div().flex().flex_1().min_h_0().child(onboarding.clone())
-        } else if has_repositories {
-            div()
-                .flex()
-                .flex_1()
-                .min_h_0()
-                .flex_col()
-                .child(
-                    div()
-                        .px(px(30.))
-                        .pt(px(30.))
-                        .pb(px(22.))
-                        .child(header::header(&self.logo, &t)),
-                )
-                .child(divider_h(&t))
-                .child(sections::repository_sections(
-                    self.groups.clone(),
-                    &pinned,
-                    &t,
-                ))
         } else {
+            let panel_shown = cfg.layout.recent_repos_panel;
+            let panel_width = self.panel_width(panel_shown, window, cx);
             div()
+                .relative()
                 .flex()
                 .flex_1()
-                .items_center()
-                .justify_center()
-                .child(header::header(&self.logo, &t))
+                .flex_row()
+                .min_h_0()
+                .children(panel_width.map(|width| self.recent_panel(&pinned, width, &t)))
+                .child(self.detail(&pinned, &t))
+                .child(panel_toggle(panel_shown, &t))
         };
 
         div()
@@ -61,4 +70,150 @@ impl Render for RepoListWindow {
             .text_color(rgb(t.fg))
             .child(content)
     }
+}
+
+impl RepoListWindow {
+    fn panel_width(
+        &mut self,
+        shown: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<f32> {
+        let now = cx.background_executor().now();
+        let to = if shown { PANEL_WIDTH } else { 0. };
+        if self
+            .panel_shown
+            .replace(shown)
+            .is_some_and(|was| was != shown)
+            && !cx.reduce_motion()
+        {
+            let from = self
+                .panel_slide
+                .map_or(PANEL_WIDTH - to, |slide| slide.width_at(now));
+            self.panel_slide = Some(PanelSlide {
+                started: now,
+                from,
+                to,
+            });
+        }
+        if self
+            .panel_slide
+            .is_some_and(|slide| now - slide.started >= PANEL_SLIDE)
+        {
+            self.panel_slide = None;
+        }
+        match self.panel_slide {
+            Some(slide) => {
+                window.request_animation_frame();
+                Some(slide.width_at(now))
+            }
+            None => shown.then_some(PANEL_WIDTH),
+        }
+    }
+
+    fn recent_panel(&self, pinned: &[String], width: f32, t: &Theme) -> Div {
+        div().flex_none().overflow_hidden().w(px(width)).child(
+            div()
+                .debug_selector(|| "repo-list-recent-panel".to_owned())
+                .flex()
+                .flex_col()
+                .w(px(PANEL_WIDTH))
+                .h_full()
+                .ml(px(width - PANEL_WIDTH))
+                .pt(px(TOP_INSET))
+                .bg(rgb(t.header_bg))
+                .border_r_1()
+                .border_color(rgb(t.border))
+                .child(
+                    scroll_column("repo-list-recent-scroll").child(
+                        sections::recent_section(self.groups.recent.clone(), pinned, t)
+                            .px(px(14.))
+                            .py(px(18.)),
+                    ),
+                ),
+        )
+    }
+
+    fn detail(&self, pinned: &[String], t: &Theme) -> Div {
+        let column = div()
+            .flex()
+            .flex_1()
+            .min_w_0()
+            .min_h_0()
+            .flex_col()
+            .pt(px(TOP_INSET));
+        let content = div()
+            .debug_selector(|| "repo-list-detail".to_owned())
+            .w_full()
+            .max_w(px(DETAIL_WIDTH))
+            .flex()
+            .flex_col();
+        if self.groups.pinned.is_empty() {
+            return column
+                .items_center()
+                .justify_center()
+                .child(content.px(px(30.)).child(header::header(&self.logo, t)));
+        }
+        column.child(
+            scroll_column("repo-list-scroll").items_center().child(
+                content
+                    .child(
+                        div()
+                            .px(px(30.))
+                            .pt(px(14.))
+                            .pb(px(22.))
+                            .child(header::header(&self.logo, t)),
+                    )
+                    .child(divider_h(t))
+                    .child(
+                        sections::repository_section(
+                            "Pinned",
+                            self.groups.pinned.clone(),
+                            sections::RowKind::Pinned,
+                            pinned,
+                            t,
+                        )
+                        .px(px(30.))
+                        .py(px(18.)),
+                    ),
+            ),
+        )
+    }
+}
+
+fn panel_toggle(panel_shown: bool, t: &Theme) -> Stateful<Div> {
+    icon_button(
+        "repo-list-toggle-recent",
+        glyph::COLUMNS,
+        14.,
+        28.,
+        24.,
+        t.fg_dim,
+        t,
+    )
+    .debug_selector(|| "repo-list-toggle-recent".to_owned())
+    .absolute()
+    .top(px(8.))
+    .left(px(TOOLBAR_LEADING_INSET))
+    .tooltip(text_tooltip(if panel_shown {
+        "Hide Recent Repositories"
+    } else {
+        "Show Recent Repositories"
+    }))
+    .on_click(|_, _, cx| {
+        config::update(cx, |cfg| {
+            cfg.layout.recent_repos_panel = !cfg.layout.recent_repos_panel;
+        });
+    })
+}
+
+fn scroll_column(id: &'static str) -> Stateful<Div> {
+    div()
+        .id(id)
+        .flex()
+        .flex_1()
+        .min_h_0()
+        .flex_col()
+        .overflow_y_scroll()
+        .scrollbar_width(px(0.))
 }

--- a/shell/gpui/src/windows/repo_list/window.rs
+++ b/shell/gpui/src/windows/repo_list/window.rs
@@ -4,6 +4,7 @@ use gpui::{
 };
 use jayjay_core::repositories::RepoListGroups;
 
+use super::view::PanelSlide;
 use crate::app::config::{self, AppConfigStore};
 use crate::app::repositories::{self, StoreHandle};
 use crate::app::theme::{Theme, observe_window_appearance};
@@ -11,8 +12,9 @@ use crate::repo::RepoWindow;
 use crate::ui::logo::Logo;
 use crate::ui::onboarding::{OnboardingCompleted, OnboardingView};
 
-const WINDOW_WIDTH: f32 = 480.;
+const WINDOW_WIDTH: f32 = 780.;
 const WINDOW_HEIGHT: f32 = 600.;
+pub(super) const DETAIL_WIDTH: f32 = 480.;
 
 pub struct RepoListWindow {
     pub(super) onboarding: Option<Entity<OnboardingView>>,
@@ -22,6 +24,8 @@ pub struct RepoListWindow {
     pub(super) recent: Vec<String>,
     pub(super) groups: RepoListGroups,
     pub(super) grouping_generation: u64,
+    pub(super) panel_shown: Option<bool>,
+    pub(super) panel_slide: Option<PanelSlide>,
 }
 
 impl RepoListWindow {
@@ -39,16 +43,15 @@ impl RepoListWindow {
             return;
         }
 
-        let window_size = size(px(WINDOW_WIDTH), px(WINDOW_HEIGHT));
         let handle = cx
             .open_window(
                 WindowOptions {
                     window_bounds: Some(WindowBounds::Windowed(Bounds::centered(
                         None,
-                        window_size,
+                        size(px(WINDOW_WIDTH), px(WINDOW_HEIGHT)),
                         cx,
                     ))),
-                    window_min_size: Some(window_size),
+                    window_min_size: Some(size(px(DETAIL_WIDTH), px(WINDOW_HEIGHT))),
                     titlebar: Some(TitlebarOptions {
                         title: Some("JayJay".into()),
                         appears_transparent: true,
@@ -85,6 +88,8 @@ impl RepoListWindow {
                             recent: Vec::new(),
                             groups: RepoListGroups::default(),
                             grouping_generation: 0,
+                            panel_shown: None,
+                            panel_slide: None,
                         }
                     })
                 },

--- a/shell/gpui/tests/gpui/main.rs
+++ b/shell/gpui/tests/gpui/main.rs
@@ -24,6 +24,7 @@ mod repo_file_multi_select;
 mod repo_file_split;
 mod repo_layout;
 mod repo_lifecycle;
+mod repo_list_recent_panel;
 mod repo_markdown_images;
 mod repo_markdown_preview_scroll;
 mod repo_mutations;

--- a/shell/gpui/tests/gpui/repo_list_recent_panel.rs
+++ b/shell/gpui/tests/gpui/repo_list_recent_panel.rs
@@ -1,0 +1,164 @@
+use std::time::Duration;
+
+use crate::harness::{install_test_globals, settle_visual};
+use gpui::{Modifiers, TestAppContext, VisualTestContext, px, size};
+use jayjay_core::repositories::normalize_repository_path;
+use jayjay_gpui::app::config;
+use jayjay_gpui::windows::repo_list::RepoListWindow;
+
+#[gpui::test]
+fn recent_panel_toggles_and_keeps_the_pinned_column_at_welcome_width(cx: &mut TestAppContext) {
+    let pinned = tempfile::tempdir().expect("pinned repository");
+    let recent = tempfile::tempdir().expect("recent repository");
+    let path = |dir: &tempfile::TempDir| {
+        normalize_repository_path(dir.path())
+            .to_string_lossy()
+            .into_owned()
+    };
+    install_test_globals(cx);
+    cx.update(RepoListWindow::open);
+    let window = cx.windows().last().copied().expect("repo list window");
+    let mut visual = VisualTestContext::from_window(window, cx);
+    settle_visual(&mut visual);
+    assert!(
+        visual.debug_bounds("repo-list-recent-panel").is_none(),
+        "nothing recent, so the panel starts hidden"
+    );
+    assert!(
+        visual.debug_bounds("repo-list-toggle-recent").is_some(),
+        "the toggle is there even with nothing listed"
+    );
+
+    visual.cx.update(|cx| {
+        config::update(cx, |cfg| {
+            cfg.recent_repos = vec![path(&pinned), path(&recent)]
+        })
+    });
+    settle_slide(&mut visual);
+    let hero = visual
+        .debug_bounds("repo-list-detail")
+        .expect("detail column");
+    let height = visual.update(|window, _| window.viewport_size().height);
+    assert!(
+        (hero.center().y - (px(38.) + height) / 2.).abs() < px(2.),
+        "with nothing pinned the hero centers below the toolbar: {hero:?}"
+    );
+    let pin = visual.debug_bounds("repo-list-pin-0").expect("pin button");
+    visual.simulate_click(pin.center(), Modifiers::default());
+    settle_visual(&mut visual);
+
+    let panel = visual
+        .debug_bounds("repo-list-recent-panel")
+        .expect("recent panel shows by default");
+    let detail = visual
+        .debug_bounds("repo-list-detail")
+        .expect("detail column");
+    assert!(
+        visual.debug_bounds("repo-list-row-0").is_some(),
+        "recent row lives in the panel"
+    );
+    assert!(detail.origin.x >= panel.origin.x + panel.size.width);
+    assert!(detail.size.width <= px(480.), "{detail:?}");
+
+    let toggle = visual
+        .debug_bounds("repo-list-toggle-recent")
+        .expect("panel toggle");
+    assert!(
+        toggle.origin.x < panel.origin.x + px(100.),
+        "toggle leads the window like the sidebar button: {toggle:?}"
+    );
+    visual.simulate_click(toggle.center(), Modifiers::default());
+    settle_visual(&mut visual);
+    visual
+        .cx
+        .executor()
+        .advance_clock(Duration::from_millis(90));
+    visual.update(|window, cx| window.simulate_next_frame(cx));
+    settle_visual(&mut visual);
+    let sliding = visual
+        .debug_bounds("repo-list-recent-panel")
+        .expect("the panel slides out before it leaves the tree");
+    assert!(
+        sliding.origin.x < px(0.) && sliding.origin.x > px(-270.),
+        "mid-slide the panel is partly off the left edge: {sliding:?}"
+    );
+    settle_slide(&mut visual);
+    assert!(
+        visual.debug_bounds("repo-list-recent-panel").is_none(),
+        "toggle hides the panel"
+    );
+    assert!(
+        !visual
+            .cx
+            .update(|cx| config::current(cx).layout.recent_repos_panel)
+    );
+    let pinned_row = visual
+        .debug_bounds("repo-list-pinned-row-0")
+        .expect("pinned row stays");
+    assert!(
+        pinned_row.size.width <= px(480.),
+        "pinned cards keep the welcome width: {pinned_row:?}"
+    );
+    let window_width = visual.update(|window, _| window.viewport_size().width);
+    assert!(
+        (pinned_row.center().x - window_width / 2.).abs() < px(2.),
+        "pinned column is centered once the panel is hidden"
+    );
+
+    let toggle = visual
+        .debug_bounds("repo-list-toggle-recent")
+        .expect("panel toggle");
+    visual.simulate_click(toggle.center(), Modifiers::default());
+    settle_slide(&mut visual);
+    assert!(
+        visual.debug_bounds("repo-list-recent-panel").is_some(),
+        "toggle shows the panel again"
+    );
+    assert!(
+        visual
+            .cx
+            .update(|cx| config::current(cx).layout.recent_repos_panel)
+    );
+
+    visual.simulate_resize(size(px(600.), px(600.)));
+    settle_visual(&mut visual);
+    let panel = visual
+        .debug_bounds("repo-list-recent-panel")
+        .expect("a narrow window keeps the panel reachable");
+    let detail = visual
+        .debug_bounds("repo-list-detail")
+        .expect("detail column");
+    assert!(detail.origin.x >= panel.origin.x + panel.size.width);
+    assert!(
+        detail.size.width < px(480.),
+        "detail compresses: {detail:?}"
+    );
+
+    let clear = visual
+        .debug_bounds("repo-list-clear")
+        .expect("clear button");
+    visual.simulate_click(clear.center(), Modifiers::default());
+    settle_slide(&mut visual);
+    assert!(
+        visual.debug_bounds("repo-list-recent-panel").is_none(),
+        "clearing the last recent hides the panel despite the earlier choice"
+    );
+    visual
+        .cx
+        .update(|cx| config::update(cx, |cfg| cfg.record_opened_repo(recent.path())));
+    settle_slide(&mut visual);
+    assert!(
+        visual.debug_bounds("repo-list-recent-panel").is_some(),
+        "the first recent shows the panel again"
+    );
+}
+
+fn settle_slide(visual: &mut VisualTestContext) {
+    settle_visual(visual);
+    visual
+        .cx
+        .executor()
+        .advance_clock(Duration::from_millis(200));
+    visual.update(|window, cx| window.simulate_next_frame(cx));
+    settle_visual(visual);
+}

--- a/shell/gpui/tests/gpui/repo_pinning.rs
+++ b/shell/gpui/tests/gpui/repo_pinning.rs
@@ -59,6 +59,38 @@ fn pinning_a_recent_repo_moves_it_without_opening_it(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn unpinning_returns_a_repository_to_recent_behind_the_startup_entry(cx: &mut TestAppContext) {
+    let repository = tempfile::tempdir().expect("pinned repository directory");
+    let repository_path = normalized_path(&repository);
+    let startup = tempfile::tempdir().expect("last opened repository directory");
+    let startup_path = normalized_path(&startup);
+    install_test_globals(cx);
+    cx.update(|cx| {
+        config::update(cx, |cfg| cfg.recent_repos = vec![startup_path.clone()]);
+        repositories::set_pinned(cx, repository.path(), true);
+        RepoListWindow::open(cx);
+    });
+    let window = cx.windows().last().copied().expect("repo list window");
+    let mut visual = VisualTestContext::from_window(window, cx);
+    settle_visual(&mut visual);
+
+    let unpin = visual
+        .debug_bounds("repo-list-pinned-pin-0")
+        .expect("unpin repository button");
+    visual.simulate_click(unpin.center(), Modifiers::default());
+    settle_visual(&mut visual);
+
+    assert!(visual.cx.update(repositories::current).is_empty());
+    assert_eq!(
+        visual
+            .cx
+            .update(|cx| config::current(cx).recent_repos.clone()),
+        vec![startup_path, repository_path]
+    );
+    assert!(visual.debug_bounds("repo-list-row-1").is_some());
+}
+
+#[gpui::test]
 fn clearing_recent_repositories_preserves_pins(cx: &mut TestAppContext) {
     let pinned_repository = tempfile::tempdir().expect("pinned repository directory");
     let pinned_path = normalized_path(&pinned_repository);
@@ -253,8 +285,8 @@ fn pinned_workspace_nests_under_its_pinned_root_and_unpins_there(cx: &mut TestAp
     assert_eq!(visual.cx.update(repositories::current), vec![root_path]);
     assert!(
         visual
-            .debug_bounds("repo-list-pinned-group-0-workspace-0")
-            .is_none(),
-        "an unpinned workspace with no recent entry leaves the list"
+            .debug_bounds("repo-list-pinned-group-0-workspace-remove-0")
+            .is_some(),
+        "an unpinned workspace joins Recent under its root instead of vanishing"
     );
 }

--- a/shell/mac/Sources/JayJay/App/Config/AppSettings.swift
+++ b/shell/mac/Sources/JayJay/App/Config/AppSettings.swift
@@ -23,6 +23,7 @@ final class AppSettings {
         static let recentRepos = "jayjay.recentRepos"
         static let lastOpenedRepo = "jayjay.lastOpenedRepo"
         static let hasCompletedOnboarding = "jayjay.hasCompletedOnboarding"
+        static let showsRecentRepositoriesPanel = "jayjay.showsRecentRepositoriesPanel"
         static let skipAbandonConfirmation = "jayjay.skipAbandonConfirmation"
         static let confirmDragRebase = "jayjay.confirmDragRebase"
         static let externalEditor = "jayjay.externalEditor"
@@ -99,7 +100,13 @@ final class AppSettings {
     // MARK: - Repos
 
     var recentRepos: [String] {
-        didSet { defaults.set(recentRepos, forKey: StorageKeys.recentRepos) }
+        didSet {
+            defaults.set(recentRepos, forKey: StorageKeys.recentRepos)
+            // The first recent shows the panel and the last removal hides it, whatever was chosen before.
+            if recentRepos.isEmpty != oldValue.isEmpty {
+                showsRecentRepositoriesPanel = !recentRepos.isEmpty
+            }
+        }
     }
 
     var lastOpenedRepo: String? {
@@ -111,6 +118,10 @@ final class AppSettings {
             hasCompletedOnboarding,
             forKey: StorageKeys.hasCompletedOnboarding
         ) }
+    }
+
+    var showsRecentRepositoriesPanel: Bool {
+        didSet { defaults.set(showsRecentRepositoriesPanel, forKey: StorageKeys.showsRecentRepositoriesPanel) }
     }
 
     // MARK: - Tools
@@ -193,6 +204,7 @@ final class AppSettings {
         lastOpenedRepo = defaults.string(forKey: StorageKeys.lastOpenedRepo)
             .flatMap { $0.isEmpty ? nil : Self.standardizedRepositoryPath($0) }
         hasCompletedOnboarding = defaults.bool(forKey: StorageKeys.hasCompletedOnboarding)
+        showsRecentRepositoriesPanel = defaults.bool(forKey: StorageKeys.showsRecentRepositoriesPanel)
         externalEditor = ExternalEditor(rawValue: defaults.string(forKey: StorageKeys.externalEditor) ?? "") ?? .vscode
         customEditorCommand = defaults.string(forKey: StorageKeys.customEditorCommand) ?? ""
         terminal = Terminal(rawValue: defaults.string(forKey: StorageKeys.terminal) ?? "") ?? .terminal
@@ -207,11 +219,16 @@ final class AppSettings {
     // MARK: - Repo helpers
 
     func recordOpenedRepo(_ path: String) {
+        lastOpenedRepo = addRecentRepo(path)
+    }
+
+    @discardableResult
+    func addRecentRepo(_ path: String) -> String {
         let standardizedPath = Self.standardizedRepositoryPath(path)
         recentRepos.removeAll(where: { $0 == standardizedPath })
         recentRepos.insert(standardizedPath, at: 0)
         recentRepos = Array(recentRepos.prefix(12))
-        lastOpenedRepo = standardizedPath
+        return standardizedPath
     }
 
     func removeRecentRepo(_ path: String) {

--- a/shell/mac/Sources/JayJay/App/Config/RepositoryStore.swift
+++ b/shell/mac/Sources/JayJay/App/Config/RepositoryStore.swift
@@ -24,4 +24,11 @@ final class RepositoryStore {
         _ = setRepositoryPinned(path: path, pinned: pinned, storePath: storePath)
         refreshGeneration &+= 1
     }
+
+    func setPinned(_ pinned: Bool, path: String, keepingListedIn settings: AppSettings) {
+        if !pinned {
+            settings.addRecentRepo(path)
+        }
+        setPinned(pinned, path: path)
+    }
 }

--- a/shell/mac/Sources/JayJay/App/Window/RepoListScene.swift
+++ b/shell/mac/Sources/JayJay/App/Window/RepoListScene.swift
@@ -15,7 +15,7 @@ struct RepoListScene: Scene {
                 .background(WindowFramePersistence(key: AppWindows.repoList))
         }
         .handlesExternalEvents(matching: [])
-        .defaultSize(WindowFrameStore.defaultSize(key: AppWindows.repoList, fallback: WelcomeView.minimumSize))
+        .defaultSize(WindowFrameStore.defaultSize(key: AppWindows.repoList, fallback: WelcomeView.defaultSize))
         .defaultLaunchBehavior(launchScene.repoListBehavior)
         .restorationBehavior(.disabled)
     }

--- a/shell/mac/Sources/JayJay/Onboarding/WelcomeView.swift
+++ b/shell/mac/Sources/JayJay/Onboarding/WelcomeView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct WelcomeView: View {
     static let minimumSize = NSSize(width: 480, height: 600)
+    static let defaultSize = NSSize(width: 760, height: 600)
 
     let onOpen: (String) -> Void
 
@@ -13,21 +14,12 @@ struct WelcomeView: View {
     var body: some View {
         let pinnedRepositories = repositoryStore.paths
         let recentRepositories = settings.recentRepos
-        let hasRepositories = !pinnedRepositories.isEmpty || !recentRepositories.isEmpty
 
-        VStack(spacing: 0) {
-            if !hasRepositories {
-                Spacer()
-                header.padding(.horizontal, 30)
-                Spacer()
-            } else {
-                header
-                    .padding(.top, 30)
-                    .padding(.bottom, 22)
-                    .padding(.horizontal, 30)
-                Divider()
-                repositorySections(model.groups)
-            }
+        NavigationSplitView(columnVisibility: recentPanelVisibility) {
+            recentPanel(model.groups.recent)
+                .navigationSplitViewColumnWidth(280)
+        } detail: {
+            detail(pinned: model.groups.pinned)
         }
         .frame(
             minWidth: Self.minimumSize.width,
@@ -40,9 +32,71 @@ struct WelcomeView: View {
             repositoryStore.reload()
             model.regroup()
         }
-        .onChange(of: pinnedRepositories + recentRepositories, initial: true) {
+        // Keyed on both lists: moving a path between them leaves their concatenation unchanged.
+        .onChange(of: [pinnedRepositories, recentRepositories], initial: true) {
             model.show(pinned: pinnedRepositories, recents: recentRepositories)
         }
+    }
+
+    /// The split view reports .automatic and .doubleColumn as well; anything but hidden counts as shown.
+    private var recentPanelVisibility: Binding<NavigationSplitViewVisibility> {
+        Binding(
+            get: { settings.showsRecentRepositoriesPanel ? .all : .detailOnly },
+            set: { settings.showsRecentRepositoriesPanel = $0 != .detailOnly }
+        )
+    }
+
+    @ViewBuilder
+    private func recentPanel(_ recent: [RepoGroup]) -> some View {
+        if recent.isEmpty {
+            Text("No Recent Repositories")
+                .jayjayFont(12)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            ScrollView {
+                repositorySection(title: "Recent Repositories", showsClear: true) {
+                    ForEach(recent) { group in
+                        repoGroupRows(group, pinned: false)
+                    }
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 18)
+            }
+        }
+    }
+
+    /// The detail keeps the single-column welcome width so a hidden panel widens the margins, not the cards.
+    private func detail(pinned: [RepoGroup]) -> some View {
+        Group {
+            if pinned.isEmpty {
+                VStack(spacing: 0) {
+                    Spacer()
+                    header.padding(.horizontal, 30)
+                    Spacer()
+                }
+            } else {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        header
+                            .padding(.top, 30)
+                            .padding(.bottom, 22)
+                            .padding(.horizontal, 30)
+                        Divider()
+                        repositorySection(title: "Pinned") {
+                            ForEach(pinned) { group in
+                                repoGroupRows(group, pinned: true)
+                            }
+                        }
+                        .padding(.horizontal, 30)
+                        .padding(.vertical, 18)
+                    }
+                    .frame(maxWidth: Self.minimumSize.width)
+                    .frame(maxWidth: .infinity)
+                }
+            }
+        }
+        .frame(minWidth: Self.minimumSize.width, maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var header: some View {
@@ -67,31 +121,6 @@ struct WelcomeView: View {
             .keyboardShortcut(.defaultAction)
         }
         .frame(maxWidth: .infinity)
-    }
-
-    private func repositorySections(_ groups: RepoListGroups) -> some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                if !groups.pinned.isEmpty {
-                    repositorySection(title: "Pinned") {
-                        ForEach(groups.pinned) { group in
-                            repoGroupRows(group, pinned: true)
-                        }
-                    }
-                }
-
-                if !groups.recent.isEmpty {
-                    repositorySection(title: "Recent Repositories", showsClear: true) {
-                        ForEach(groups.recent) { group in
-                            repoGroupRows(group, pinned: false)
-                        }
-                    }
-                }
-            }
-            .padding(.horizontal, 30)
-            .padding(.vertical, 18)
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
     @ViewBuilder
@@ -167,7 +196,7 @@ struct WelcomeView: View {
 
     @ViewBuilder
     private func pinAndRemoveButtons(path: String, pinned: Bool) -> some View {
-        Button { repositoryStore.setPinned(!pinned, path: path) } label: {
+        Button { repositoryStore.setPinned(!pinned, path: path, keepingListedIn: settings) } label: {
             Image(systemName: pinned ? "pin.slash.fill" : "pin.fill")
                 .foregroundStyle(.tertiary)
         }

--- a/shell/mac/Sources/JayJay/Repo/ContentView/RepoContentView+CommandPalette.swift
+++ b/shell/mac/Sources/JayJay/Repo/ContentView/RepoContentView+CommandPalette.swift
@@ -118,6 +118,11 @@ extension RepoContentView {
             icon: "bookmark.slash",
             category: "Repository"
         ) { viewModel.forgetStaleBookmarks() })
+        items.append(CommandPaletteItem(
+            title: "Repository List",
+            icon: "list.bullet.rectangle",
+            category: "Repository"
+        ) { windowManager.showRepoList() })
         return items
     }
 

--- a/shell/mac/Sources/JayJay/Repo/RepoTitlePicker.swift
+++ b/shell/mac/Sources/JayJay/Repo/RepoTitlePicker.swift
@@ -11,6 +11,7 @@ struct RepoTitlePicker: View {
     let onCreateWorkspace: () -> Void
     let onRefresh: () -> Void
 
+    @Environment(AppSettings.self) private var settings
     @Environment(RepositoryStore.self) private var repositoryStore
     @Environment(RepoWindowManager.self) private var windowManager
     @State private var anchor = PickerAnchor()
@@ -228,7 +229,7 @@ struct RepoTitlePicker: View {
         let pinned = repositoryStore.paths.contains(path)
         return Button(pinned ? "Unpin" : "Pin", systemImage: pinned ? "pin.slash" : "pin") {
             panel.dismiss()
-            repositoryStore.setPinned(!pinned, path: path)
+            repositoryStore.setPinned(!pinned, path: path, keepingListedIn: settings)
         }
     }
 

--- a/shell/mac/Tests/JayJayTests/AppSettingsTests.swift
+++ b/shell/mac/Tests/JayJayTests/AppSettingsTests.swift
@@ -29,6 +29,25 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertEqual(AppSettings(defaults: defaults).secondaryPaneWidth, 340)
     }
 
+    func testRecentRepositoriesPanelFollowsTheListUntilToggled() throws {
+        let suite = "AppSettingsTests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suite))
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        XCTAssertFalse(AppSettings(defaults: defaults).showsRecentRepositoriesPanel)
+
+        let settings = AppSettings(defaults: defaults)
+        settings.addRecentRepo("/tmp/one")
+        XCTAssertTrue(settings.showsRecentRepositoriesPanel)
+        settings.showsRecentRepositoriesPanel = false
+        XCTAssertFalse(AppSettings(defaults: defaults).showsRecentRepositoriesPanel)
+
+        settings.removeRecentRepo("/tmp/one")
+        XCTAssertFalse(settings.showsRecentRepositoriesPanel)
+        settings.addRecentRepo("/tmp/two")
+        XCTAssertTrue(AppSettings(defaults: defaults).showsRecentRepositoriesPanel)
+    }
+
     func testMonoFontChoicesComeFromCoreOptions() {
         let coreOptions = monoFontOptions()
 

--- a/shell/mac/Tests/JayJayUITests/Scenes/RepoListRecentPanelScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/RepoListRecentPanelScene.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+final class RepoListRecentPanelScene: SceneBase {
+    override class var opensFixtureOnLaunch: Bool {
+        false
+    }
+
+    override class var repositoryStoreFixtureName: String {
+        "repositories-recent-panel.json"
+    }
+
+    func testRecentPanelTogglesAndRemembersItsState() throws {
+        let app = try XCTUnwrap(app)
+        let recents = app.staticTexts["Recent Repositories"]
+        let pinned = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "simple,")).firstMatch
+        XCTAssertTrue(recents.waitForExistence(timeout: 5), "Recent panel did not show on a fresh launch")
+        XCTAssertTrue(pinned.exists, "Pinned repository is missing beside the hero")
+
+        let window = app.windows["JayJay"]
+        window.toolbars.buttons["Hide Sidebar"].click()
+        XCTAssertTrue(recents.waitForNonExistence(timeout: 5), "Hide Sidebar did not hide the Recent panel")
+        XCTAssertTrue(pinned.exists, "Hiding the Recent panel removed the pinned repository")
+
+        app.terminate()
+        app.launch()
+        XCTAssertTrue(pinned.waitForExistence(timeout: 10), "Repository list did not come back after relaunch")
+        XCTAssertFalse(recents.exists, "Recent panel forgot that it was hidden")
+
+        window.toolbars.buttons["Show Sidebar"].click()
+        XCTAssertTrue(recents.waitForExistence(timeout: 5), "Show Sidebar did not bring the Recent panel back")
+    }
+
+    func testUnpinningReturnsARepositoryToRecent() throws {
+        let app = try XCTUnwrap(app)
+        let pinned = app.buttons.matching(NSPredicate(format: "label BEGINSWITH %@", "simple,")).firstMatch
+        XCTAssertTrue(pinned.waitForExistence(timeout: 5), "Pinned repository did not appear")
+        XCTAssertTrue(app.staticTexts["Pinned"].exists)
+
+        app.buttons["Remove Pin"].firstMatch.click()
+
+        XCTAssertTrue(app.staticTexts["Pinned"].waitForNonExistence(timeout: 5), "Unpinning left the Pinned section")
+        XCTAssertTrue(pinned.waitForExistence(timeout: 5), "Unpinned repository vanished instead of joining Recent")
+    }
+}


### PR DESCRIPTION
The repository list stacked the hero, Pinned, and Recent in one 480pt column, so with many repositories most of them sat below the fold. Both shells now show Recent Repositories in a side panel with its Clear button, while the detail keeps today's hero and Pinned cards. The detail holds the old single-column width, so hiding the panel widens the margins rather than the cards.

SwiftUI uses a split view with the system sidebar toggle; its visibility persists in a new setting, and the default window grows to 760×600 while the minimum stays 480 for the hidden state. GPUI draws the panel beside a centered detail, with the toggle leading the window like the sidebar button, and persists the choice in the layout config. The panel slides open and closed over 180ms, honoring reduce-motion, and it shows whenever it is preferred: a narrow window compresses the detail instead of hiding the panel, since resizing the window is not something a tiling compositor allows. Both command palettes gain a Repository List item, which neither had.

Editing the list no longer flashes in GPUI. The window redrew every list change with flat rows while the background regroup ran, so nested workspaces popped out and back in on each remove or unpin. RepoListGroups::with_entries re-lists the new entries with the nesting already known, and the regroup only changes what actually moved.

Unpinning no longer loses a repository: pinned entries were hidden from Recent but still aged out of its 12-entry cap, so unpinning an old pin left it in neither list. Unpin now puts the path back at the top of Recent in both shells, including a nested workspace, which stays under its root as a recent entry. Two bugs surfaced on the way: the shared pin store compared stored paths verbatim, so an entry that predates normalization could never be unpinned, and the SwiftUI welcome view keyed its update on the two lists concatenated, so moving a path between them in one pass never refreshed the model.

Covered by a settings unit test, core tests for the non-canonical entry and for re-listing known groups, UI scenes that hide, relaunch, and show the panel and that unpin a seeded repository into Recent, and GPUI component tests for the toggle placement, the slide, the persisted flag, the detail width, the narrow window, and unpin returning a repository to Recent.
