### PR TITLE
fix(dag): refuse a drag-rebase onto the change's own descendant

### DIFF
--- a/crates/jayjay-core/src/dag.rs
+++ b/crates/jayjay-core/src/dag.rs
@@ -1,10 +1,14 @@
-//! DAG lane-assignment for the jj log graph.
+//! Lane assignment for the jj log graph, plus the drag-rebase drop rule in `rebase`.
 //!
 //! Mirrors `shell/mac/Sources/JayJay/Repo/DAGLayout.swift`. Pure logic — both
 //! the SwiftUI shell (via uniffi) and the GPUI shell can render against the
 //! same lane assignments.
 
+mod rebase;
+
 use std::collections::HashMap;
+
+pub use rebase::{can_rebase_onto, descendant_commit_ids};
 
 use crate::types::{EdgeType, GraphEntry};
 
@@ -234,16 +238,18 @@ fn lane_is_compacted(lane: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{ChangeInfo, CommitAuthor, GraphEdge, ShortId};
+    use crate::types::GraphEdge;
 
-    fn entry(commit_id: &str, parents: &[&str]) -> GraphEntry {
+    pub(super) fn entry(commit_id: &str, parents: &[&str]) -> GraphEntry {
+        use crate::types::{ChangeInfo, CommitAuthor, GraphEdge, NewChangeEligibility, ShortId};
+
         GraphEntry {
             change: ChangeInfo {
                 change_id: ShortId::new(format!("change-{commit_id}"), 1),
                 commit_id: ShortId::new(commit_id.to_owned(), 1),
                 description: String::new(),
                 author: CommitAuthor::empty(0),
-                parents: parents.iter().map(|s| (*s).to_owned()).collect(),
+                parents: parents.iter().map(|id| (*id).to_owned()).collect(),
                 bookmarks: Vec::new(),
                 tags: Vec::new(),
                 workspaces: Vec::new(),
@@ -252,7 +258,7 @@ mod tests {
                 is_empty: false,
                 is_immutable: false,
                 is_divergent: false,
-                new_change: crate::types::NewChangeEligibility {
+                new_change: NewChangeEligibility {
                     on_top: true,
                     before: true,
                     after: true,
@@ -260,8 +266,8 @@ mod tests {
             },
             edges: parents
                 .iter()
-                .map(|p| GraphEdge {
-                    target: (*p).to_owned(),
+                .map(|target| GraphEdge {
+                    target: (*target).to_owned(),
                     edge_type: EdgeType::Direct,
                 })
                 .collect(),

--- a/crates/jayjay-core/src/dag/rebase.rs
+++ b/crates/jayjay-core/src/dag/rebase.rs
@@ -1,0 +1,131 @@
+use std::collections::HashSet;
+
+use crate::types::{EdgeType, GraphEntry};
+
+/// jj rejects a rebase onto a descendant, so refuse it before the confirmation sheet; self and the only parent would move nothing.
+pub fn can_rebase_onto(
+    entries: &[GraphEntry],
+    source_commit_id: &str,
+    target_commit_id: &str,
+) -> bool {
+    if source_commit_id == target_commit_id {
+        return false;
+    }
+    let Some(source) = entries
+        .iter()
+        .find(|entry| entry.change.commit_id.id == source_commit_id)
+    else {
+        return false;
+    };
+    if source.change.parents == [target_commit_id] {
+        return false;
+    }
+    !has_ancestor(entries, target_commit_id, source_commit_id)
+}
+
+/// Every visible descendant of `commit_id`; rows are in graph order (children above parents), so only the rows above it can descend from it.
+pub fn descendant_commit_ids(entries: &[GraphEntry], commit_id: &str) -> Vec<String> {
+    let Some(source) = entries
+        .iter()
+        .position(|entry| entry.change.commit_id.id == commit_id)
+    else {
+        return Vec::new();
+    };
+    let mut descendants = HashSet::from([commit_id]);
+    for entry in entries[..source].iter().rev() {
+        let reaches = entry
+            .edges
+            .iter()
+            .filter(|edge| edge.edge_type != EdgeType::Missing)
+            .any(|edge| descendants.contains(edge.target.as_str()));
+        if reaches {
+            descendants.insert(entry.change.commit_id.id.as_str());
+        }
+    }
+    descendants.remove(commit_id);
+    descendants.into_iter().map(str::to_owned).collect()
+}
+
+/// Rows are in graph order (children above parents), so a descendant sits above its ancestor and only the rows between them can connect the two.
+fn has_ancestor(entries: &[GraphEntry], commit_id: &str, ancestor_id: &str) -> bool {
+    let (mut start, mut end) = (None, None);
+    for (ix, entry) in entries.iter().enumerate() {
+        let id = entry.change.commit_id.id.as_str();
+        if id == commit_id {
+            start = Some(ix);
+        } else if id == ancestor_id {
+            end = Some(ix);
+        }
+        if start.is_some() && end.is_some() {
+            break;
+        }
+    }
+    let (Some(start), Some(end)) = (start, end) else {
+        return false;
+    };
+    if end <= start {
+        return false;
+    }
+    let mut reachable = HashSet::from([commit_id]);
+    for entry in &entries[start..end] {
+        if reachable.contains(entry.change.commit_id.id.as_str()) {
+            reachable.extend(
+                entry
+                    .edges
+                    .iter()
+                    .filter(|edge| edge.edge_type != EdgeType::Missing)
+                    .map(|edge| edge.target.as_str()),
+            );
+        }
+    }
+    reachable.contains(ancestor_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::entry;
+    use super::*;
+
+    #[test]
+    fn a_change_refuses_itself_its_only_parent_and_its_descendants() {
+        let entries = [
+            entry("a", &["b"]),
+            entry("d", &["c"]),
+            entry("b", &["c"]),
+            entry("c", &[]),
+        ];
+
+        assert!(!can_rebase_onto(&entries, "b", "b"), "self");
+        assert!(!can_rebase_onto(&entries, "b", "c"), "only parent");
+        assert!(!can_rebase_onto(&entries, "b", "a"), "descendant");
+        assert!(can_rebase_onto(&entries, "b", "d"), "sibling branch");
+    }
+
+    #[test]
+    fn descendants_are_every_row_that_leads_back_to_the_change() {
+        let entries = [
+            entry("a", &["b"]),
+            entry("d", &["c"]),
+            entry("b", &["c"]),
+            entry("c", &[]),
+        ];
+        let sorted = |id: &str| {
+            let mut ids = descendant_commit_ids(&entries, id);
+            ids.sort();
+            ids
+        };
+
+        assert_eq!(sorted("c"), ["a", "b", "d"]);
+        assert_eq!(sorted("b"), ["a"]);
+        assert!(sorted("a").is_empty());
+        assert!(sorted("missing").is_empty());
+    }
+
+    #[test]
+    fn an_indirect_descendant_is_still_refused_and_an_ancestor_is_allowed() {
+        let entries = [entry("a", &["b"]), entry("b", &["c"]), entry("c", &[])];
+
+        assert!(!can_rebase_onto(&entries, "c", "a"));
+        assert!(can_rebase_onto(&entries, "a", "c"), "grandparent");
+    }
+}

--- a/crates/jayjay-uniffi/src/dag.rs
+++ b/crates/jayjay-uniffi/src/dag.rs
@@ -39,3 +39,17 @@ fn compute_dag_layout(entries: Vec<jayjay_core::GraphEntry>) -> DagLayoutData {
         display_lane_count: display_lane_count as u32,
     }
 }
+
+#[uniffi::export]
+fn descendant_commit_ids(entries: Vec<jayjay_core::GraphEntry>, commit_id: &str) -> Vec<String> {
+    jayjay_core::dag::descendant_commit_ids(&entries, commit_id)
+}
+
+#[uniffi::export]
+fn can_rebase_onto(
+    entries: Vec<jayjay_core::GraphEntry>,
+    source_commit_id: &str,
+    target_commit_id: &str,
+) -> bool {
+    jayjay_core::dag::can_rebase_onto(&entries, source_commit_id, target_commit_id)
+}

--- a/shell/gpui/src/repo/window/dag_drag/payload.rs
+++ b/shell/gpui/src/repo/window/dag_drag/payload.rs
@@ -1,7 +1,6 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 
-use jayjay_core::{ChangeInfo, EdgeType, GraphEntry};
+use jayjay_core::{ChangeInfo, GraphEntry};
 
 #[derive(Clone)]
 pub(crate) enum DagDrag {
@@ -61,98 +60,16 @@ impl DagDrag {
             Self::Bookmark { name, conflicted } => {
                 *conflicted || !change.bookmarks.iter().any(|bookmark| bookmark == name)
             }
-            Self::Change { source_ix, entries } => {
+            Self::Change { entries, .. } => {
                 let Some(source) = self.source_change() else {
                     return false;
                 };
-                let target_id = change.commit_id.as_str();
-                let source_id = source.commit_id.as_str();
-                target_id != source_id
-                    && source.parents.as_slice() != [target_id]
-                    && !descends_from(&entries[..*source_ix], target_id, source_id)
+                jayjay_core::dag::can_rebase_onto(
+                    entries,
+                    source.commit_id.as_str(),
+                    change.commit_id.as_str(),
+                )
             }
         }
-    }
-}
-
-/// Rows are in graph order (children above parents), so a descendant of the source sits in the rows above it; follow the displayed edges down from the target.
-fn descends_from(rows_above: &[GraphEntry], target_id: &str, source_id: &str) -> bool {
-    let Some(target_ix) = rows_above
-        .iter()
-        .position(|entry| entry.change.commit_id.as_str() == target_id)
-    else {
-        return false;
-    };
-    let mut reachable = HashSet::from([target_id]);
-    for entry in &rows_above[target_ix..] {
-        if reachable.contains(entry.change.commit_id.as_str()) {
-            reachable.extend(
-                entry
-                    .edges
-                    .iter()
-                    .filter(|edge| edge.edge_type != EdgeType::Missing)
-                    .map(|edge| edge.target.as_str()),
-            );
-        }
-    }
-    reachable.contains(source_id)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use jayjay_core::{ChangeInfo, CommitAuthor, EdgeType, GraphEdge, GraphEntry, ShortId};
-
-    use super::DagDrag;
-
-    fn entry(commit: &str, edges: &[&str]) -> GraphEntry {
-        let change = ChangeInfo {
-            change_id: ShortId::new(format!("change-{commit}"), 1),
-            commit_id: ShortId::new(commit.to_owned(), 1),
-            description: String::new(),
-            author: CommitAuthor::empty(0),
-            parents: edges.iter().map(|edge| (*edge).to_owned()).collect(),
-            bookmarks: Vec::new(),
-            tags: Vec::new(),
-            workspaces: Vec::new(),
-            is_working_copy: false,
-            has_conflict: false,
-            is_empty: false,
-            is_immutable: false,
-            is_divergent: false,
-            new_change: jayjay_core::NewChangeEligibility {
-                on_top: true,
-                before: true,
-                after: true,
-            },
-        };
-        GraphEntry {
-            change,
-            edges: edges
-                .iter()
-                .map(|target| GraphEdge {
-                    target: (*target).to_owned(),
-                    edge_type: EdgeType::Direct,
-                })
-                .collect(),
-        }
-    }
-
-    #[test]
-    fn change_drag_refuses_itself_its_only_parent_and_its_descendants() {
-        let entries = Arc::new(vec![
-            entry("a", &["b"]),
-            entry("d", &["c"]),
-            entry("b", &["c"]),
-            entry("c", &[]),
-        ]);
-        let drag = DagDrag::for_change(2, &entries).expect("b is draggable");
-        let target = |ix: usize| &entries[ix].change;
-
-        assert!(!drag.can_drop_on(target(2)), "self");
-        assert!(!drag.can_drop_on(target(3)), "only parent");
-        assert!(!drag.can_drop_on(target(0)), "descendant");
-        assert!(drag.can_drop_on(target(1)), "sibling branch");
     }
 }

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGRebaseGesturePolicy.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGRebaseGesturePolicy.swift
@@ -30,14 +30,13 @@ enum DAGRebaseGesturePolicy {
     ) -> DAGRebaseRequest? {
         guard let rebaseDrag,
               let targetCommitId = previewTargetCommitId ?? hoveredCommitId,
-              targetCommitId != rebaseDrag.sourceCommitId,
-              let targetEntry = entries.first(where: { $0.change.commitId.id == targetCommitId })
+              let targetEntry = entries.first(where: { $0.change.commitId.id == targetCommitId }),
+              canRebaseOnto(
+                  entries: entries,
+                  sourceCommitId: rebaseDrag.sourceCommitId,
+                  targetCommitId: targetCommitId
+              )
         else {
-            return nil
-        }
-        // Dropping a change onto its only parent has nothing to rebase.
-        let sourceParents = entries.first(where: { $0.change.commitId.id == rebaseDrag.sourceCommitId })?.change.parents
-        if sourceParents == [targetCommitId] {
             return nil
         }
 
@@ -51,6 +50,17 @@ enum DAGRebaseGesturePolicy {
             destCommitId: targetEntry.change.commitId.id,
             destLabel: displayLabel(for: targetEntry.change)
         )
+    }
+
+    /// What the hover bubble says when dropping here would cancel; nil when the target is valid.
+    static func targetRefusal(rebaseDrag: DAGRebaseDragState, targetCommitId: String) -> String? {
+        if rebaseDrag.sourceParents == [targetCommitId] {
+            return "Already its parent"
+        }
+        if rebaseDrag.descendantCommitIds.contains(targetCommitId) {
+            return "Can't rebase onto its own descendant"
+        }
+        return nil
     }
 
     static func changeAction(

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGRebaseModels.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGRebaseModels.swift
@@ -22,9 +22,13 @@ struct DAGRebaseDragState {
     let sourceChangeId: String
     let sourceRev: String
     let sourceLabel: String
+    let sourceParents: [String]
     let startLocation: CGPoint
     var armedAt: Date?
     var phase: DAGRebasePhase
     var location: CGPoint
     var hoveredCommitId: String?
+    /// Rows a drop must refuse, computed once when the drag starts so hovering never crosses into Rust.
+    var descendantCommitIds: Set<String> = []
+    var targetRefusal: String?
 }

--- a/shell/mac/Sources/JayJay/Repo/DAG/DAGView+RebaseDrag.swift
+++ b/shell/mac/Sources/JayJay/Repo/DAG/DAGView+RebaseDrag.swift
@@ -38,6 +38,9 @@ extension DAGView {
         guard rebasePreviewTargetId == change.commitId.id,
               let rebaseDrag
         else { return nil }
+        if let refusal = rebaseDrag.targetRefusal {
+            return refusal
+        }
         return "Rebase \(rebaseDrag.sourceLabel) onto \(DAGRebaseGesturePolicy.displayLabel(for: change))?"
     }
 
@@ -109,6 +112,7 @@ extension DAGView {
             sourceChangeId: entry.change.changeId.id,
             sourceRev: DAGRebaseGesturePolicy.revision(for: entry.change),
             sourceLabel: DAGRebaseGesturePolicy.displayLabel(for: entry.change),
+            sourceParents: entry.change.parents,
             startLocation: location,
             armedAt: nil,
             phase: .pressing,
@@ -138,6 +142,7 @@ extension DAGView {
     private func beginDraggingIfNeeded() {
         guard var rebaseDrag, rebaseDrag.phase != .dragging else { return }
         rebaseDrag.phase = .dragging
+        rebaseDrag.descendantCommitIds = Set(descendantCommitIds(entries: entries, commitId: rebaseDrag.sourceCommitId))
         self.rebaseDrag = rebaseDrag
     }
 
@@ -149,12 +154,18 @@ extension DAGView {
             hoveredCommitId: hoveredCommitId
         )
         rebaseDrag.location = location
-        rebaseDrag.hoveredCommitId = normalizedTarget
+        if normalizedTarget != rebaseDrag.hoveredCommitId {
+            rebaseDrag.hoveredCommitId = normalizedTarget
+            rebaseDrag.targetRefusal = normalizedTarget.flatMap {
+                DAGRebaseGesturePolicy.targetRefusal(rebaseDrag: rebaseDrag, targetCommitId: $0)
+            }
+        }
         self.rebaseDrag = rebaseDrag
-        updateRebasePreviewTarget(normalizedTarget)
+        // A refusal shows at once; only a valid target waits for the preview delay.
+        updateRebasePreviewTarget(normalizedTarget, delayed: rebaseDrag.targetRefusal == nil)
     }
 
-    private func updateRebasePreviewTarget(_ commitId: String?) {
+    private func updateRebasePreviewTarget(_ commitId: String?, delayed: Bool) {
         if commitId == rebasePreviewTargetId {
             return
         }
@@ -164,6 +175,10 @@ extension DAGView {
         rebasePreviewTargetId = nil
 
         guard let commitId else { return }
+        guard delayed else {
+            rebasePreviewTargetId = commitId
+            return
+        }
 
         rebasePreviewTask = Task {
             try? await Task.sleep(for: .milliseconds(DAGRebaseGesturePolicy.previewDelayMs))

--- a/shell/mac/Tests/JayJayTests/DAGRebaseGesturePolicyTests.swift
+++ b/shell/mac/Tests/JayJayTests/DAGRebaseGesturePolicyTests.swift
@@ -95,19 +95,26 @@ final class DAGRebaseGesturePolicyTests: XCTestCase {
             description: "main",
             isImmutable: false
         )
-        let source = makeEntry(
-            changeId: "source-change",
-            commitId: "source-commit",
-            description: "feat-x",
+        let parent = makeEntry(
+            changeId: "parent-change",
+            commitId: "parent-commit",
+            description: "parent",
             isImmutable: false,
             parents: ["base-commit"]
+        )
+        let source = makeEntry(
+            changeId: "change",
+            commitId: "source",
+            description: "feat-x",
+            isImmutable: false,
+            parents: ["parent-commit"]
         )
 
         let request = DAGRebaseGesturePolicy.dropRequest(
             rebaseDrag: makeDragState(phase: .dragging),
             previewTargetCommitId: nil,
             hoveredCommitId: "base-commit",
-            entries: [source, ancestor]
+            entries: [source, parent, ancestor]
         )
 
         XCTAssertEqual(request?.sourceChangeId, "change")
@@ -129,7 +136,15 @@ final class DAGRebaseGesturePolicyTests: XCTestCase {
             rebaseDrag: makeDragState(phase: .dragging),
             previewTargetCommitId: nil,
             hoveredCommitId: "target-commit",
-            entries: [immutableTarget]
+            entries: [
+                makeEntry(
+                    changeId: "change",
+                    commitId: "source",
+                    description: "feat-x",
+                    isImmutable: false
+                ),
+                immutableTarget
+            ]
         )
 
         XCTAssertEqual(request?.destCommitId, "target-commit")
@@ -162,15 +177,54 @@ final class DAGRebaseGesturePolicyTests: XCTestCase {
         XCTAssertNil(request)
     }
 
+    func testRefusesDropOntoADescendant() {
+        let source = makeEntry(
+            changeId: "change",
+            commitId: "source",
+            description: "feat-x",
+            isImmutable: false
+        )
+        let child = makeEntry(
+            changeId: "child-change",
+            commitId: "child-commit",
+            description: "child",
+            isImmutable: false,
+            parents: ["source"]
+        )
+
+        let request = DAGRebaseGesturePolicy.dropRequest(
+            rebaseDrag: makeDragState(phase: .dragging),
+            previewTargetCommitId: nil,
+            hoveredCommitId: "child-commit",
+            entries: [child, source]
+        )
+
+        XCTAssertNil(request)
+    }
+
+    func testHoverRefusalNamesTheReason() {
+        var state = makeDragState(phase: .dragging, sourceParents: ["base-commit"])
+        state.descendantCommitIds = ["child-commit"]
+
+        XCTAssertEqual(
+            DAGRebaseGesturePolicy.targetRefusal(rebaseDrag: state, targetCommitId: "child-commit"),
+            "Can't rebase onto its own descendant"
+        )
+        XCTAssertEqual(DAGRebaseGesturePolicy.targetRefusal(rebaseDrag: state, targetCommitId: "base-commit"), "Already its parent")
+        XCTAssertNil(DAGRebaseGesturePolicy.targetRefusal(rebaseDrag: state, targetCommitId: "other-commit"))
+    }
+
     private func makeDragState(
         phase: DAGRebasePhase,
-        startLocation: CGPoint = .zero
+        startLocation: CGPoint = .zero,
+        sourceParents: [String] = []
     ) -> DAGRebaseDragState {
         DAGRebaseDragState(
             sourceCommitId: "source",
             sourceChangeId: "change",
             sourceRev: "change",
             sourceLabel: "feat-x",
+            sourceParents: sourceParents,
             startLocation: startLocation,
             armedAt: phase == .pressing ? nil : Date(timeIntervalSinceReferenceDate: 10),
             phase: phase,
@@ -196,7 +250,7 @@ final class DAGRebaseGesturePolicyTests: XCTestCase {
                 bookmarks: bookmarks,
                 isImmutable: isImmutable
             ),
-            edges: []
+            edges: parents.map { GraphEdge(target: $0, edgeType: .direct) }
         )
     }
 }

--- a/shell/mac/Tests/JayJayTests/DAGRowViewModelTests.swift
+++ b/shell/mac/Tests/JayJayTests/DAGRowViewModelTests.swift
@@ -459,6 +459,7 @@ final class DAGRowViewModelTests: XCTestCase {
             sourceChangeId: "source-change",
             sourceRev: "source-change",
             sourceLabel: "feat-x",
+            sourceParents: [],
             startLocation: .zero,
             armedAt: armedAt,
             phase: phase,


### PR DESCRIPTION
SwiftUI only refused a drop on the source itself or its only parent, so dropping a change onto one of its descendants opened the confirmation for a rebase that core rejects. GPUI already walked the displayed edges for that case.

jayjay_core::dag::can_rebase_onto now owns the whole drop rule (self, only parent, descendant) and both shells call it, so GPUI's own descends_from walk and its test are gone. The walk is the bounded row scan GPUI used, since GPUI evaluates the rule per frame while dragging.

Stacked on #245; rebase onto main once that lands.