### PR TITLE
fix(mac): stop the bookmark picker offering Delete on trunk

### DIFF
--- a/shell/mac/Sources/JayJay/Repo/Bookmarks/BookmarkPicker.swift
+++ b/shell/mac/Sources/JayJay/Repo/Bookmarks/BookmarkPicker.swift
@@ -205,12 +205,14 @@ struct BookmarkPicker: View {
             Text("No remote bookmark available")
         }
 
-        Divider()
-        Button(role: .destructive) {
-            panel.dismiss()
-            actions?.deleteBookmark(name: bookmark.name)
-        } label: {
-            Label("Delete", systemImage: "trash")
+        if canDeleteBookmark(bookmark.name, conflicted: bookmark.isConflicted) {
+            Divider()
+            Button(role: .destructive) {
+                panel.dismiss()
+                actions?.deleteBookmark(name: bookmark.name)
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
         }
     }
 

--- a/shell/mac/Sources/JayJay/Shared/TrunkBookmarks.swift
+++ b/shell/mac/Sources/JayJay/Shared/TrunkBookmarks.swift
@@ -12,3 +12,7 @@ func isTrunkBookmark(_ name: String) -> Bool {
 func canRemoveBookmarkFromChip(_ name: String, conflicted: Bool) -> Bool {
     conflicted || !isTrunkBookmark(name)
 }
+
+func canDeleteBookmark(_ name: String, conflicted: Bool) -> Bool {
+    !conflicted && !isTrunkBookmark(name)
+}

--- a/shell/mac/Tests/JayJayTests/TrunkBookmarksTests.swift
+++ b/shell/mac/Tests/JayJayTests/TrunkBookmarksTests.swift
@@ -9,4 +9,11 @@ final class TrunkBookmarksTests: XCTestCase {
         XCTAssertFalse(canRemoveBookmarkFromChip("main", conflicted: false))
         XCTAssertFalse(canRemoveBookmarkFromChip("master", conflicted: false))
     }
+
+    func testWholeBookmarkDeleteSkipsTrunkAndConflictedBookmarks() {
+        XCTAssertTrue(canDeleteBookmark("feature", conflicted: false))
+        XCTAssertFalse(canDeleteBookmark("feature", conflicted: true))
+        XCTAssertFalse(canDeleteBookmark("main", conflicted: false))
+        XCTAssertFalse(canDeleteBookmark("main@origin", conflicted: false))
+    }
 }


### PR DESCRIPTION
The picker's context menu deletes the whole bookmark, so it must not offer it for trunk names or for a conflicted bookmark whose targets are dropped per change. GPUI already applied that rule; SwiftUI showed Delete for every bookmark.