### PR TITLE
perf(refresh): stop a cold open refreshing three times

### DIFF
--- a/crates/jayjay-core/src/repo/undo.rs
+++ b/crates/jayjay-core/src/repo/undo.rs
@@ -1,4 +1,5 @@
 use super::Repo;
+use super::support::block_on_result;
 use crate::types::*;
 
 impl Repo {
@@ -51,6 +52,13 @@ impl Repo {
     /// Restore the repo to a given operation via `jj op restore`.
     pub fn op_restore(&self, op_id: &str) -> CoreResult<()> {
         self.run_jj_reload(&["op", "restore", op_id])
+    }
+
+    /// Whether the loaded repo matches the sole on-disk operation head.
+    pub fn is_at_operation_head(&self) -> CoreResult<bool> {
+        let repo = self.get_repo();
+        let heads = block_on_result("read operation heads", repo.op_heads_store().get_op_heads())?;
+        Ok(heads.len() == 1 && heads[0] == *repo.op_id())
     }
 
     /// Description of the operation the repo is currently at, read in-process from the loaded repo (no subprocess) so the status bar can show it cheaply.

--- a/crates/jayjay-core/tests/integration/repo.rs
+++ b/crates/jayjay-core/tests/integration/repo.rs
@@ -568,3 +568,18 @@ fn squash_snapshots_unsnapshotted_working_copy_edit() {
         .expect("squash must capture the un-snapshotted disk edit");
     assert_eq!(notes.new.content.as_deref(), Some("edit in progress\n"));
 }
+
+#[test]
+fn loaded_repo_knows_when_an_operation_landed_elsewhere() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let repo = Repo::open(&repo_path).expect("open repo");
+    assert!(repo.is_at_operation_head().expect("read heads"));
+
+    run_jj_in(&repo_path, &["describe", "-m", "elsewhere"]);
+    assert!(!repo.is_at_operation_head().expect("read heads"));
+
+    repo.refresh_working_copy()
+        .expect("snapshot adopts the head");
+    assert!(repo.is_at_operation_head().expect("read heads"));
+}

--- a/crates/jayjay-uniffi/src/repo.rs
+++ b/crates/jayjay-uniffi/src/repo.rs
@@ -935,6 +935,10 @@ impl JayJayRepo {
         Ok(self.inner.review_notes(&rev, include_resolved)?)
     }
 
+    fn is_at_operation_head(&self) -> Result<bool, JayJayError> {
+        Ok(self.inner.is_at_operation_head()?)
+    }
+
     fn current_operation_description(&self) -> String {
         self.inner.current_operation_description()
     }

--- a/shell/mac/Sources/JayJay/App/Watcher/RepoFSWatcher.swift
+++ b/shell/mac/Sources/JayJay/App/Watcher/RepoFSWatcher.swift
@@ -1,13 +1,12 @@
 import Foundation
 import JayJayCore
 
-/// Watches jj operation heads and working copy for changes.
 final class RepoFSWatcher {
     private var opSource: DispatchSourceFileSystemObject?
     private var wcStream: FSEventStreamRef?
     private let debounceInterval: TimeInterval = 1.0
     private var lastOpFired: Date = .distantPast
-    private var lastWCFired: Date = .distantPast
+    private var trailingOp: DispatchWorkItem?
     let repoPath: String
 
     let onOpChange: @Sendable () -> Void
@@ -36,19 +35,27 @@ final class RepoFSWatcher {
                 queue: .main
             )
             src.setEventHandler { [weak self] in
-                guard let self else { return }
-                let now = Date()
-                guard now.timeIntervalSince(lastOpFired) > debounceInterval else { return }
-                lastOpFired = now
-                onOpChange()
+                self?.fireOpChange()
             }
             src.setCancelHandler { close(fileDescriptor) }
             src.resume()
             opSource = src
         }
 
-        // 2. Watch working copy
         startWCWatch()
+    }
+
+    private func fireOpChange() {
+        guard trailingOp == nil else { return }
+        let delay = max(0, debounceInterval - Date().timeIntervalSince(lastOpFired))
+        let item = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            trailingOp = nil
+            lastOpFired = Date()
+            onOpChange()
+        }
+        trailingOp = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
     }
 
     private func startWCWatch() {
@@ -81,13 +88,15 @@ final class RepoFSWatcher {
         let watcher = Unmanaged<RepoFSWatcher>.fromOpaque(info).takeUnretainedValue()
         guard let paths = unsafeBitCast(eventPaths, to: NSArray.self) as? [String] else { return }
 
-        guard watcher.isRelevantWorkingCopyChange(paths) else { return }
+        watcher.handleWorkingCopyEvents(paths)
+    }
 
-        let now = Date()
-        guard now.timeIntervalSince(watcher.lastWCFired) > 2.0 else { return }
-        watcher.lastWCFired = now
+    func handleWorkingCopyEvents(_ paths: [String]) {
+        guard isRelevantWorkingCopyChange(paths) else { return }
+
+        // FSEvents already batches at the stream latency; another time gate can discard a delivered batch.
         DispatchQueue.main.async {
-            watcher.onWorkingCopyChange()
+            self.onWorkingCopyChange()
         }
     }
 

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+Rebase.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Actions/RepoViewModel+Rebase.swift
@@ -8,14 +8,12 @@ struct RepoRebaseFeedback {
 
 private struct RepoRebaseRefreshResult {
     let graphEntries: [GraphEntry]
-    let bookmarks: [BookmarkInfo]
-    let workspaces: [WorkspaceInfo]?
     let selectedChange: ChangeDetail?
     let workingCopyChangeId: String
     let workingCopyDescription: String
     let hadConflicts: Bool
     let undoOperationId: String?
-    let statusBar: StatusBarSnapshot
+    let context: RepoRefreshContext
 }
 
 extension RepoViewModel {
@@ -41,16 +39,12 @@ extension RepoViewModel {
         } onSuccess: { viewModel, result in
             viewModel.successActionSignal += 1
             viewModel.graphEntries = result.graphEntries
-            viewModel.bookmarks = result.bookmarks
-            if let workspaces = result.workspaces {
-                viewModel.workspaces = workspaces
-            }
             viewModel.applySingleSelectedChange(result.selectedChange)
             viewModel.applyWorkingCopy(
                 changeId: result.workingCopyChangeId,
                 description: result.workingCopyDescription
             )
-            viewModel.apply(result.statusBar)
+            viewModel.apply(result.context)
             viewModel.isLoading = false
             viewModel.isRefreshingInFlight = false
             viewModel.canLoadMore = Self.canLoadMore(
@@ -67,7 +61,7 @@ extension RepoViewModel {
         } onFailure: { viewModel, error in
             viewModel.isLoading = false
             viewModel.isRefreshingInFlight = false
-            viewModel.resumePendingBackgroundRefresh()
+            viewModel.resumePendingBackgroundRefresh(afterFailure: true)
             onFailure(viewModel, error.friendlyDescription)
         }
     }
@@ -84,8 +78,6 @@ extension RepoViewModel {
 
         let graphEntries = try repo.logGraph(revset: revset)
         let log = graphEntries.map(\.change)
-        let bookmarks = try repo.listBookmarks()
-        let workspaces = try? repo.workspaceList()
         let selectedChange = try loadSelectedDetail(
             repo: repo,
             log: log,
@@ -97,16 +89,14 @@ extension RepoViewModel {
             $0.change.changeId.id == request.sourceChangeId && $0.change.hasConflict
         })
 
-        return RepoRebaseRefreshResult(
+        return try RepoRebaseRefreshResult(
             graphEntries: graphEntries,
-            bookmarks: bookmarks,
-            workspaces: workspaces,
             selectedChange: selectedChange,
             workingCopyChangeId: workingCopy?.changeId.id ?? "",
             workingCopyDescription: workingCopy?.description ?? "",
             hadConflicts: hadConflicts,
             undoOperationId: undoOperationId,
-            statusBar: StatusBarSnapshot.load(from: repo)
+            context: RepoRefreshContext(repo: repo)
         )
     }
 

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoRefreshContext.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoRefreshContext.swift
@@ -1,0 +1,15 @@
+import JayJayCore
+
+struct RepoRefreshContext {
+    let bookmarks: [BookmarkInfo]
+    let workspaces: [WorkspaceInfo]?
+    let prHostName: String?
+    let statusBar: StatusBarSnapshot
+
+    init(repo: JayJayRepo) throws {
+        bookmarks = try repo.listBookmarks()
+        workspaces = try? repo.workspaceList()
+        prHostName = repo.prHostName()
+        statusBar = StatusBarSnapshot.load(from: repo)
+    }
+}

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel+AsyncSupport.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel+AsyncSupport.swift
@@ -42,8 +42,11 @@ extension RepoViewModel {
     }
 
     @MainActor
-    func applyRefreshFailure(_ error: any Error, presence: WorkspacePresence) {
+    func applyRefreshFailure(_ error: any Error, presence: WorkspacePresence, context: RepoRefreshContext? = nil) {
         guard !Task.isCancelled, !isShuttingDown else { return }
+        if let context {
+            apply(context)
+        }
         isLoading = false
         isRefreshingInFlight = false
         if presence == .gone {
@@ -52,7 +55,7 @@ extension RepoViewModel {
             present(error: error)
         }
         // A queued background refresh must not be stranded by a failed one.
-        resumePendingBackgroundRefresh()
+        resumePendingBackgroundRefresh(afterFailure: true)
     }
 
     func perform(

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel+Refresh.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel+Refresh.swift
@@ -3,28 +3,33 @@ import JayJayCore
 
 private struct RepoRefreshContent {
     let graph: [GraphEntry]
-    let bookmarks: [BookmarkInfo]
-    let workspaces: [WorkspaceInfo]?
-    let prHostName: String?
     let selectedChange: ChangeDetail?
     let workingCopyChangeId: String
     let workingCopyDescription: String
-    let statusBar: StatusBarSnapshot
+    let context: RepoRefreshContext?
+}
+
+enum BackgroundRefreshRequest {
+    case checkOperation
+    case reload
 }
 
 extension RepoViewModel {
+    func handleOperationChange() {
+        pendingBackgroundRefresh = pendingBackgroundRefresh ?? .checkOperation
+        resumePendingBackgroundRefresh()
+    }
+
     func handleWorkingCopyChange() {
         guard !isShuttingDown else { return }
-        // Remember an event while editing even if a mutation also stamped the echo window; resume without re-checking the stamp once editing ends.
-        if isBackgroundRefreshSuspended {
-            hasPendingBackgroundRefresh = true
+        // Editing defers events even within the mutation echo window.
+        if !isBackgroundRefreshSuspended,
+           let last = lastInternalMutationAt, Date().timeIntervalSince(last) < 5
+        {
             return
         }
-        // Ignore the FS echo from our own mutations — perform() already refreshed.
-        if let last = lastInternalMutationAt, Date().timeIntervalSince(last) < 5 {
-            return
-        }
-        refresh(isAutoTriggered: true)
+        pendingBackgroundRefresh = .reload
+        resumePendingBackgroundRefresh()
     }
 
     func setBackgroundRefreshSuspended(_ suspended: Bool) {
@@ -67,9 +72,8 @@ extension RepoViewModel {
         snapshotWorkingCopy: Bool = true
     ) {
         guard !isShuttingDown else { return }
-        // Don't pile FS-triggered refreshes on an in-flight one — our own refreshWorkingCopy re-fires the watcher.
         if isAutoTriggered, isRefreshingInFlight {
-            hasPendingBackgroundRefresh = true
+            pendingBackgroundRefresh = .reload
             return
         }
         refreshTask?.cancel()
@@ -83,21 +87,28 @@ extension RepoViewModel {
         let requestedRevset = revset
         let includeSubmoduleStatuses = includeSubmoduleStatuses
         let shouldLoadBeforeSnapshot = graphEntries.isEmpty && snapshotWorkingCopy
+        // A requested revision wins the first pass; later passes preserve subsequent user selections.
+        var selectionBaseline = preferredRev == nil ? selectedChangeIds : nil
+        let repo = repo
+        let load = { includeContext in
+            try Self.loadRefreshContent(
+                repo: repo,
+                revset: requestedRevset,
+                preferredRev: preferredRev ?? currentSelection,
+                includeSubmoduleStatuses: includeSubmoduleStatuses,
+                includeContext: includeContext
+            )
+        }
         refreshTask = startRepoTask { [weak self, repo] in
             do {
                 if shouldLoadBeforeSnapshot {
-                    let content = try Self.loadRefreshContent(
-                        repo: repo,
-                        revset: requestedRevset,
-                        preferredRev: preferredRev ?? currentSelection,
-                        includeSubmoduleStatuses: includeSubmoduleStatuses
-                    )
+                    let content = try load(false)
                     guard !Task.isCancelled else { return }
-                    await self?.applyRefreshContent(
+                    selectionBaseline = await self?.applyRefreshContent(
                         content,
                         revset: requestedRevset,
-                        isRefreshComplete: false,
-                        isAutoTriggered: isAutoTriggered
+                        isAutoTriggered: isAutoTriggered,
+                        selectionBaseline: selectionBaseline
                     )
                 }
 
@@ -106,66 +117,78 @@ extension RepoViewModel {
                     guard !Task.isCancelled else { return }
                 }
 
-                let content = try Self.loadRefreshContent(
-                    repo: repo,
-                    revset: requestedRevset,
-                    preferredRev: preferredRev ?? currentSelection,
-                    includeSubmoduleStatuses: includeSubmoduleStatuses
-                )
+                let content = try load(true)
                 guard !Task.isCancelled else { return }
                 await self?.applyRefreshContent(
                     content,
                     revset: requestedRevset,
-                    isRefreshComplete: true,
-                    isAutoTriggered: isAutoTriggered
+                    isAutoTriggered: isAutoTriggered,
+                    selectionBaseline: selectionBaseline
                 )
             } catch {
                 guard !Task.isCancelled else { return }
-                let presence = repo.workspacePresence()
-                await self?.applyRefreshFailure(error, presence: presence)
+                // A failed snapshot must still populate the context omitted from the first paint.
+                let context = shouldLoadBeforeSnapshot ? try? RepoRefreshContext(repo: repo) : nil
+                await self?.applyRefreshFailure(error, presence: repo.workspacePresence(), context: context)
             }
         }
     }
 
     @MainActor
+    @discardableResult
     private func applyRefreshContent(
         _ content: RepoRefreshContent,
         revset: String,
-        isRefreshComplete: Bool,
-        isAutoTriggered: Bool
-    ) {
-        guard !isShuttingDown else { return }
+        isAutoTriggered: Bool,
+        selectionBaseline: [String]?
+    ) -> [String]? {
+        guard !Task.isCancelled, !isShuttingDown else { return selectionBaseline }
+        let isRefreshComplete = content.context != nil
         if isAutoTriggered, isBackgroundRefreshSuspended {
-            hasPendingBackgroundRefresh = true
+            pendingBackgroundRefresh = .reload
             if isRefreshComplete {
                 isRefreshingInFlight = false
             }
-            return
+            return selectionBaseline
         }
-        graphEntries = content.graph
-        bookmarks = content.bookmarks
-        if let workspaces = content.workspaces {
-            self.workspaces = workspaces
-        }
-        prHostName = content.prHostName
-        applySingleSelectedChange(content.selectedChange)
-        applyWorkingCopy(
-            changeId: content.workingCopyChangeId,
-            description: content.workingCopyDescription
-        )
-        apply(content.statusBar)
-        isLoading = false
-        if isRefreshComplete {
-            isRefreshingInFlight = false
-        }
+        let selectsLoadedChange = selectionBaseline == nil || selectionBaseline == selectedChangeIds
+        apply(content, selectsLoadedChange: selectsLoadedChange)
         canLoadMore = Self.canLoadMore(
             revset: revset,
             loadedCount: content.graph.count
         )
-        fetchPrInfo(bookmarks: content.selectedChange?.info.bookmarks ?? [])
-        if isRefreshComplete {
-            resumePendingBackgroundRefresh()
+        let baseline = selectsLoadedChange ? selectedChangeIds : selectionBaseline
+        guard isRefreshComplete else { return baseline }
+        isRefreshingInFlight = false
+        fetchPrInfo(bookmarks: selectedChange?.info.bookmarks ?? [])
+        resumePendingBackgroundRefresh()
+        return baseline
+    }
+
+    @MainActor
+    private func apply(_ content: RepoRefreshContent, selectsLoadedChange: Bool = true) {
+        graphEntries = content.graph
+        if let context = content.context {
+            apply(context)
         }
+        if selectsLoadedChange {
+            applySingleSelectedChange(content.selectedChange)
+        }
+        applyWorkingCopy(
+            changeId: content.workingCopyChangeId,
+            description: content.workingCopyDescription
+        )
+        isLoading = false
+    }
+
+    @MainActor
+    func apply(_ context: RepoRefreshContext) {
+        bookmarks = context.bookmarks
+        if let workspaces = context.workspaces {
+            self.workspaces = workspaces
+        }
+        prHostName = context.prHostName
+        apply(context.statusBar)
     }
 
     func loadMore() {
@@ -220,19 +243,7 @@ extension RepoViewModel {
         revset: String
     ) {
         guard !isShuttingDown else { return }
-        graphEntries = content.graph
-        bookmarks = content.bookmarks
-        if let workspaces = content.workspaces {
-            self.workspaces = workspaces
-        }
-        prHostName = content.prHostName
-        applySingleSelectedChange(content.selectedChange)
-        applyWorkingCopy(
-            changeId: content.workingCopyChangeId,
-            description: content.workingCopyDescription
-        )
-        apply(content.statusBar)
-        isLoading = false
+        apply(content)
         isRefreshingInFlight = false
         self.canLoadMore = canLoadMore
         if didGrow {
@@ -241,9 +252,17 @@ extension RepoViewModel {
         resumePendingBackgroundRefresh()
     }
 
-    func resumePendingBackgroundRefresh() {
-        guard !isBackgroundRefreshSuspended, hasPendingBackgroundRefresh else { return }
-        hasPendingBackgroundRefresh = false
+    func resumePendingBackgroundRefresh(afterFailure: Bool = false) {
+        if afterFailure, pendingBackgroundRefresh != nil {
+            pendingBackgroundRefresh = .reload
+        }
+        guard !isShuttingDown, !isBackgroundRefreshSuspended, !isRefreshingInFlight,
+              let pending = pendingBackgroundRefresh else { return }
+        pendingBackgroundRefresh = nil
+        // Compare only after a successful load; a failed load may have advanced the repo without updating the UI.
+        if pending == .checkOperation, (try? repo.isAtOperationHead()) == true {
+            return
+        }
         refresh(isAutoTriggered: true)
     }
 
@@ -251,7 +270,8 @@ extension RepoViewModel {
         repo: JayJayRepo,
         revset: String,
         preferredRev: String?,
-        includeSubmoduleStatuses: Bool
+        includeSubmoduleStatuses: Bool,
+        includeContext: Bool = true
     ) throws -> RepoRefreshContent {
         let graph = try repo.logGraph(revset: revset)
         let log = graph.map(\.change)
@@ -261,17 +281,13 @@ extension RepoViewModel {
             preferredRev: preferredRev,
             includeSubmoduleStatuses: includeSubmoduleStatuses
         )
-        let statusBar = StatusBarSnapshot.load(from: repo)
         let workingCopy = log.first(where: { $0.isWorkingCopy })
         return try RepoRefreshContent(
             graph: graph,
-            bookmarks: repo.listBookmarks(),
-            workspaces: try? repo.workspaceList(),
-            prHostName: repo.prHostName(),
             selectedChange: selectedChange,
             workingCopyChangeId: workingCopy?.changeId.id ?? "",
             workingCopyDescription: workingCopy?.description ?? "",
-            statusBar: statusBar
+            context: includeContext ? RepoRefreshContext(repo: repo) : nil
         )
     }
 }

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
@@ -75,7 +75,7 @@ final class RepoViewModel: ChangeActions, DAGActions, BookmarkActions {
     var lastInternalMutationAt: Date?
     /// FS-triggered refreshes wait while a sheet or editor owns transient user input.
     var isBackgroundRefreshSuspended = false
-    var hasPendingBackgroundRefresh = false
+    var pendingBackgroundRefresh: BackgroundRefreshRequest?
     /// True while a refresh task is running — gates FS-triggered re-entry.
     var isRefreshingInFlight: Bool = false
     var isPullingInFlight = false
@@ -118,7 +118,7 @@ final class RepoViewModel: ChangeActions, DAGActions, BookmarkActions {
         self.configWarning = configWarning
         fsWatcher = RepoFSWatcher(
             repoPath: path,
-            onChange: { [weak self] in self?.handleWorkingCopyChange() },
+            onChange: { [weak self] in self?.handleOperationChange() },
             onWorkingCopyChange: { [weak self] in self?.handleWorkingCopyChange() },
             isRelevantWorkingCopyChange: { [repo] paths in
                 (try? repo.hasUnignoredWorkingCopyPaths(paths: paths)) ?? true

--- a/shell/mac/Tests/JayJayTests/RepoFSWatcherTests.swift
+++ b/shell/mac/Tests/JayJayTests/RepoFSWatcherTests.swift
@@ -2,8 +2,37 @@
 import JayJayCore
 import XCTest
 
+private final class Counter: @unchecked Sendable {
+    private var value = 0
+    private let lock = NSLock()
+
+    func increment() -> Int {
+        lock.withLock {
+            value += 1
+            return value
+        }
+    }
+}
+
 @MainActor
 final class RepoFSWatcherTests: XCTestCase {
+    func testWorkingCopyBatchesInsideTheLatencyWindowAreBothDelivered() {
+        let observed = expectation(description: "both relevant working-copy batches delivered")
+        observed.expectedFulfillmentCount = 2
+        let watcher = RepoFSWatcher(
+            repoPath: "/unavailable-jayjay-watcher-\(UUID().uuidString)",
+            onChange: { XCTFail("working-copy events must not become operation events") },
+            onWorkingCopyChange: { observed.fulfill() },
+            isRelevantWorkingCopyChange: { $0.contains("tracked.txt") }
+        )
+
+        watcher.handleWorkingCopyEvents(["tracked.txt"])
+        watcher.handleWorkingCopyEvents(["ignored.txt"])
+        watcher.handleWorkingCopyEvents(["tracked.txt"])
+
+        wait(for: [observed], timeout: 3)
+    }
+
     func testSecondaryWorkspaceSeesOperationsInThePrimary() throws {
         let directory = FileManager.default.temporaryDirectory
             .appending(path: "jayjay-watcher-\(UUID().uuidString)")
@@ -21,6 +50,28 @@ final class RepoFSWatcherTests: XCTestCase {
         try repo.describe(rev: "@", message: "an operation in the primary")
 
         wait(for: [observed], timeout: 5)
+        withExtendedLifetime(watcher) {}
+    }
+
+    func testOperationInsideTheDebounceWindowStillFires() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: "jayjay-watcher-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try initJjGitRepo(path: directory.path)
+        let repo = try JayJayRepo.open(path: directory.path)
+
+        let first = expectation(description: "first operation observed")
+        let second = expectation(description: "second operation observed after the debounce window")
+        let count = Counter()
+        let watcher = RepoFSWatcher(repoPath: directory.path, onChange: {
+            (count.increment() == 1 ? first : second).fulfill()
+        })
+        try repo.describe(rev: "@", message: "first")
+        wait(for: [first], timeout: 5)
+        try repo.describe(rev: "@", message: "second, inside the debounce window")
+
+        wait(for: [second], timeout: 5)
         withExtendedLifetime(watcher) {}
     }
 }

--- a/shell/mac/Tests/JayJayTests/RepoViewModelRefreshTests.swift
+++ b/shell/mac/Tests/JayJayTests/RepoViewModelRefreshTests.swift
@@ -20,14 +20,14 @@ final class RepoViewModelRefreshTests: RepoViewModelTestCase {
         viewModel.lastInternalMutationAt = Date()
         viewModel.handleWorkingCopyChange()
         XCTAssertFalse(viewModel.isRefreshingInFlight)
-        XCTAssertTrue(viewModel.hasPendingBackgroundRefresh)
+        XCTAssertEqual(viewModel.pendingBackgroundRefresh, .reload)
 
         viewModel.setBackgroundRefreshSuspended(false)
         XCTAssertTrue(viewModel.isRefreshingInFlight)
         viewModel.setBackgroundRefreshSuspended(true)
 
         try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
-        XCTAssertTrue(viewModel.hasPendingBackgroundRefresh)
+        XCTAssertEqual(viewModel.pendingBackgroundRefresh, .reload)
         XCTAssertFalse(viewModel.selectedChange?.diff.contains { $0.path == "late-edit.txt" } == true)
 
         viewModel.setBackgroundRefreshSuspended(false)
@@ -35,6 +35,146 @@ final class RepoViewModelRefreshTests: RepoViewModelTestCase {
         try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
         XCTAssertNil(viewModel.error)
         XCTAssertTrue(viewModel.selectedChange?.diff.contains { $0.path == "late-edit.txt" } == true)
+    }
+
+    func testOperationEventIsDroppedOnlyWhileTheRepoIsAtHead() async throws {
+        let viewModel = try XCTUnwrap(viewModel)
+        try await snapshotAnEdit(viewModel, file: "echo.txt")
+
+        viewModel.handleOperationChange()
+        XCTAssertFalse(viewModel.isRefreshingInFlight)
+        XCTAssertNil(viewModel.pendingBackgroundRefresh)
+
+        viewModel.isRefreshingInFlight = true
+        viewModel.handleOperationChange()
+        viewModel.isRefreshingInFlight = false
+        viewModel.resumePendingBackgroundRefresh()
+        XCTAssertFalse(viewModel.isRefreshingInFlight)
+        XCTAssertNil(viewModel.pendingBackgroundRefresh)
+
+        try "from elsewhere\n".write(
+            to: URL(fileURLWithPath: viewModel.repoPath).appending(path: "external.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try JayJayRepo.open(path: viewModel.repoPath).refreshWorkingCopy()
+        viewModel.lastInternalMutationAt = Date()
+        viewModel.handleOperationChange()
+        XCTAssertTrue(viewModel.isRefreshingInFlight)
+        try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
+        XCTAssertTrue(viewModel.selectedChange?.diff.contains { $0.path == "external.txt" } == true)
+    }
+
+    func testFailedReloadRetainsPendingOperationEvenAtHead() async throws {
+        let viewModel = try XCTUnwrap(viewModel)
+        try await snapshotAnEdit(viewModel, file: "before.txt")
+
+        for suspended in [false, true] {
+            let file = "after-\(suspended).txt"
+            try "new snapshot\n".write(
+                to: URL(fileURLWithPath: viewModel.repoPath).appending(path: file),
+                atomically: true,
+                encoding: .utf8
+            )
+            viewModel.isRefreshingInFlight = true
+            try viewModel.repo.refreshWorkingCopy()
+            XCTAssertTrue(try viewModel.repo.isAtOperationHead())
+            XCTAssertFalse(viewModel.selectedChange?.diff.contains { $0.path == file } == true)
+            viewModel.handleOperationChange()
+            viewModel.lastInternalMutationAt = Date()
+            viewModel.setBackgroundRefreshSuspended(suspended)
+
+            viewModel.applyRefreshFailure(TestRefreshError.failed, presence: viewModel.repo.workspacePresence())
+
+            if suspended {
+                XCTAssertFalse(viewModel.isRefreshingInFlight)
+                XCTAssertEqual(viewModel.pendingBackgroundRefresh, .reload)
+                viewModel.setBackgroundRefreshSuspended(false)
+            }
+            XCTAssertTrue(viewModel.isRefreshingInFlight)
+            try await waitUntil("the retry finishes") { !viewModel.isRefreshingInFlight }
+            XCTAssertTrue(viewModel.selectedChange?.diff.contains { $0.path == file } == true)
+            XCTAssertNotNil(viewModel.error)
+            XCTAssertNil(viewModel.pendingBackgroundRefresh)
+        }
+
+        viewModel.applyRefreshFailure(TestRefreshError.failed, presence: .exists)
+        XCTAssertFalse(viewModel.isRefreshingInFlight)
+    }
+
+    func testQueuedWorkingCopyAndOperationEventsShareOneRefresh() async throws {
+        let viewModel = try XCTUnwrap(viewModel)
+        try await snapshotAnEdit(viewModel, file: "before.txt")
+
+        for operationFirst in [false, true] {
+            let file = "queued-\(operationFirst).txt"
+            try "queued edit\n".write(
+                to: URL(fileURLWithPath: viewModel.repoPath).appending(path: file),
+                atomically: true,
+                encoding: .utf8
+            )
+            try JayJayRepo.open(path: viewModel.repoPath).refreshWorkingCopy()
+            XCTAssertFalse(try viewModel.repo.isAtOperationHead())
+            viewModel.isRefreshingInFlight = true
+            if operationFirst {
+                viewModel.handleOperationChange()
+                viewModel.handleWorkingCopyChange()
+            } else {
+                viewModel.handleWorkingCopyChange()
+                viewModel.handleOperationChange()
+            }
+            viewModel.isRefreshingInFlight = false
+            viewModel.resumePendingBackgroundRefresh()
+
+            XCTAssertTrue(viewModel.isRefreshingInFlight)
+            XCTAssertNil(viewModel.pendingBackgroundRefresh)
+            try await waitUntil("the queued refresh finishes") { !viewModel.isRefreshingInFlight }
+            XCTAssertTrue(viewModel.selectedChange?.diff.contains { $0.path == file } == true)
+        }
+    }
+
+    func testSelectionChangedDuringARefreshSurvivesIt() async throws {
+        let viewModel = try XCTUnwrap(viewModel)
+        viewModel.refresh()
+        viewModel.selectedChangeIds = ["first", "second"]
+        viewModel.selectedChangeId = "second"
+
+        try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
+
+        XCTAssertFalse(viewModel.graphEntries.isEmpty)
+        XCTAssertEqual(viewModel.selectedChangeIds, ["first", "second"])
+    }
+
+    func testSelectionMadeAfterTheFirstPaintSurvivesTheSnapshotPass() async throws {
+        let viewModel = try XCTUnwrap(viewModel)
+        viewModel.refresh(selecting: "@")
+        try await waitUntil("the first paint lands") { !viewModel.graphEntries.isEmpty }
+        viewModel.selectedChangeIds = ["first", "second"]
+        viewModel.selectedChangeId = "second"
+
+        try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
+
+        XCTAssertEqual(viewModel.selectedChangeIds, ["first", "second"])
+    }
+
+    func testWorkingCopyEventIsNeverTakenForOurSnapshotEcho() async throws {
+        let viewModel = try XCTUnwrap(viewModel)
+        try await snapshotAnEdit(viewModel, file: "echo.txt")
+
+        viewModel.handleWorkingCopyChange()
+        XCTAssertTrue(viewModel.isRefreshingInFlight)
+        try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
+    }
+
+    private func snapshotAnEdit(_ viewModel: RepoViewModel, file: String) async throws {
+        try "snapshot me\n".write(
+            to: URL(fileURLWithPath: viewModel.repoPath).appending(path: file),
+            atomically: true,
+            encoding: .utf8
+        )
+        viewModel.refresh()
+        try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
+        XCTAssertTrue(viewModel.selectedChange?.diff.contains { $0.path == file } == true)
     }
 
     func testCancelledFailureProbeCannotOverwriteNewerRefreshState() async throws {


### PR DESCRIPTION
A cold open ran the full load before the snapshot, again after it, and a third time when the snapshot's own operation write came back through the watcher and was replayed as a background refresh. The pre-snapshot pass now loads only the graph and the selected change, and an operation event is dropped when the loaded repo already sits at the on-disk operation head, so the echo of our own snapshot costs nothing while an operation written elsewhere still refreshes. Working-copy events keep their old path: they never advance the operation head, so the at-head check must not see them. GPUI is unchanged; its watcher merges both event kinds into one channel, so the same check there would drop a user's write.