### PR TITLE
fix(mac): auto-size descriptions with expand and collapse

### DIFF
--- a/scripts/ui-test-fixtures.sh
+++ b/scripts/ui-test-fixtures.sh
@@ -48,6 +48,23 @@ fixture_simple() {
   )
 }
 
+fixture_description_height() {
+  copy_fixture simple description-height
+  (
+    cd "$fixtures/description-height"
+    jj describe -r 'subject("initial")' -m "short description"
+    jj describe -r 'subject("add hello")' -m $'multiline description\n\nFirst detail line.\nSecond detail line.\nThird detail line.'
+    local body=""
+    for n in $(seq 1 24); do
+      body+=$'\n'"Detail line $n."
+    done
+    jj describe -r 'subject("add feature")' -m "long description$body"
+    jj describe -m "wrapped description $(printf 'This paragraph wraps to fit the available width. %.0s' {1..30})"
+    jj new -m "editable description"
+    jj new
+  )
+}
+
 fixture_external_tools() {
   local root="$fixtures/external-tool"
   mkdir -p "$root/diff-left" "$root/diff-right" "$root/edit-left" "$root/edit-right"
@@ -383,6 +400,7 @@ rm -rf "$fixtures"
 mkdir -p "$fixtures"
 fixture_simple
 fixture_mutating_scenes
+fixture_description_height
 fixture_external_tools
 fixture_sync_cancel
 fixture_bookmark_diff

--- a/shell/mac/Sources/JayJay/Detail/ChangeDetailView+PreviewColumn.swift
+++ b/shell/mac/Sources/JayJay/Detail/ChangeDetailView+PreviewColumn.swift
@@ -41,12 +41,13 @@ extension ChangeDetailView {
             VStack(alignment: .leading, spacing: 12) {
                 if !isCompareMode {
                     headerSection
-                    descriptionSection(resizeIndicatorOverflow: Self.previewHorizontalPadding)
+                    descriptionSection()
                 }
             }
             .padding(.horizontal, Self.previewHorizontalPadding)
             .padding(.top, isCompareMode ? 4 : 14)
             .padding(.bottom, 8)
+            .layoutPriority(1)
             .zIndex(1)
 
             Divider()

--- a/shell/mac/Sources/JayJay/Detail/DetailDescription.swift
+++ b/shell/mac/Sources/JayJay/Detail/DetailDescription.swift
@@ -2,15 +2,13 @@ import JayJayCore
 import SwiftUI
 
 extension ChangeDetailView {
-    func descriptionSection(resizeIndicatorOverflow: CGFloat = 0) -> some View {
+    func descriptionSection() -> some View {
         DetailDescriptionSection(
             description: detail.info.description,
             descriptionText: $descriptionText,
             editingDescription: $editingDescription,
             canEditDescription: !detail.info.isWorkingCopy,
             canShowDiffEditButton: canShowDiffEditButton,
-            changeKey: detailRevision,
-            resizeIndicatorOverflow: resizeIndicatorOverflow,
             onSave: { onDescribe(detailRevision, $0) },
             onOpenDiffEdit: { paneMode = .diffEdit }
         )
@@ -32,9 +30,8 @@ extension ChangeDetailView {
 
 private struct DetailDescriptionSection: View {
     private enum Metrics {
-        static let compactHeight: CGFloat = 32
         static let minimumHeight: CGFloat = 24
-        static let maximumHeight: CGFloat = 180
+        static let collapsedMaximumHeight: CGFloat = 180
         static let editingMinimumHeight: CGFloat = 80
     }
 
@@ -43,68 +40,33 @@ private struct DetailDescriptionSection: View {
     @Binding var editingDescription: Bool
     let canEditDescription: Bool
     let canShowDiffEditButton: Bool
-    let changeKey: String
-    let resizeIndicatorOverflow: CGFloat
     let onSave: (String) -> Void
     let onOpenDiffEdit: () -> Void
 
-    /// Per-change description heights, so switching changes keeps the user's size
-    /// instead of snapping back to the default.
-    private static var heightByChange: [String: CGFloat] = [:]
-
-    @State private var descriptionHeight: CGFloat
-    @GestureState private var resizeTranslation: CGFloat = 0
-
-    init(
-        description: String,
-        descriptionText: Binding<String>,
-        editingDescription: Binding<Bool>,
-        canEditDescription: Bool,
-        canShowDiffEditButton: Bool,
-        changeKey: String,
-        resizeIndicatorOverflow: CGFloat,
-        onSave: @escaping (String) -> Void,
-        onOpenDiffEdit: @escaping () -> Void
-    ) {
-        self.description = description
-        _descriptionText = descriptionText
-        _editingDescription = editingDescription
-        self.canEditDescription = canEditDescription
-        self.canShowDiffEditButton = canShowDiffEditButton
-        self.changeKey = changeKey
-        self.resizeIndicatorOverflow = resizeIndicatorOverflow
-        self.onSave = onSave
-        self.onOpenDiffEdit = onOpenDiffEdit
-        _descriptionHeight = State(initialValue: Self.heightByChange[changeKey] ?? Metrics.compactHeight)
-    }
+    @State private var contentHeight: CGFloat = 0
+    @State private var isExpanded = false
 
     private var isEditingDescription: Bool {
         canEditDescription && editingDescription
     }
 
-    private var visibleDescriptionHeight: CGFloat {
-        let minimum = isEditingDescription ? Metrics.editingMinimumHeight : Metrics.minimumHeight
-        let baseHeight = isEditingDescription ? max(descriptionHeight, Metrics.editingMinimumHeight) : descriptionHeight
-        return clampedDescriptionHeight(baseHeight, minimum: minimum)
-    }
-
-    private var previewDescriptionHeight: CGFloat {
-        clampedDescriptionHeight(visibleDescriptionHeight + resizeTranslation, minimum: minimumDescriptionHeight)
-    }
-
-    private var minimumDescriptionHeight: CGFloat {
+    private var minimumHeight: CGFloat {
         isEditingDescription ? Metrics.editingMinimumHeight : Metrics.minimumHeight
     }
 
-    private var resizePreviewOffset: CGFloat {
-        previewDescriptionHeight - visibleDescriptionHeight
+    private var descriptionHeight: CGFloat {
+        let height = max(contentHeight, minimumHeight)
+        return isExpanded ? height : min(height, Metrics.collapsedMaximumHeight)
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             descriptionHeader
-            descriptionBody
+            if isEditingDescription || !description.isEmpty {
+                descriptionBody
+            }
         }
+        .layoutPriority(1)
     }
 
     private var descriptionHeader: some View {
@@ -126,7 +88,6 @@ private struct DetailDescriptionSection: View {
             } else if canEditDescription {
                 Button {
                     editingDescription = true
-                    descriptionHeight = max(descriptionHeight, Metrics.editingMinimumHeight)
                 } label: {
                     Label("Edit", systemImage: "pencil")
                         .labelStyle(.titleAndIcon)
@@ -134,6 +95,21 @@ private struct DetailDescriptionSection: View {
                 .buttonStyle(.plain)
                 .foregroundStyle(.secondary)
                 .help("Edit message")
+            }
+            if contentHeight > Metrics.collapsedMaximumHeight, isEditingDescription || !description.isEmpty {
+                Button {
+                    isExpanded.toggle()
+                } label: {
+                    Label(
+                        isExpanded ? "Collapse description" : "Expand description",
+                        systemImage: isExpanded ? "chevron.up" : "chevron.down"
+                    )
+                    .labelStyle(.iconOnly)
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .help(isExpanded ? "Collapse description" : "Expand description")
+                .accessibilityIdentifier(AID.Detail.descriptionExpansion)
             }
             Spacer()
             if canShowDiffEditButton {
@@ -146,73 +122,43 @@ private struct DetailDescriptionSection: View {
         }
     }
 
-    @ViewBuilder
     private var descriptionBody: some View {
-        if isEditingDescription {
-            VStack(spacing: 2) {
+        ScrollView {
+            // The zero-width space measures the editor's last empty line, including the insertion point after a trailing newline.
+            Text(isEditingDescription ? descriptionText + "\u{200B}" : description)
+                .jayjayFont(13, design: .monospaced)
+                .textSelection(.enabled)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, isEditingDescription ? 5 : 0)
+                .onGeometryChange(for: CGFloat.self) { geometry in
+                    ceil(geometry.size.height)
+                } action: { height in
+                    contentHeight = height
+                    if height <= Metrics.collapsedMaximumHeight {
+                        isExpanded = false
+                    }
+                }
+        }
+        .opacity(isEditingDescription ? 0 : 1)
+        .accessibilityHidden(isEditingDescription)
+        .accessibilityIdentifier(AID.Detail.description)
+        .overlay {
+            if isEditingDescription {
                 TextEditor(text: $descriptionText)
                     .jayjayFont(13, design: .monospaced)
-                    .frame(height: visibleDescriptionHeight)
                     .scrollContentBackground(.hidden)
-                    .padding(6)
-                    .background(Color.primary.opacity(0.04), in: RoundedRectangle(cornerRadius: 8))
-                    .overlay(RoundedRectangle(cornerRadius: 8).stroke(Color.primary.opacity(0.1)))
-                descriptionResizeHandle
-            }
-        } else if !description.isEmpty {
-            VStack(spacing: 2) {
-                ScrollView {
-                    Text(description)
-                        .jayjayFont(13, design: .monospaced)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .frame(height: visibleDescriptionHeight)
-                descriptionResizeHandle
+                    .accessibilityIdentifier(AID.Detail.descriptionEditor)
             }
         }
-    }
-
-    private var descriptionResizeHandle: some View {
-        ZStack {
-            Capsule()
-                .fill(Color.accentColor.opacity(resizeTranslation == 0 ? 0 : 0.45))
-                .frame(height: 2)
-                .padding(.horizontal, -resizeIndicatorOverflow)
-                .offset(y: resizePreviewOffset)
-                .opacity(resizeTranslation == 0 ? 0 : 1)
-
-            Capsule()
-                .fill(Color.secondary.opacity(0.35))
-                .frame(width: 36, height: 3)
-                .offset(y: resizePreviewOffset)
+        .frame(minHeight: minimumHeight, idealHeight: descriptionHeight, maxHeight: descriptionHeight)
+        .padding(isEditingDescription ? 6 : 0)
+        .background {
+            if isEditingDescription {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.primary.opacity(0.04))
+                    .stroke(Color.primary.opacity(0.1))
+            }
         }
-        .frame(maxWidth: .infinity, minHeight: 10)
-        .contentShape(Rectangle())
-        .gesture(descriptionResizeGesture)
-        .help("Resize description")
-    }
-
-    private var descriptionResizeGesture: some Gesture {
-        DragGesture(minimumDistance: 1)
-            .updating($resizeTranslation) { value, state, transaction in
-                transaction.disablesAnimations = true
-                state = value.translation.height
-            }
-            .onEnded { value in
-                var transaction = Transaction()
-                transaction.disablesAnimations = true
-                withTransaction(transaction) {
-                    descriptionHeight = clampedDescriptionHeight(
-                        visibleDescriptionHeight + value.translation.height,
-                        minimum: minimumDescriptionHeight
-                    )
-                }
-                Self.heightByChange[changeKey] = descriptionHeight
-            }
-    }
-
-    private func clampedDescriptionHeight(_ height: CGFloat, minimum: CGFloat) -> CGFloat {
-        min(max(height, minimum), Metrics.maximumHeight)
     }
 }

--- a/shell/mac/Sources/JayJay/Shared/AccessibilityIdentifiers.swift
+++ b/shell/mac/Sources/JayJay/Shared/AccessibilityIdentifiers.swift
@@ -70,6 +70,9 @@ enum AID {
     }
 
     enum Detail {
+        static let description = "detail.description"
+        static let descriptionExpansion = "detail.descriptionExpansion"
+        static let descriptionEditor = "detail.descriptionEditor"
         static let selectionWithoutDiff = "detail.selectionWithoutDiff"
 
         /// Counts are encoded in the id so UI tests assert on existence, not a11y value.

--- a/shell/mac/Tests/JayJayUITests/Scenes/DescriptionHeightScene.swift
+++ b/shell/mac/Tests/JayJayUITests/Scenes/DescriptionHeightScene.swift
@@ -1,0 +1,101 @@
+import XCTest
+
+final class DescriptionHeightScene: SceneBase {
+    override class var fixtureName: String {
+        "description-height"
+    }
+
+    func testDescriptionFitsContentAndExpandsAcrossChanges() throws {
+        let app = try XCTUnwrap(app)
+        let description = app.scrollViews[AID.Detail.description]
+        let toggle = app.buttons[AID.Detail.descriptionExpansion]
+
+        selectChange("short description", in: app)
+        let shortHeight = description.frame.height
+        XCTAssertFalse(toggle.exists)
+
+        selectChange("multiline description", in: app)
+        let multilineHeight = description.frame.height
+        XCTAssertGreaterThan(multilineHeight, shortHeight + 20)
+        XCTAssertFalse(toggle.exists)
+        XCTAssertLessThanOrEqual(description.staticTexts.firstMatch.frame.height, multilineHeight + 2)
+
+        selectChange("long description", in: app)
+        let collapsedHeight = description.frame.height
+        XCTAssertGreaterThan(collapsedHeight, multilineHeight)
+        XCTAssertGreaterThan(description.staticTexts.firstMatch.frame.height, collapsedHeight)
+        XCTAssertTrue(toggle.waitForExistence(timeout: 5))
+        toggle.click()
+        XCTAssertGreaterThan(description.frame.height, collapsedHeight + 40)
+        XCTAssertEqual(toggle.label, "Collapse description")
+        XCTAssertTrue(toggle.isHittable)
+        toggle.click()
+        XCTAssertEqual(description.frame.height, collapsedHeight, accuracy: 2)
+
+        selectChange("wrapped description", in: app)
+        XCTAssertEqual(description.frame.height, collapsedHeight, accuracy: 2)
+        toggle.click()
+        XCTAssertGreaterThan(description.frame.height, collapsedHeight + 40)
+        XCTAssertTrue(app.windows.firstMatch.frame.contains(description.frame))
+        XCTAssertTrue(toggle.isHittable)
+
+        for (message, expected) in [
+            ("short description", shortHeight),
+            ("multiline description", multilineHeight),
+            ("long description", collapsedHeight)
+        ] {
+            selectChange(message, in: app)
+            XCTAssertEqual(description.frame.height, expected, accuracy: 2)
+        }
+    }
+
+    func testDescriptionEditorFitsDraftAndSaves() throws {
+        let app = try XCTUnwrap(app)
+        selectChange("editable description", in: app)
+        app.buttons["Edit"].click()
+        let editor = app.textViews[AID.Detail.descriptionEditor]
+        XCTAssertTrue(editor.waitForExistence(timeout: 5))
+        let initialHeight = editor.frame.height
+        editor.click()
+        keyStroke("a", modifiers: [.command])
+        let draft = "updated description\n" + (1 ... 24).map { "Draft line \($0)." }.joined(separator: "\n")
+        paste(draft)
+        XCTAssertGreaterThan(editor.frame.height, initialHeight + 40)
+        let toggle = app.buttons[AID.Detail.descriptionExpansion]
+        XCTAssertTrue(toggle.waitForExistence(timeout: 5))
+        toggle.click()
+        XCTAssertTrue(app.windows.firstMatch.frame.contains(editor.frame))
+        XCTAssertTrue(app.buttons["Save"].isHittable)
+        editor.click()
+        keyStroke("a", modifiers: [.command])
+        paste("Small draft")
+        XCTAssertEqual(editor.frame.height, initialHeight, accuracy: 2)
+        XCTAssertFalse(toggle.exists)
+        app.buttons["Cancel"].click()
+        XCTAssertFalse(editor.exists)
+        XCTAssertFalse(toggle.exists)
+
+        app.buttons["Edit"].click()
+        editor.click()
+        keyStroke("a", modifiers: [.command])
+        paste(draft)
+        app.buttons["Save"].click()
+        XCTAssertFalse(editor.exists)
+        selectChange("multiline description", in: app)
+        selectChange("updated description", in: app)
+        let saved = app.scrollViews[AID.Detail.description].staticTexts.firstMatch
+        XCTAssertTrue((saved.value as? String ?? saved.label).contains("Draft line 24."))
+    }
+
+    private func selectChange(_ message: String, in app: XCUIApplication) {
+        let row = dagRows(of: app).matching(NSPredicate(format: "value CONTAINS %@", message)).firstMatch
+        XCTAssertTrue(row.waitForExistence(timeout: 10), "Change \(message) missing")
+        row.click()
+        XCTAssertTrue(
+            app.scrollViews[AID.Detail.description].staticTexts
+                .matching(NSPredicate(format: "value CONTAINS %@ OR label CONTAINS %@", message, message))
+                .firstMatch.waitForExistence(timeout: 10),
+            "Description for \(message) never loaded"
+        )
+    }
+}


### PR DESCRIPTION
Descriptions now grow to fit their wrapped contents up to 180 points. Longer messages have an expand/collapse button; expansion uses the available pane height and keeps oversized content scrollable. The editor also adjusts as its draft changes.

Remove the manual resize handle and saved pane height. Selecting a change sizes its description from the content, so multiline messages are visible without dragging the pane open.

Fixes #242.

Validation:

- `jj --config-file .jj-config.toml fix -s fix-description-height`: no changes.
- `RUSTUP_TOOLCHAIN=1.96.0 just test-ui JayJayUITests/DescriptionHeightScene`: 2 tests passed, covering automatic sizing, expand/collapse, navigation, and editing/save/cancel.
- `swiftlint lint --config .swiftlint.yml --strict --quiet`: passed.
- `RUSTUP_TOOLCHAIN=1.96.0 just lint`: blocked by existing `clippy::nonminimal_bool` errors in `shell/gpui/tests/gpui/repo_diff_context/controls.rs:133` and `sessions.rs:93`. Both files are unchanged from the base revision.
