### PR TITLE
feat(dag): add context menus to workspace chips (#237)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -321,7 +321,7 @@
     <div>
       <span class="tag">native macOS &amp; Linux · jujutsu</span>
       <h1>The native way to<br><span class="g">drive jj.</span></h1>
-      <p class="lede">A fast, keyboard-first client for Jujutsu. The change graph, diffs, splits, and conflicts — in one window, built on jj-lib in Rust.</p>
+      <p class="lede">A fast, keyboard-friendly client for Jujutsu. The change graph, diffs, splits, and conflicts — in one window, built on jj-lib in Rust.</p>
       <div class="cta">
         <a class="btn btn-p" href="https://github.com/hewigovens/jayjay/releases/latest">
           <svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M8 2v9m0 0l-3-3m3 3l3-3M3 14h10" /></svg>
@@ -473,7 +473,7 @@
   <!-- Shortcuts -->
   <section class="keys" id="shortcuts">
     <div class="wrap">
-      <div class="sec-label">// keyboard-first</div>
+      <div class="sec-label">// keyboard-friendly</div>
       <h2 class="sec-h" style="margin-bottom:0">Every action reachable without the mouse.</h2>
       <div class="keys-grid">
         <div class="krow"><span>Command palette</span><kbd>⌘ ⇧ P</kbd></div>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # JayJay
 
-> JayJay is a native GUI for Jujutsu (jj) version control on macOS and Linux — DAG graph, unified and side-by-side diffs, interdiff, diff edit, evolog, bookmark diff, and one-click conflict resolution. Fast, keyboard-first, built in Rust on jj-lib, with SwiftUI on macOS and GPUI on Linux.
+> JayJay is a native GUI for Jujutsu (jj) version control on macOS and Linux — DAG graph, unified and side-by-side diffs, interdiff, diff edit, evolog, bookmark diff, and one-click conflict resolution. Fast, keyboard-friendly, built in Rust on jj-lib, with SwiftUI on macOS and GPUI on Linux.
 
 JayJay is a desktop client for [Jujutsu (jj)](https://github.com/jj-vcs/jj), the version control system that reimagines the git model with mutable history, changes instead of commits, and bookmarks instead of branches. It is free and source-available and wraps `jj-lib` directly rather than scraping the CLI. The macOS app requires macOS 26 or later. The Linux app, built on Zed's GPUI framework, shares the same Rust core, ships as an AppImage for x86_64 and aarch64 and as an Arch Linux package, and is in beta.
 

--- a/scripts/ui-test-fixtures.sh
+++ b/scripts/ui-test-fixtures.sh
@@ -333,6 +333,14 @@ fixture_dag_long() {
   )
 }
 
+fixture_picker() {
+  copy_fixture simple picker
+  (
+    cd "$fixtures/picker"
+    jj workspace add --name feature "$fixtures/picker-feature"
+  )
+}
+
 fixture_repository_stores() {
   printf '{"repositories":[]}\n' > "$fixtures/repositories-empty.json"
   printf '{"repositories":["%s"]}\n' "$fixtures/formats" > "$fixtures/repositories-pinned.json"
@@ -387,4 +395,5 @@ fixture_context_expansion
 fixture_complex
 fixture_conflict
 fixture_dag_long
+fixture_picker
 fixture_repository_stores

--- a/shell/gpui/src/repo/window/dag_row.rs
+++ b/shell/gpui/src/repo/window/dag_row.rs
@@ -16,7 +16,7 @@ use super::dag_drag::{DagDrag, DagDragGhost};
 
 const DAG_ROW_HEIGHT: f32 = 76.;
 
-pub(super) type BookmarkRightClick =
+pub(super) type ChipRightClick =
     Arc<dyn Fn(&str, &MouseDownEvent, &mut Window, &mut App) + Send + Sync + 'static>;
 
 /// Invoked when a dragged DAG reference or change is dropped onto this row.
@@ -38,7 +38,8 @@ pub(super) fn dag_row<F, FR>(
     row: DagRow<'_>,
     on_click: F,
     on_right_click: FR,
-    on_bookmark_right_click: BookmarkRightClick,
+    on_bookmark_right_click: ChipRightClick,
+    on_workspace_right_click: ChipRightClick,
     on_drop: DagDrop,
 ) -> AnyElement
 where
@@ -128,6 +129,7 @@ where
                     t,
                     bookmarks,
                     on_bookmark_right_click,
+                    on_workspace_right_click,
                 ))
                 .child(summary_line(&summary, t))
                 .child(meta_row(&change.author, t)),
@@ -141,7 +143,8 @@ fn tags_row(
     row_ix: usize,
     t: &Theme,
     bookmarks: &[BookmarkInfo],
-    on_bookmark_right_click: BookmarkRightClick,
+    on_bookmark_right_click: ChipRightClick,
+    on_workspace_right_click: ChipRightClick,
 ) -> impl IntoElement {
     let mut row = div()
         .flex()
@@ -201,12 +204,13 @@ fn tags_row(
             FONT_TAG,
         ));
     }
-    for ws in change.workspaces.iter().take(3) {
-        row = row.child(capsule(
-            format!("{ws}@"),
-            t.tag_wc_bg,
-            t.tag_wc_fg,
-            FONT_TAG,
+    for (w_ix, ws) in change.workspaces.iter().take(3).enumerate() {
+        row = row.child(workspace_chip(
+            row_ix,
+            w_ix,
+            ws.clone(),
+            t,
+            on_workspace_right_click.clone(),
         ));
     }
     if change.workspaces.len() > 3 {
@@ -261,7 +265,7 @@ fn bookmark_chip(
     name: String,
     conflicted: bool,
     t: &Theme,
-    on_right_click: BookmarkRightClick,
+    on_right_click: ChipRightClick,
 ) -> impl IntoElement {
     let drag_name = name.clone();
     let debug_name = name.clone();
@@ -317,6 +321,29 @@ fn working_copy_chip(row_ix: usize, t: &Theme) -> impl IntoElement {
             move |drag: &DagDrag, _offset, _w, cx| cx.new(|_| DagDragGhost::new(drag.clone())),
         )
         .child(capsule("@", t.tag_wc_bg, t.tag_wc_fg, FONT_TAG))
+}
+
+fn workspace_chip(
+    row_ix: usize,
+    w_ix: usize,
+    name: String,
+    t: &Theme,
+    on_right_click: ChipRightClick,
+) -> impl IntoElement {
+    let debug_name = name.clone();
+    div()
+        .id(("ws", row_ix * 16 + w_ix))
+        .debug_selector(move || format!("dag-workspace-{debug_name}"))
+        .child(capsule(
+            format!("{name}@"),
+            t.tag_wc_bg,
+            t.tag_wc_fg,
+            FONT_TAG,
+        ))
+        .on_mouse_down(MouseButton::Right, move |ev, w, cx| {
+            cx.stop_propagation();
+            on_right_click(&name, ev, w, cx);
+        })
 }
 
 /// A git-tag chip: neutral pill with a colored tag glyph. Non-interactive

--- a/shell/gpui/src/repo/window/mod.rs
+++ b/shell/gpui/src/repo/window/mod.rs
@@ -46,6 +46,7 @@ mod status_bar;
 mod sync;
 mod view;
 mod workspace;
+mod workspace_menu;
 
 pub use change_actions::ChangeAction;
 pub use commit_ai::CommitMessageProvider;

--- a/shell/gpui/src/repo/window/repo_switcher/rows.rs
+++ b/shell/gpui/src/repo/window/repo_switcher/rows.rs
@@ -11,6 +11,7 @@ use super::sections::{RowContent, SwitcherRow};
 use crate::app::repositories;
 use crate::app::theme::{Theme, ui_font_size};
 use crate::repo::window::picker::row;
+use crate::repo::window::workspace_menu::workspace_open_copy_items;
 use crate::repo::window::{RepoWindow, format_relative, split_prefix};
 use crate::ui::context_menu::{ContextAction, ContextMenuItem};
 use crate::ui::icons::{self, glyph};
@@ -240,25 +241,7 @@ fn workspace_context_items(
         items.push(repository_pin_item(path, cx));
         items.push(ContextMenuItem::separator());
     }
-    if !workspace.is_current && workspace.is_path_resolved {
-        items.push(ContextMenuItem::new(
-            "Open in New Window",
-            glyph::COLUMNS,
-            ContextAction::OpenWorkspaceAt(workspace.path.clone().into()),
-        ));
-    }
-    items.push(ContextMenuItem::new(
-        "Copy Workspace Name",
-        glyph::COPY,
-        ContextAction::CopyText(workspace.name.clone().into()),
-    ));
-    if workspace.is_path_resolved {
-        items.push(ContextMenuItem::new(
-            "Copy Path",
-            glyph::COPY,
-            ContextAction::CopyText(workspace.path.clone().into()),
-        ));
-    }
+    items.extend(workspace_open_copy_items(workspace));
     if !workspace.is_current {
         items.push(ContextMenuItem::new(
             "Forget",

--- a/shell/gpui/src/repo/window/sidebar.rs
+++ b/shell/gpui/src/repo/window/sidebar.rs
@@ -1,15 +1,16 @@
 use gpui::{
-    AnyElement, App, ClickEvent, Context, InteractiveElement, IntoElement, MouseDownEvent,
+    AnyElement, App, ClickEvent, Context, Entity, InteractiveElement, IntoElement, MouseDownEvent,
     ParentElement, SharedString, StatefulInteractiveElement, Styled, Window, div, px, rgb,
     uniform_list,
 };
 
 use super::RepoWindow;
 use super::dag::{DagRowLanes, dag_column};
-use super::dag_row::{BookmarkRightClick, DagDrop, DagRow, dag_row};
+use super::dag_row::{ChipRightClick, DagDrop, DagRow, dag_row};
 use super::revset_filter::revset_filter_panel;
 use crate::app::fonts;
 use crate::app::theme::{FONT_META, Theme, ui_font_size};
+use crate::ui::context_menu::ContextMenuItem;
 use crate::ui::icons::glyph;
 use crate::ui::primitives::{button, icon_button, icon_label, no_scrollbar_gutter, text_tooltip};
 
@@ -99,22 +100,13 @@ pub(super) fn sidebar(
                                 let items = view.build_change_menu(&change_for_menu, cx);
                                 view.open_context_menu(ev.position, items, cx);
                             });
-                        let view_for_bm = view_handle.clone();
                         let bookmark_rev = change.commit_id.id.clone();
-                        let on_bookmark: BookmarkRightClick = std::sync::Arc::new(
-                            move |name: &str,
-                                  ev: &MouseDownEvent,
-                                  _w: &mut Window,
-                                  cx: &mut App| {
-                                let position = ev.position;
-                                let name = name.to_owned();
-                                let rev = bookmark_rev.clone();
-                                view_for_bm.update(cx, |view, cx| {
-                                    let items = view.build_bookmark_menu(&name, Some(&rev), cx);
-                                    view.open_context_menu(position, items, cx);
-                                });
-                            },
-                        );
+                        let on_bookmark = chip_menu(view_handle.clone(), move |view, name, cx| {
+                            view.build_bookmark_menu(name, Some(&bookmark_rev), cx)
+                        });
+                        let on_workspace = chip_menu(view_handle.clone(), |view, name, cx| {
+                            view.build_workspace_chip_menu(name, cx)
+                        });
                         let view_for_drop = view_handle.clone();
                         let drop_target = change.clone();
                         let on_drop: DagDrop =
@@ -162,6 +154,7 @@ pub(super) fn sidebar(
                             on_click,
                             on_right_click,
                             on_bookmark,
+                            on_workspace,
                             on_drop,
                         )
                     })
@@ -342,4 +335,19 @@ fn load_more_button(loading: bool, t: &Theme, cx: &mut Context<RepoWindow>) -> A
             .on_click(cx.listener(|view, _: &ClickEvent, _w, cx| view.load_more(cx)));
     }
     button.into_any_element()
+}
+
+fn chip_menu(
+    view: Entity<RepoWindow>,
+    build: impl Fn(&RepoWindow, &str, &App) -> Vec<ContextMenuItem> + Send + Sync + 'static,
+) -> ChipRightClick {
+    std::sync::Arc::new(
+        move |name: &str, ev: &MouseDownEvent, _w: &mut Window, cx: &mut App| {
+            let position = ev.position;
+            view.update(cx, |view, cx| {
+                let items = build(view, name, cx);
+                view.open_context_menu(position, items, cx);
+            });
+        },
+    )
 }

--- a/shell/gpui/src/repo/window/workspace_menu.rs
+++ b/shell/gpui/src/repo/window/workspace_menu.rs
@@ -1,0 +1,44 @@
+use gpui::App;
+use jayjay_core::WorkspaceInfo;
+
+use super::RepoWindow;
+use crate::ui::context_menu::{ContextAction, ContextMenuItem};
+use crate::ui::icons::glyph;
+
+pub(super) fn workspace_open_copy_items(workspace: &WorkspaceInfo) -> Vec<ContextMenuItem> {
+    let mut items = Vec::new();
+    if !workspace.is_current && workspace.is_path_resolved {
+        items.push(ContextMenuItem::new(
+            "Open in New Window",
+            glyph::COLUMNS,
+            ContextAction::OpenWorkspaceAt(workspace.path.clone().into()),
+        ));
+    }
+    items.push(ContextMenuItem::new(
+        "Copy Workspace Name",
+        glyph::COPY,
+        ContextAction::CopyText(workspace.name.clone().into()),
+    ));
+    if workspace.is_path_resolved {
+        items.push(ContextMenuItem::new(
+            "Copy Path",
+            glyph::COPY,
+            ContextAction::CopyText(workspace.path.clone().into()),
+        ));
+    }
+    items
+}
+
+impl RepoWindow {
+    /// No menu when the listing has no workspace of that name; a chip carries only the name.
+    pub(super) fn build_workspace_chip_menu(&self, name: &str, cx: &App) -> Vec<ContextMenuItem> {
+        self.vm
+            .read(cx)
+            .graph
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.name == name)
+            .map(workspace_open_copy_items)
+            .unwrap_or_default()
+    }
+}

--- a/shell/gpui/tests/gpui/repo_workspaces.rs
+++ b/shell/gpui/tests/gpui/repo_workspaces.rs
@@ -1,5 +1,5 @@
 use crate::harness::*;
-use gpui::{AppContext, Entity, TestAppContext};
+use gpui::{AppContext, Entity, Modifiers, MouseButton, TestAppContext, VisualContext};
 use jayjay_gpui::repo::RepoWindow;
 use jj_test::{LinearFixture, run_jj_in};
 
@@ -156,4 +156,96 @@ fn create_workspace_without_open_repo_shows_toast(cx: &mut TestAppContext) {
         assert!(!view.has_text_modal(), "no modal without an open repo");
         assert_eq!(view.toast().as_deref(), Some("Repository is not open"));
     });
+}
+
+#[gpui::test]
+fn workspace_chip_menu_acts_on_that_workspace(cx: &mut TestAppContext) {
+    let fixture = LinearFixture::build();
+    let workspace_path = fixture
+        .path
+        .parent()
+        .expect("fixture parent")
+        .join("feature-chip");
+    run_jj_in(
+        &fixture.path,
+        &[
+            "workspace",
+            "add",
+            "--name",
+            "feature-chip",
+            workspace_path.to_str().expect("workspace path UTF-8"),
+        ],
+    );
+    let (view, repo_cx) = open_repo(fixture.path.clone(), cx);
+    repo_cx.focus(&view);
+
+    let chip = repo_cx
+        .debug_bounds("dag-workspace-feature-chip")
+        .expect("workspace chip");
+    repo_cx.simulate_mouse_down(chip.center(), MouseButton::Right, Modifiers::default());
+    settle_visual(repo_cx);
+    assert!(
+        repo_cx
+            .debug_bounds("context-menu-Open in New Window")
+            .is_some()
+    );
+    assert!(
+        repo_cx
+            .debug_bounds("context-menu-Copy Workspace Name")
+            .is_some()
+    );
+    assert!(
+        repo_cx
+            .debug_bounds("context-menu-New change on top")
+            .is_none(),
+        "chip menu must not open the change menu"
+    );
+    let copy_path = repo_cx
+        .debug_bounds("context-menu-Copy Path")
+        .expect("copy path item");
+    repo_cx.simulate_click(copy_path.center(), Modifiers::default());
+    let listed_path = view.read_with(repo_cx, |view, cx| {
+        view.view_model()
+            .read(cx)
+            .graph
+            .workspaces
+            .iter()
+            .find(|workspace| workspace.name == "feature-chip")
+            .expect("listed workspace")
+            .path
+            .clone()
+    });
+    assert_eq!(
+        repo_cx
+            .cx
+            .read_from_clipboard()
+            .and_then(|item| item.text()),
+        Some(listed_path)
+    );
+
+    view.update_in(repo_cx, |view, _, cx| {
+        view.view_model().update(cx, |vm, _| {
+            let workspace = std::sync::Arc::make_mut(&mut vm.graph.workspaces)
+                .iter_mut()
+                .find(|workspace| workspace.name == "feature-chip")
+                .unwrap();
+            workspace.is_path_resolved = false;
+        });
+    });
+    let chip = repo_cx
+        .debug_bounds("dag-workspace-feature-chip")
+        .expect("workspace chip");
+    repo_cx.simulate_mouse_down(chip.center(), MouseButton::Right, Modifiers::default());
+    settle_visual(repo_cx);
+    assert!(
+        repo_cx
+            .debug_bounds("context-menu-Copy Workspace Name")
+            .is_some()
+    );
+    assert!(
+        repo_cx
+            .debug_bounds("context-menu-Open in New Window")
+            .is_none()
+    );
+    assert!(repo_cx.debug_bounds("context-menu-Copy Path").is_none());
 }

--- a/shell/mac/Sources/JayJay/Repo/ContentView/RepoContentView+Sidebar.swift
+++ b/shell/mac/Sources/JayJay/Repo/ContentView/RepoContentView+Sidebar.swift
@@ -65,6 +65,8 @@ extension RepoContentView {
                 onOpenPRForBookmark: { viewModel.openPR(bookmark: $0) },
                 onDeleteBookmark: { viewModel.removeBookmark(name: $0, fromRev: $1) },
                 conflictedBookmarkNames: viewModel.conflictedBookmarkNames,
+                workspacesByName: viewModel.workspacesByName,
+                onOpenWorkspace: { windowManager.openRepo($0.path) },
                 onAbandon: { requestAbandon($0) },
                 onAbandonSelection: { requestAbandonSelection($0) },
                 onSquashSelection: { requestSquashSelection($0) },

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGRow+Refs.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGRow+Refs.swift
@@ -32,8 +32,7 @@ extension DAGRow {
                     .help(change.tags.joined(separator: ", "))
             }
             ForEach(change.workspaces.prefix(3), id: \.self) {
-                tag("\($0)@", tint: .accentColor.opacity(0.10))
-                    .help("Working copy of the \($0) workspace")
+                workspaceChip($0)
             }
             if change.workspaces.count > 3 {
                 tag("+\(change.workspaces.count - 3)", tint: .primary.opacity(0.05))
@@ -112,6 +111,20 @@ extension DAGRow {
                 .onChanged { onBookmarkDragChanged?(name, change.commitId.id, $0) }
                 .onEnded { onBookmarkDragEnded?(name, $0) }
         )
+    }
+
+    @ViewBuilder
+    private func workspaceChip(_ name: String) -> some View {
+        let chip = tag("\(name)@", tint: .accentColor.opacity(0.10))
+            .help("Working copy of the \(name) workspace")
+            .accessibilityLabel("Workspace \(name)")
+        if let workspace = workspacesByName[name] {
+            chip.contextMenu {
+                WorkspaceMenuItems(workspace: workspace) { onOpenWorkspace?(workspace) }
+            }
+        } else {
+            chip
+        }
     }
 
     private func gitTag(_ name: String) -> some View {

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGRow.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGRow.swift
@@ -11,6 +11,8 @@ struct DAGRow: View {
     var onOpenPRForBookmark: ((String) -> Void)?
     var onDeleteBookmark: ((String) -> Void)?
     var conflictedBookmarkNames: Set<String> = []
+    var workspacesByName: [String: WorkspaceInfo] = [:]
+    var onOpenWorkspace: ((WorkspaceInfo) -> Void)?
     var onBookmarkDragChanged: ((String, String, DragGesture.Value) -> Void)?
     var onBookmarkDragEnded: ((String, DragGesture.Value) -> Void)?
 

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGView.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGView.swift
@@ -18,6 +18,8 @@ struct DAGView: View {
     var onOpenPRForBookmark: ((String) -> Void)?
     var onDeleteBookmark: ((String, String) -> Void)?
     var conflictedBookmarkNames: Set<String> = []
+    var workspacesByName: [String: WorkspaceInfo] = [:]
+    var onOpenWorkspace: ((WorkspaceInfo) -> Void)?
     var onAbandon: ((String) -> Void)?
     var onAbandonSelection: (([String]) -> Void)?
     var onSquashSelection: (([String]) -> Void)?
@@ -57,6 +59,8 @@ struct DAGView: View {
         onOpenPRForBookmark: ((String) -> Void)? = nil,
         onDeleteBookmark: ((String, String) -> Void)? = nil,
         conflictedBookmarkNames: Set<String> = [],
+        workspacesByName: [String: WorkspaceInfo] = [:],
+        onOpenWorkspace: ((WorkspaceInfo) -> Void)? = nil,
         onAbandon: ((String) -> Void)? = nil,
         onAbandonSelection: (([String]) -> Void)? = nil,
         onSquashSelection: (([String]) -> Void)? = nil,
@@ -80,6 +84,8 @@ struct DAGView: View {
         self.onOpenPRForBookmark = onOpenPRForBookmark
         self.onDeleteBookmark = onDeleteBookmark
         self.conflictedBookmarkNames = conflictedBookmarkNames
+        self.workspacesByName = workspacesByName
+        self.onOpenWorkspace = onOpenWorkspace
         self.onAbandon = onAbandon
         self.onAbandonSelection = onAbandonSelection
         self.onSquashSelection = onSquashSelection
@@ -133,6 +139,8 @@ struct DAGView: View {
                                         onDeleteBookmark?(name, entry.change.commitId.id)
                                     },
                                     conflictedBookmarkNames: conflictedBookmarkNames,
+                                    workspacesByName: workspacesByName,
+                                    onOpenWorkspace: onOpenWorkspace,
                                     onBookmarkDragChanged: { name, sourceCommitId, value in
                                         handleBookmarkDragChanged(
                                             name: name,

--- a/shell/mac/Sources/JayJay/Repo/RepoTitlePicker.swift
+++ b/shell/mac/Sources/JayJay/Repo/RepoTitlePicker.swift
@@ -143,21 +143,9 @@ struct RepoTitlePicker: View {
             pinButton(path: path)
             Divider()
         }
-        if !workspace.isCurrent, workspace.isPathResolved {
-            Button("Open in New Window") {
-                panel.dismiss()
-                deferred { onOpenWorkspace(workspace) }
-            }
-        }
-        Button("Copy Workspace Name") {
-            NSPasteboard.general.clearContents()
-            NSPasteboard.general.setString(workspace.name, forType: .string)
-        }
-        if workspace.isPathResolved {
-            Button("Copy Path") {
-                NSPasteboard.general.clearContents()
-                NSPasteboard.general.setString(workspace.path, forType: .string)
-            }
+        WorkspaceMenuItems(workspace: workspace) {
+            panel.dismiss()
+            deferred { onOpenWorkspace(workspace) }
         }
         if !workspace.isCurrent {
             Divider()

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
@@ -27,6 +27,10 @@ final class RepoViewModel: ChangeActions, DAGActions, BookmarkActions {
     var compareToId: String?
     var compareDisplay: CompareDisplay?
     var bookmarks: [BookmarkInfo] = []
+    var workspacesByName: [String: WorkspaceInfo] {
+        Dictionary(uniqueKeysWithValues: workspaces.map { ($0.name, $0) })
+    }
+
     var conflictedBookmarkNames: Set<String> {
         Set(bookmarks.filter(\.isConflicted).map(\.name))
     }

--- a/shell/mac/Sources/JayJay/Repo/Workspaces/WorkspaceMenuItems.swift
+++ b/shell/mac/Sources/JayJay/Repo/Workspaces/WorkspaceMenuItems.swift
@@ -1,0 +1,27 @@
+import AppKit
+import JayJayCore
+import SwiftUI
+
+struct WorkspaceMenuItems: View {
+    let workspace: WorkspaceInfo
+    let onOpen: () -> Void
+
+    var body: some View {
+        if !workspace.isCurrent, workspace.isPathResolved {
+            Button("Open in New Window", action: onOpen)
+        }
+        Button("Copy Workspace Name") {
+            copy(workspace.name)
+        }
+        if workspace.isPathResolved {
+            Button("Copy Path") {
+                copy(workspace.path)
+            }
+        }
+    }
+
+    private func copy(_ value: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(value, forType: .string)
+    }
+}

--- a/shell/mac/Tests/JayJayTests/RepoViewModelTests.swift
+++ b/shell/mac/Tests/JayJayTests/RepoViewModelTests.swift
@@ -71,6 +71,16 @@ final class RepoViewModelTests: RepoViewModelTestCase {
         XCTAssertEqual(viewModel.commitDescriptionDraft, "Updated details")
     }
 
+    func testCleanBoxClearsWhenWorkingCopyMovesToEmptyChange() throws {
+        let viewModel = try XCTUnwrap(viewModel)
+        viewModel.applyWorkingCopy(changeId: "old", description: "Described summary\n\nDescribed details")
+
+        viewModel.applyWorkingCopy(changeId: "new", description: "")
+
+        XCTAssertEqual(viewModel.commitSummaryDraft, "")
+        XCTAssertEqual(viewModel.commitDescriptionDraft, "")
+    }
+
     func testNewChangeClearsCommitBox() async throws {
         let viewModel = try XCTUnwrap(viewModel)
         viewModel.commitSummaryDraft = "Previous summary"

--- a/shell/mac/Tests/JayJayUITests/Scenes/RepositoryPickerPinningScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/RepositoryPickerPinningScene.swift
@@ -1,13 +1,18 @@
+import AppKit
 import XCTest
 
 final class RepositoryPickerPinningScene: SceneBase {
+    override class var fixtureName: String {
+        "picker"
+    }
+
     override class var repositoryStoreFixtureName: String {
         "repositories-picker-pinning.json"
     }
 
     func testPinCurrentRepositoryAndUnpinClosedRepository() throws {
         let app = try XCTUnwrap(app)
-        let repoWindow = app.windows["simple"]
+        let repoWindow = app.windows["picker"]
         let currentPath = try XCTUnwrap(fixtureURL).resolvingSymlinksInPath().path
         XCTAssertTrue(repoWindow.waitForExistence(timeout: 5))
 
@@ -41,6 +46,26 @@ final class RepositoryPickerPinningScene: SceneBase {
         XCTAssertTrue(closedRow.waitForNonExistence(timeout: 5))
         openRepositoryTitlePicker(in: repoWindow)
         XCTAssertFalse(closedRow.exists)
+        keyStroke(.escape)
+        XCTAssertEqual(app.windows.count, 1)
+    }
+
+    func testWorkspaceRowMenuCopiesWorkspacePath() throws {
+        let app = try XCTUnwrap(app)
+        let repoWindow = app.windows["picker"]
+        XCTAssertTrue(repoWindow.waitForExistence(timeout: 5))
+
+        openRepositoryTitlePicker(in: repoWindow)
+        let row = app.descendants(matching: .any)[AID.Picker.row("ws-feature")].firstMatch
+        XCTAssertTrue(row.waitForExistence(timeout: 5), "feature workspace row missing")
+        row.rightClick()
+        XCTAssertTrue(app.menuItems["Open in New Window"].waitForExistence(timeout: 3), "\"Open in New Window\" menu item missing")
+        NSPasteboard.general.clearContents()
+        app.menuItems["Copy Path"].click()
+
+        let expected = Self.fixtureRoot.appendingPathComponent("picker-feature").resolvingSymlinksInPath().path
+        let copied = try XCTUnwrap(NSPasteboard.general.string(forType: .string), "nothing copied")
+        XCTAssertEqual(URL(fileURLWithPath: copied).resolvingSymlinksInPath().path, expected)
         keyStroke(.escape)
         XCTAssertEqual(app.windows.count, 1)
     }


### PR DESCRIPTION
Right-clicking a workspace chip in the DAG offers Open in New Window, Copy Workspace Name, and Copy Path, with the same items and availability rules as the workspace picker; both shells now build those items from one shared list. The picker XCUITest scene gains a fixture with a second workspace and covers the shared menu through the workspace row.

Also adds the regression test for the commit box clearing after an external jj new (#187) and describes the app as keyboard-friendly rather than keyboard-first on the site.

Closes #237.