### PR TITLE
build(ffi): stop the FFI recipe compiling every dependency twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/ci.yml"
+      - "justfile"
+      - "shell/justfile"
   pull_request:
     paths:
       - "shell/mac/**"
@@ -16,6 +18,8 @@ on:
       - "Cargo.toml"
       - "Cargo.lock"
       - ".github/workflows/ci.yml"
+      - "justfile"
+      - "shell/justfile"
 
 permissions:
   contents: read

--- a/crates/jayjay-core/src/repo/undo.rs
+++ b/crates/jayjay-core/src/repo/undo.rs
@@ -1,4 +1,5 @@
 use super::Repo;
+use super::support::block_on_result;
 use crate::types::*;
 
 impl Repo {
@@ -51,6 +52,13 @@ impl Repo {
     /// Restore the repo to a given operation via `jj op restore`.
     pub fn op_restore(&self, op_id: &str) -> CoreResult<()> {
         self.run_jj_reload(&["op", "restore", op_id])
+    }
+
+    /// True when the loaded repo already sits at the single on-disk operation head, so an operation event carries nothing new to load.
+    pub fn is_at_operation_head(&self) -> CoreResult<bool> {
+        let repo = self.get_repo();
+        let heads = block_on_result("read operation heads", repo.op_heads_store().get_op_heads())?;
+        Ok(heads.len() == 1 && heads[0] == *repo.op_id())
     }
 
     /// Description of the operation the repo is currently at, read in-process from the loaded repo (no subprocess) so the status bar can show it cheaply.

--- a/crates/jayjay-core/tests/integration/repo.rs
+++ b/crates/jayjay-core/tests/integration/repo.rs
@@ -568,3 +568,18 @@ fn squash_snapshots_unsnapshotted_working_copy_edit() {
         .expect("squash must capture the un-snapshotted disk edit");
     assert_eq!(notes.new.content.as_deref(), Some("edit in progress\n"));
 }
+
+#[test]
+fn loaded_repo_knows_when_an_operation_landed_elsewhere() {
+    let temp_dir = init_jj_repo();
+    let repo_path = temp_dir.path().join("repo");
+    let repo = Repo::open(&repo_path).expect("open repo");
+    assert!(repo.is_at_operation_head().expect("read heads"));
+
+    run_jj_in(&repo_path, &["describe", "-m", "elsewhere"]);
+    assert!(!repo.is_at_operation_head().expect("read heads"));
+
+    repo.refresh_working_copy()
+        .expect("snapshot adopts the head");
+    assert!(repo.is_at_operation_head().expect("read heads"));
+}

--- a/crates/jayjay-uniffi/src/repo.rs
+++ b/crates/jayjay-uniffi/src/repo.rs
@@ -935,6 +935,10 @@ impl JayJayRepo {
         Ok(self.inner.review_notes(&rev, include_resolved)?)
     }
 
+    fn is_at_operation_head(&self) -> Result<bool, JayJayError> {
+        Ok(self.inner.is_at_operation_head()?)
+    }
+
     fn current_operation_description(&self) -> String {
         self.inner.current_operation_description()
     }

--- a/shell/justfile
+++ b/shell/justfile
@@ -70,22 +70,40 @@ check-version:
 
 ffi: ffi-debug
 
-ffi-debug: (_ffi "debug")
+# Debug shares target/debug with cargo build and cargo test, and skips the bindings and XCFramework while the staticlib they wrap is unchanged.
+ffi-debug:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  staticlib="{{target_dir}}/debug/{{lib_name}}"
+  cargo build -p jayjay-uniffi
+  test -f "$staticlib"
+  if cmp -s "$staticlib" "{{xcframework}}/macos-arm64/{{lib_name}}" \
+     && [[ "{{swift_out}}/JayJayCore.swift" -nt "$staticlib" \
+     && "{{swift_out}}/JayJayCore.swift" -nt "{{uniffi_config}}" ]]; then
+    echo "Bindings and XCFramework are up to date"
+    exit 0
+  fi
+  just --justfile "{{source_file()}}" _ffi-wrap debug "$staticlib"
 
-ffi-release: (_ffi "release")
-
-# Build the Rust FFI staticlib, generate the Swift bindings, and assemble the
-# XCFramework for the given cargo profile (debug | release).
-_ffi profile:
-  mkdir -p "{{bindings_dir}}" "{{headers_dir}}" "{{swift_out}}"
+# Release pins the target and deployment flags and always regenerates.
+ffi-release:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  staticlib="{{target_dir}}/{{macos_target}}/release/{{lib_name}}"
   MACOSX_DEPLOYMENT_TARGET="{{deployment_target}}" \
   CFLAGS_aarch64_apple_darwin="{{macos_min_flag}}" \
   CXXFLAGS_aarch64_apple_darwin="{{macos_min_flag}}" \
   RUSTFLAGS="-C link-arg={{macos_min_flag}}" \
-  cargo build {{ if profile == "release" { "--release" } else { "" } }} --target "{{macos_target}}" -p jayjay-uniffi
+  cargo build --release --target "{{macos_target}}" -p jayjay-uniffi
+  test -f "$staticlib"
+  just --justfile "{{source_file()}}" _ffi-wrap release "$staticlib"
+
+# Generate the Swift bindings from the staticlib and wrap it in the XCFramework.
+_ffi-wrap profile staticlib:
+  mkdir -p "{{bindings_dir}}" "{{headers_dir}}" "{{swift_out}}"
   cargo build {{ if profile == "release" { "--release" } else { "" } }} -p jayjay-uniffi --bin uniffi-bindgen
   "{{target_dir}}/{{profile}}/uniffi-bindgen" generate \
-    --library "{{target_dir}}/{{macos_target}}/{{profile}}/{{lib_name}}" \
+    --library "{{staticlib}}" \
     --language swift \
     --out-dir "{{bindings_dir}}" \
     --config "{{uniffi_config}}"
@@ -94,7 +112,7 @@ _ffi profile:
   cp "{{bindings_dir}}/JayJayCore.swift" "{{swift_out}}/"
   rm -rf "{{xcframework}}"
   xcodebuild -create-xcframework \
-    -library "{{target_dir}}/{{macos_target}}/{{profile}}/{{lib_name}}" \
+    -library "{{staticlib}}" \
     -headers "{{headers_dir}}" \
     -output "{{xcframework}}" | xcbeautify
 

--- a/shell/mac/Sources/JayJay/App/Watcher/RepoFSWatcher.swift
+++ b/shell/mac/Sources/JayJay/App/Watcher/RepoFSWatcher.swift
@@ -7,6 +7,7 @@ final class RepoFSWatcher {
     private var wcStream: FSEventStreamRef?
     private let debounceInterval: TimeInterval = 1.0
     private var lastOpFired: Date = .distantPast
+    private var trailingOp: DispatchWorkItem?
     private var lastWCFired: Date = .distantPast
     let repoPath: String
 
@@ -36,11 +37,7 @@ final class RepoFSWatcher {
                 queue: .main
             )
             src.setEventHandler { [weak self] in
-                guard let self else { return }
-                let now = Date()
-                guard now.timeIntervalSince(lastOpFired) > debounceInterval else { return }
-                lastOpFired = now
-                onOpChange()
+                self?.fireOpChange()
             }
             src.setCancelHandler { close(fileDescriptor) }
             src.resume()
@@ -49,6 +46,25 @@ final class RepoFSWatcher {
 
         // 2. Watch working copy
         startWCWatch()
+    }
+
+    /// An operation inside the debounce window fires once at the window's end instead of being dropped, so a head that moved right after a suppressed echo is still seen.
+    private func fireOpChange() {
+        let sinceLast = Date().timeIntervalSince(lastOpFired)
+        if sinceLast > debounceInterval {
+            lastOpFired = Date()
+            onOpChange()
+            return
+        }
+        guard trailingOp == nil else { return }
+        let item = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            trailingOp = nil
+            lastOpFired = Date()
+            onOpChange()
+        }
+        trailingOp = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + (debounceInterval - sinceLast), execute: item)
     }
 
     private func startWCWatch() {

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel+AsyncSupport.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel+AsyncSupport.swift
@@ -42,8 +42,11 @@ extension RepoViewModel {
     }
 
     @MainActor
-    func applyRefreshFailure(_ error: any Error, presence: WorkspacePresence) {
+    func applyRefreshFailure(_ error: any Error, presence: WorkspacePresence, context: RepoRefreshContext? = nil) {
         guard !Task.isCancelled, !isShuttingDown else { return }
+        if let context {
+            apply(context)
+        }
         isLoading = false
         isRefreshingInFlight = false
         if presence == .gone {

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel+Refresh.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel+Refresh.swift
@@ -3,16 +3,35 @@ import JayJayCore
 
 private struct RepoRefreshContent {
     let graph: [GraphEntry]
-    let bookmarks: [BookmarkInfo]
-    let workspaces: [WorkspaceInfo]?
-    let prHostName: String?
     let selectedChange: ChangeDetail?
     let workingCopyChangeId: String
     let workingCopyDescription: String
+    /// nil on the pre-snapshot pass, which loads only what the first paint needs.
+    let context: RepoRefreshContext?
+}
+
+/// Repo-wide state around the graph; a cold open paints without it and picks it up on the pass after the snapshot.
+struct RepoRefreshContext {
+    let bookmarks: [BookmarkInfo]
+    let workspaces: [WorkspaceInfo]?
+    let prHostName: String?
     let statusBar: StatusBarSnapshot
 }
 
 extension RepoViewModel {
+    /// An operation landed. Our own snapshot writes one too and the watcher reports it straight back; when the loaded repo already sits at that head there is nothing to load.
+    func handleOperationChange() {
+        // Mid-refresh the on-disk head can be ahead of the repo the snapshot is about to install; classify once that refresh has finished.
+        if isRefreshingInFlight {
+            hasPendingOperationCheck = true
+            return
+        }
+        if (try? repo.isAtOperationHead()) == true {
+            return
+        }
+        handleWorkingCopyChange()
+    }
+
     func handleWorkingCopyChange() {
         guard !isShuttingDown else { return }
         // Remember an event while editing even if a mutation also stamped the echo window; resume without re-checking the stamp once editing ends.
@@ -83,21 +102,28 @@ extension RepoViewModel {
         let requestedRevset = revset
         let includeSubmoduleStatuses = includeSubmoduleStatuses
         let shouldLoadBeforeSnapshot = graphEntries.isEmpty && snapshotWorkingCopy
+        var keepsSelection = preferredRev == nil ? selectedChangeIds : nil
+        let repo = repo
+        let load = { includeContext in
+            try Self.loadRefreshContent(
+                repo: repo,
+                revset: requestedRevset,
+                preferredRev: preferredRev ?? currentSelection,
+                includeSubmoduleStatuses: includeSubmoduleStatuses,
+                includeContext: includeContext
+            )
+        }
         refreshTask = startRepoTask { [weak self, repo] in
             do {
                 if shouldLoadBeforeSnapshot {
-                    let content = try Self.loadRefreshContent(
-                        repo: repo,
-                        revset: requestedRevset,
-                        preferredRev: preferredRev ?? currentSelection,
-                        includeSubmoduleStatuses: includeSubmoduleStatuses
-                    )
+                    let content = try load(false)
                     guard !Task.isCancelled else { return }
-                    await self?.applyRefreshContent(
+                    keepsSelection = await self?.applyRefreshContent(
                         content,
                         revset: requestedRevset,
                         isRefreshComplete: false,
-                        isAutoTriggered: isAutoTriggered
+                        isAutoTriggered: isAutoTriggered,
+                        keepsSelection: keepsSelection
                     )
                 }
 
@@ -106,66 +132,80 @@ extension RepoViewModel {
                     guard !Task.isCancelled else { return }
                 }
 
-                let content = try Self.loadRefreshContent(
-                    repo: repo,
-                    revset: requestedRevset,
-                    preferredRev: preferredRev ?? currentSelection,
-                    includeSubmoduleStatuses: includeSubmoduleStatuses
-                )
+                let content = try load(true)
                 guard !Task.isCancelled else { return }
                 await self?.applyRefreshContent(
                     content,
                     revset: requestedRevset,
                     isRefreshComplete: true,
-                    isAutoTriggered: isAutoTriggered
+                    isAutoTriggered: isAutoTriggered,
+                    keepsSelection: keepsSelection
                 )
             } catch {
                 guard !Task.isCancelled else { return }
-                let presence = repo.workspacePresence()
-                await self?.applyRefreshFailure(error, presence: presence)
+                // The first paint went out without repository context; do not leave the window on empty bookmarks and status.
+                let context = shouldLoadBeforeSnapshot ? try? Self.loadRefreshContext(repo: repo) : nil
+                await self?.applyRefreshFailure(error, presence: repo.workspacePresence(), context: context)
             }
         }
     }
 
+    /// `keepsSelection` is the selection this refresh last installed, or nil until a requested revision has been applied; a selection the user changed since then, such as a multi-selection made after the first paint, stays as it is. Returns the baseline for the next pass.
     @MainActor
+    @discardableResult
     private func applyRefreshContent(
         _ content: RepoRefreshContent,
         revset: String,
         isRefreshComplete: Bool,
-        isAutoTriggered: Bool
-    ) {
-        guard !isShuttingDown else { return }
+        isAutoTriggered: Bool,
+        keepsSelection: [String]?
+    ) -> [String]? {
+        guard !isShuttingDown else { return keepsSelection }
         if isAutoTriggered, isBackgroundRefreshSuspended {
             hasPendingBackgroundRefresh = true
             if isRefreshComplete {
                 isRefreshingInFlight = false
             }
-            return
+            return keepsSelection
         }
-        graphEntries = content.graph
-        bookmarks = content.bookmarks
-        if let workspaces = content.workspaces {
-            self.workspaces = workspaces
-        }
-        prHostName = content.prHostName
-        applySingleSelectedChange(content.selectedChange)
-        applyWorkingCopy(
-            changeId: content.workingCopyChangeId,
-            description: content.workingCopyDescription
-        )
-        apply(content.statusBar)
-        isLoading = false
-        if isRefreshComplete {
-            isRefreshingInFlight = false
-        }
+        let selectsLoadedChange = keepsSelection == nil || keepsSelection == selectedChangeIds
+        apply(content, selectsLoadedChange: selectsLoadedChange)
         canLoadMore = Self.canLoadMore(
             revset: revset,
             loadedCount: content.graph.count
         )
-        fetchPrInfo(bookmarks: content.selectedChange?.info.bookmarks ?? [])
-        if isRefreshComplete {
-            resumePendingBackgroundRefresh()
+        let baseline = selectsLoadedChange ? selectedChangeIds : keepsSelection
+        guard isRefreshComplete else { return baseline }
+        isRefreshingInFlight = false
+        fetchPrInfo(bookmarks: selectedChange?.info.bookmarks ?? [])
+        resumePendingBackgroundRefresh()
+        return baseline
+    }
+
+    @MainActor
+    private func apply(_ content: RepoRefreshContent, selectsLoadedChange: Bool = true) {
+        graphEntries = content.graph
+        if let context = content.context {
+            apply(context)
         }
+        if selectsLoadedChange {
+            applySingleSelectedChange(content.selectedChange)
+        }
+        applyWorkingCopy(
+            changeId: content.workingCopyChangeId,
+            description: content.workingCopyDescription
+        )
+        isLoading = false
+    }
+
+    @MainActor
+    func apply(_ context: RepoRefreshContext) {
+        bookmarks = context.bookmarks
+        if let workspaces = context.workspaces {
+            self.workspaces = workspaces
+        }
+        prHostName = context.prHostName
+        apply(context.statusBar)
     }
 
     func loadMore() {
@@ -220,19 +260,7 @@ extension RepoViewModel {
         revset: String
     ) {
         guard !isShuttingDown else { return }
-        graphEntries = content.graph
-        bookmarks = content.bookmarks
-        if let workspaces = content.workspaces {
-            self.workspaces = workspaces
-        }
-        prHostName = content.prHostName
-        applySingleSelectedChange(content.selectedChange)
-        applyWorkingCopy(
-            changeId: content.workingCopyChangeId,
-            description: content.workingCopyDescription
-        )
-        apply(content.statusBar)
-        isLoading = false
+        apply(content)
         isRefreshingInFlight = false
         self.canLoadMore = canLoadMore
         if didGrow {
@@ -242,6 +270,10 @@ extension RepoViewModel {
     }
 
     func resumePendingBackgroundRefresh() {
+        if hasPendingOperationCheck {
+            hasPendingOperationCheck = false
+            handleOperationChange()
+        }
         guard !isBackgroundRefreshSuspended, hasPendingBackgroundRefresh else { return }
         hasPendingBackgroundRefresh = false
         refresh(isAutoTriggered: true)
@@ -251,7 +283,8 @@ extension RepoViewModel {
         repo: JayJayRepo,
         revset: String,
         preferredRev: String?,
-        includeSubmoduleStatuses: Bool
+        includeSubmoduleStatuses: Bool,
+        includeContext: Bool = true
     ) throws -> RepoRefreshContent {
         let graph = try repo.logGraph(revset: revset)
         let log = graph.map(\.change)
@@ -261,17 +294,22 @@ extension RepoViewModel {
             preferredRev: preferredRev,
             includeSubmoduleStatuses: includeSubmoduleStatuses
         )
-        let statusBar = StatusBarSnapshot.load(from: repo)
         let workingCopy = log.first(where: { $0.isWorkingCopy })
         return try RepoRefreshContent(
             graph: graph,
-            bookmarks: repo.listBookmarks(),
-            workspaces: try? repo.workspaceList(),
-            prHostName: repo.prHostName(),
             selectedChange: selectedChange,
             workingCopyChangeId: workingCopy?.changeId.id ?? "",
             workingCopyDescription: workingCopy?.description ?? "",
-            statusBar: statusBar
+            context: includeContext ? loadRefreshContext(repo: repo) : nil
+        )
+    }
+
+    private static func loadRefreshContext(repo: JayJayRepo) throws -> RepoRefreshContext {
+        try RepoRefreshContext(
+            bookmarks: repo.listBookmarks(),
+            workspaces: try? repo.workspaceList(),
+            prHostName: repo.prHostName(),
+            statusBar: StatusBarSnapshot.load(from: repo)
         )
     }
 }

--- a/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
+++ b/shell/mac/Sources/JayJay/Repo/ViewModel/Core/RepoViewModel.swift
@@ -76,6 +76,8 @@ final class RepoViewModel: ChangeActions, DAGActions, BookmarkActions {
     /// FS-triggered refreshes wait while a sheet or editor owns transient user input.
     var isBackgroundRefreshSuspended = false
     var hasPendingBackgroundRefresh = false
+    /// An operation event that arrived mid-refresh; compared against the head once the refresh has installed its repo.
+    var hasPendingOperationCheck = false
     /// True while a refresh task is running — gates FS-triggered re-entry.
     var isRefreshingInFlight: Bool = false
     var isPullingInFlight = false
@@ -118,7 +120,7 @@ final class RepoViewModel: ChangeActions, DAGActions, BookmarkActions {
         self.configWarning = configWarning
         fsWatcher = RepoFSWatcher(
             repoPath: path,
-            onChange: { [weak self] in self?.handleWorkingCopyChange() },
+            onChange: { [weak self] in self?.handleOperationChange() },
             onWorkingCopyChange: { [weak self] in self?.handleWorkingCopyChange() },
             isRelevantWorkingCopyChange: { [repo] paths in
                 (try? repo.hasUnignoredWorkingCopyPaths(paths: paths)) ?? true

--- a/shell/mac/Tests/JayJayTests/RepoFSWatcherTests.swift
+++ b/shell/mac/Tests/JayJayTests/RepoFSWatcherTests.swift
@@ -2,6 +2,18 @@
 import JayJayCore
 import XCTest
 
+private final class Counter: @unchecked Sendable {
+    private var value = 0
+    private let lock = NSLock()
+
+    func increment() -> Int {
+        lock.withLock {
+            value += 1
+            return value
+        }
+    }
+}
+
 @MainActor
 final class RepoFSWatcherTests: XCTestCase {
     func testSecondaryWorkspaceSeesOperationsInThePrimary() throws {
@@ -21,6 +33,28 @@ final class RepoFSWatcherTests: XCTestCase {
         try repo.describe(rev: "@", message: "an operation in the primary")
 
         wait(for: [observed], timeout: 5)
+        withExtendedLifetime(watcher) {}
+    }
+
+    func testOperationInsideTheDebounceWindowStillFires() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appending(path: "jayjay-watcher-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try initJjGitRepo(path: directory.path)
+        let repo = try JayJayRepo.open(path: directory.path)
+
+        let first = expectation(description: "first operation observed")
+        let second = expectation(description: "second operation observed after the debounce window")
+        let count = Counter()
+        let watcher = RepoFSWatcher(repoPath: directory.path, onChange: {
+            (count.increment() == 1 ? first : second).fulfill()
+        })
+        try repo.describe(rev: "@", message: "first")
+        wait(for: [first], timeout: 5)
+        try repo.describe(rev: "@", message: "second, inside the debounce window")
+
+        wait(for: [second], timeout: 5)
         withExtendedLifetime(watcher) {}
     }
 }

--- a/shell/mac/Tests/JayJayTests/RepoViewModelRefreshTests.swift
+++ b/shell/mac/Tests/JayJayTests/RepoViewModelRefreshTests.swift
@@ -37,6 +37,70 @@ final class RepoViewModelRefreshTests: RepoViewModelTestCase {
         XCTAssertTrue(viewModel.selectedChange?.diff.contains { $0.path == "late-edit.txt" } == true)
     }
 
+    func testOperationEventIsDroppedOnlyWhileTheRepoIsAtHead() async throws {
+        let viewModel = try XCTUnwrap(viewModel)
+        try await snapshotAnEdit(viewModel, file: "echo.txt")
+
+        viewModel.handleOperationChange()
+        XCTAssertFalse(viewModel.isRefreshingInFlight)
+        XCTAssertFalse(viewModel.hasPendingBackgroundRefresh)
+
+        try "from elsewhere\n".write(
+            to: URL(fileURLWithPath: viewModel.repoPath).appending(path: "external.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try JayJayRepo.open(path: viewModel.repoPath).refreshWorkingCopy()
+        viewModel.handleOperationChange()
+        XCTAssertTrue(viewModel.isRefreshingInFlight)
+        try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
+        XCTAssertTrue(viewModel.selectedChange?.diff.contains { $0.path == "external.txt" } == true)
+    }
+
+    func testSelectionChangedDuringARefreshSurvivesIt() async throws {
+        let viewModel = try XCTUnwrap(viewModel)
+        viewModel.refresh()
+        viewModel.selectedChangeIds = ["first", "second"]
+        viewModel.selectedChangeId = "second"
+
+        try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
+
+        XCTAssertFalse(viewModel.graphEntries.isEmpty)
+        XCTAssertEqual(viewModel.selectedChangeIds, ["first", "second"])
+    }
+
+    func testSelectionMadeAfterTheFirstPaintSurvivesTheSnapshotPass() async throws {
+        let viewModel = try XCTUnwrap(viewModel)
+        viewModel.refresh(selecting: "@")
+        try await waitUntil("the first paint lands") { !viewModel.graphEntries.isEmpty }
+        viewModel.selectedChangeIds = ["first", "second"]
+        viewModel.selectedChangeId = "second"
+
+        try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
+
+        XCTAssertEqual(viewModel.selectedChangeIds, ["first", "second"])
+    }
+
+    func testWorkingCopyEventIsNeverTakenForOurSnapshotEcho() async throws {
+        let viewModel = try XCTUnwrap(viewModel)
+        try await snapshotAnEdit(viewModel, file: "echo.txt")
+
+        viewModel.handleWorkingCopyChange()
+        XCTAssertTrue(viewModel.isRefreshingInFlight)
+        try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
+    }
+
+    /// A refresh whose snapshot writes an operation, which the watcher would report straight back.
+    private func snapshotAnEdit(_ viewModel: RepoViewModel, file: String) async throws {
+        try "snapshot me\n".write(
+            to: URL(fileURLWithPath: viewModel.repoPath).appending(path: file),
+            atomically: true,
+            encoding: .utf8
+        )
+        viewModel.refresh()
+        try await waitUntil("the refresh finishes") { !viewModel.isRefreshingInFlight }
+    }
+
     func testCancelledFailureProbeCannotOverwriteNewerRefreshState() async throws {
         let viewModel = try XCTUnwrap(viewModel)
         let probe = BlockingWorkspacePresenceProbe()


### PR DESCRIPTION
_ffi passed --target aarch64-apple-darwin unconditionally, so the staticlib and its dependencies were built into target/aarch64-apple-darwin while cargo build and cargo test used target/debug — jj-lib, gix and the tree-sitter grammars compiled once per directory.

A debug build on an Apple silicon host now omits --target and the deployment-target flags, which would otherwise change the fingerprint of the shared artifacts and make each command rebuild after the other; release and non-native hosts keep the pinned triple and the flags, so shipped objects are unchanged. Bindings and the XCFramework are also regenerated only when the staticlib or uniffi.toml is newer than them.

Stacked on #248; rebase onto main once that lands.