### PR TITLE
fix(ui): keep the description editor caret at the end and swallow Tab in diff edit

### DIFF
--- a/shell/mac/Sources/JayJay/Repo/CommitMessageEditor.swift
+++ b/shell/mac/Sources/JayJay/Repo/CommitMessageEditor.swift
@@ -54,13 +54,14 @@ struct CommitMessageEditor: View {
         .onChange(of: summarySelection) { _, selection in
             guard focusSummaryAtEnd, !didSetInitialSelection, selection != nil else { return }
             didSetInitialSelection = true
-            summarySelection = TextSelection(insertionPoint: summary.endIndex)
-            // SwiftUI sets the insertion point without revealing it in a long single-line field.
+            // Set on the field editor once focus settles: SwiftUI follows its select-all with a hit-test caret, which beat a binding-set caret.
             DispatchQueue.main.async {
                 guard let editor = NSApp.keyWindow?.firstResponder as? NSTextView,
                       editor.isFieldEditor, editor.string == summary
                 else { return }
-                editor.scrollRangeToVisible(NSRange(location: (summary as NSString).length, length: 0))
+                let end = NSRange(location: (summary as NSString).length, length: 0)
+                editor.setSelectedRange(end)
+                editor.scrollRangeToVisible(end)
             }
         }
     }

--- a/shell/mac/Sources/JayJay/Repo/KeyboardFocus/KeyboardFocus.swift
+++ b/shell/mac/Sources/JayJay/Repo/KeyboardFocus/KeyboardFocus.swift
@@ -41,12 +41,15 @@ final class KeyboardFocus {
     }
 
     func handleKey(_ event: NSEvent) -> Bool {
-        guard !isSuspended else { return false }
         let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         if event.keyCode == KeyCode.tab, modifiers.isSubset(of: .shift) {
-            move(backward: modifiers.contains(.shift))
+            // Swallowed even while suspended: an unhandled Tab enters AppKit's key-view loop, which differs per machine.
+            if !isSuspended {
+                move(backward: modifiers.contains(.shift))
+            }
             return true
         }
+        guard !isSuspended else { return false }
         guard let control, !control.isTextInput else { return false }
         switch event.keyCode {
             case KeyCode.space, KeyCode.returnKey, KeyCode.keypadEnter:

--- a/shell/mac/Tests/JayJayTests/KeyboardFocusTests.swift
+++ b/shell/mac/Tests/JayJayTests/KeyboardFocusTests.swift
@@ -98,7 +98,8 @@ final class KeyboardFocusTests: XCTestCase {
         focus.isSuspended = true
         focus.updateInputFocus(.commitSummary, isFocused: true)
         XCTAssertNil(focus.control)
-        XCTAssertFalse(focus.handleKey(Self.key(KeyCode.tab)))
+        XCTAssertTrue(focus.handleKey(Self.key(KeyCode.tab)), "Tab is swallowed rather than handed to the key-view loop")
+        XCTAssertNil(focus.control)
         XCTAssertFalse(focus.handleKey(Self.key(KeyCode.space)))
         XCTAssertFalse(activated)
         focus.isSuspended = false


### PR DESCRIPTION
Two UI scenes failed on main after the keyboard focus change (fb24a66f). The description editor set its initial caret through the SwiftUI selection binding, and SwiftUI follows its select-all on focus with a hit-test caret that now landed after the binding write, so pasted text went into the middle of a long summary; the caret is now set on the field editor once focus settles. In diff edit the focus cycle is suspended and Tab fell through to AppKit's key-view loop, which moves focus differently per machine; Tab is now swallowed while suspended.

Validation: KeyboardFocusTests (5), DescriptionEditingScene and KeyboardPaneFocusScene (3 UI tests) pass locally.