### PR TITLE
ci(mac): build the UI test bundle once and run the shards without compiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,8 @@ jobs:
       - name: Test app
         run: just test-app
 
-  swift-ui:
-    name: swift-ui (${{ matrix.shard }}/3)
+  swift-ui-build:
     runs-on: macos-26
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -95,7 +90,7 @@ jobs:
           toolchain: stable
 
       - name: Install tools
-        run: brew install just xcodegen xcbeautify jj
+        run: brew install just xcodegen xcbeautify
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
@@ -103,11 +98,43 @@ jobs:
           shared-key: swift
           save-if: false
 
-      - name: Build app
-        run: just build
+      - name: Build app and UI test bundle
+        run: just shell::ui-test-build
+
+      # upload-artifact drops file modes, so the bundles travel as a tarball.
+      - name: Pack build products
+        run: tar -C build/DerivedData/Build -czf ui-test-products.tgz Products
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ui-test-products
+          path: ui-test-products.tgz
+          retention-days: 1
+          if-no-files-found: error
+
+  swift-ui:
+    name: swift-ui (${{ matrix.shard }}/3)
+    needs: swift-ui-build
+    runs-on: macos-26
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install tools
+        run: brew install just xcbeautify jj
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ui-test-products
+
+      - name: Unpack build products
+        run: mkdir -p build/DerivedData/Build && tar -C build/DerivedData/Build -xzf ui-test-products.tgz
 
       - name: UI tests
-        run: just test-ui-shard ${{ matrix.shard }} 3
+        run: just test-ui-shard ${{ matrix.shard }} 3 shell::ui-test-prebuilt
 
       - name: Upload xcresult on failure
         if: failure()

--- a/justfile
+++ b/justfile
@@ -53,13 +53,13 @@ test-app:
 test-ui *test_ids:
   just shell::ui-test {{test_ids}}
 
-# Run every count-th UI scene class starting at index (1-based), so CI can split the serial XCUITest bundle across runners.
-test-ui-shard index count:
+# Run every count-th UI scene class starting at index (1-based), so CI can split the serial XCUITest bundle across runners; `recipe` selects the shell runner (ui-test builds, ui-test-prebuilt reuses a ui-test-build output).
+test-ui-shard index count recipe="shell::ui-test":
   #!/usr/bin/env bash
   set -euo pipefail
   scenes=$(grep -hoE '^final class [A-Za-z0-9_]+' "{{justfile_directory()}}/shell/mac/Tests/JayJayUITests/Scenes/"*.swift \
     | awk '{print "JayJayUITests/" $3}' | sort | awk -v i="{{index}}" -v n="{{count}}" 'NR % n == i % n')
-  just shell::ui-test $scenes
+  just {{recipe}} $scenes
 
 test-gpui:
   just shell::gpui-test

--- a/shell/justfile
+++ b/shell/justfile
@@ -151,6 +151,31 @@ ui-test *test_ids: ffi sync-icon help ui-test-setup
   done
   xcodebuild "${args[@]}" test | xcbeautify
 
+# Build the app and the UI test bundle once; CI shards run them with ui-test-prebuilt.
+ui-test-build: build
+  xcodebuild \
+    -project "{{project}}/JayJay.xcodeproj" \
+    -scheme JayJayUITests \
+    -configuration Debug \
+    -sdk macosx \
+    -derivedDataPath "{{derived_data}}" \
+    build-for-testing | xcbeautify
+
+# Run UI tests from a ui-test-build output without compiling; test ids narrow the run like ui-test.
+ui-test-prebuilt *test_ids: ui-test-setup
+  #!/usr/bin/env bash
+  set -euo pipefail
+  xctestrun=$(ls "{{derived_data}}"/Build/Products/JayJayUITests_*.xctestrun | head -1)
+  args=(
+    -xctestrun "$xctestrun"
+    -destination "platform=macOS"
+    -derivedDataPath "{{derived_data}}"
+  )
+  for test_id in {{test_ids}}; do
+    args+=(-only-testing:"$test_id")
+  done
+  xcodebuild "${args[@]}" test-without-building | xcbeautify
+
 reset-help-cache:
   #!/usr/bin/env bash
   set -euo pipefail


### PR DESCRIPTION
Each swift-ui shard rebuilt the FFI, the CLI, and the app before testing, so a run built the app four times. A swift-ui-build job now runs build-for-testing once, ships the Products directory as a tarball (upload-artifact drops file modes), and the three shards run test-without-building from its xctestrun. test-ui-shard takes the shell recipe as a parameter so local runs keep building.

Verified locally: build-for-testing plus test-without-building runs a UI scene from the generated xctestrun; the just recipes were dry-run; YAML parsed. The CI run on this PR is the end-to-end proof.